### PR TITLE
Make color() function naming more explicit

### DIFF
--- a/package/src/animation/functions/interpolateColors.ts
+++ b/package/src/animation/functions/interpolateColors.ts
@@ -4,7 +4,7 @@ import {
   green,
   blue,
   alpha,
-  color,
+  rgbaColor,
 } from "../../renderer/processors/Paint";
 
 import { interpolate } from "./interpolate";
@@ -43,7 +43,7 @@ const interpolateColorsRGB = (
     outputRange.map((c) => alpha(c)),
     CLAMP
   );
-  return color(r, g, b, a);
+  return rgbaColor(r, g, b, a);
 };
 
 export const interpolateColors = (

--- a/package/src/renderer/processors/Paint.ts
+++ b/package/src/renderer/processors/Paint.ts
@@ -26,7 +26,7 @@ export const alpha = (c: number) => ((c >> 24) & 255) / 255;
 export const red = (c: number) => (c >> 16) & 255;
 export const green = (c: number) => (c >> 8) & 255;
 export const blue = (c: number) => c & 255;
-export const color = (r: number, g: number, b: number, af: number) => {
+export const rgbaColor = (r: number, g: number, b: number, af: number) => {
   const a = Math.round(af * 255);
   return ((a << 24) | (r << 16) | (g << 8) | b) >>> 0;
 };
@@ -37,14 +37,14 @@ export const processColor = (cl: ColorProp, currentOpacity: number) => {
   const g = green(icl);
   const b = blue(icl);
   const o = alpha(icl);
-  return color(r, g, b, o * currentOpacity);
+  return rgbaColor(r, g, b, o * currentOpacity);
 };
 
 export const processPaint = (
   paint: IPaint,
   currentOpacity: number,
   {
-    color: cl,
+    color,
     blendMode,
     style,
     strokeWidth,
@@ -54,8 +54,8 @@ export const processPaint = (
     opacity,
   }: CustomPaintProps
 ) => {
-  if (cl !== undefined) {
-    const c = processColor(cl, currentOpacity);
+  if (color !== undefined) {
+    const c = processColor(color, currentOpacity);
     paint.setShader(null);
     paint.setColor(c);
   } else {


### PR DESCRIPTION
I noticed in examples that the color variable was used so many times that it was worth making this function name more explicit.