### PR TITLE
Fix nested shader precendence

### DIFF
--- a/package/cpp/api/JsiSkPaint.h
+++ b/package/cpp/api/JsiSkPaint.h
@@ -140,31 +140,31 @@ public:
   }
 
   JSI_HOST_FUNCTION(setMaskFilter) {
-    auto maskFilter = JsiSkMaskFilter::fromValue(runtime, arguments[0]);
+    auto maskFilter = arguments[0].isNull() || arguments[0].isUndefined() ? nullptr : JsiSkMaskFilter::fromValue(runtime, arguments[0]);
     getObject()->setMaskFilter(maskFilter);
     return jsi::Value::undefined();
   }
 
   JSI_HOST_FUNCTION(setImageFilter) {
-    auto imageFilter = JsiSkImageFilter::fromValue(runtime, arguments[0]);
+    auto imageFilter = arguments[0].isNull() || arguments[0].isUndefined() ? nullptr : JsiSkImageFilter::fromValue(runtime, arguments[0]);
     getObject()->setImageFilter(imageFilter);
     return jsi::Value::undefined();
   }
 
   JSI_HOST_FUNCTION(setColorFilter) {
-    auto colorFilter = JsiSkColorFilter::fromValue(runtime, arguments[0]);
+    auto colorFilter = arguments[0].isNull() || arguments[0].isUndefined() ? nullptr : JsiSkColorFilter::fromValue(runtime, arguments[0]);
     getObject()->setColorFilter(colorFilter);
     return jsi::Value::undefined();
   }
 
   JSI_HOST_FUNCTION(setShader) {
-    auto shader = JsiSkShader::fromValue(runtime, arguments[0]);
+    auto shader = arguments[0].isNull() || arguments[0].isUndefined() ? nullptr : JsiSkShader::fromValue(runtime, arguments[0]);
     getObject()->setShader(shader);
     return jsi::Value::undefined();
   }
 
   JSI_HOST_FUNCTION(setPathEffect) {
-    auto pathEffect = JsiSkPathEffect::fromValue(runtime, arguments[0]);
+    auto pathEffect = arguments[0].isNull() || arguments[0].isUndefined() ? nullptr : JsiSkPathEffect::fromValue(runtime, arguments[0]);
     getObject()->setPathEffect(pathEffect);
     return jsi::Value::undefined();
   }

--- a/package/src/renderer/components/Defs.tsx
+++ b/package/src/renderer/components/Defs.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { ReactNode } from "react";
 
 import { useDeclaration } from "../nodes";

--- a/package/src/renderer/components/colorFilters/Blend.tsx
+++ b/package/src/renderer/components/colorFilters/Blend.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { ReactNode } from "react";
 
 import { BlendMode, Skia, isColorFilter } from "../../../skia";

--- a/package/src/renderer/components/colorFilters/LinearToSRGBGamma.tsx
+++ b/package/src/renderer/components/colorFilters/LinearToSRGBGamma.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import { Skia, isColorFilter } from "../../../skia";
 import { useDeclaration } from "../../nodes/Declaration";
 import type { AnimatedProps } from "../../processors/Animations/Animations";

--- a/package/src/renderer/components/pathEffects/Discrete.tsx
+++ b/package/src/renderer/components/pathEffects/Discrete.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { ReactNode } from "react";
 
 import { Skia } from "../../../skia";

--- a/package/src/renderer/components/pathEffects/Sum.tsx
+++ b/package/src/renderer/components/pathEffects/Sum.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { ReactNode } from "react";
 
 import { Skia } from "../../../skia";

--- a/package/src/renderer/processors/Paint.ts
+++ b/package/src/renderer/processors/Paint.ts
@@ -56,6 +56,7 @@ export const processPaint = (
 ) => {
   if (cl !== undefined) {
     const c = processColor(cl, currentOpacity);
+    paint.setShader(null);
     paint.setColor(c);
   } else {
     const c = processColor(paint.getColor(), currentOpacity);

--- a/package/src/skia/Paint/Paint.ts
+++ b/package/src/skia/Paint/Paint.ts
@@ -95,31 +95,31 @@ export interface IPaint extends SkJSIInstance<"Paint"> {
    * Sets the current color filter, replacing the existing one if there was one.
    * @param filter
    */
-  setColorFilter(filter: IColorFilter): void;
+  setColorFilter(filter: IColorFilter | null): void;
 
   /**
    * Sets the current image filter, replacing the existing one if there was one.
    * @param filter
    */
-  setImageFilter(filter: IImageFilter): void;
+  setImageFilter(filter: IImageFilter | null): void;
 
   /**
    * Sets the current mask filter, replacing the existing one if there was one.
    * @param filter
    */
-  setMaskFilter(filter: IMaskFilter): void;
+  setMaskFilter(filter: IMaskFilter | null): void;
 
   /**
    * Sets the current path effect, replacing the existing one if there was one.
    * @param effect
    */
-  setPathEffect(effect: IPathEffect): void;
+  setPathEffect(effect: IPathEffect | null): void;
 
   /**
    * Sets the current shader, replacing the existing one if there was one.
    * @param shader
    */
-  setShader(shader: IShader): void;
+  setShader(shader: IShader | null): void;
 
   /**
    * Sets the geometry drawn at the beginning and end of strokes.


### PR DESCRIPTION
Skia has two ways to paint a pixel: `setColor` and `setShader`.
`setShader` has precedence over  `setColor` and we respect that.
However, in the reconciler, things are deeply nested and if we do `setColor` and the shader comes from "above" (= is in inherited), we want the new color to take over.

This PR enables `setShader(null)`, which is compatible with the Flutter/CanvasKit API and enables a new behaviour for set color that ben be tested here:

```tsx
export const Filters = () => {
  return (
    <Canvas style={{ width, height }}>
      {/*
        Here we set red but the shader has precedence like in Skia imperative API
        In fact, the paint will show red until the image is loaded.
      */}
      <Paint color="red">
        <Shader
          source={source}
          uniforms={(ctx) => [mix(progress(ctx), 0, 100)]}
        >
          <ImageShader
            source={require("../../assets/oslo.jpg")}
            fit="cover"
            fitRect={{ x: 0, y: 0, width, height }}
          />
        </Shader>
      </Paint>
      <Fill />
      {/* Here color has precendence over the inherited shader */}
      <Circle r={150} cx={200} cy={200} color="blue" />
    </Canvas>
  );
};
```

before this PR, the examples above would just fill the circle with the shader, making it invisible.