### PR TITLE
fix: Initialize RNSkManager on JS Thread (JSI Module callback Android)

### DIFF
--- a/package/android/src/main/java/com/shopify/reactnative/skia/RNSkiaModulePackage.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/RNSkiaModulePackage.java
@@ -1,0 +1,16 @@
+package com.shopify.reactnative.skia;
+
+import com.facebook.react.bridge.JSIModulePackage;
+import com.facebook.react.bridge.JSIModuleSpec;
+import com.facebook.react.bridge.JavaScriptContextHolder;
+import com.facebook.react.bridge.ReactApplicationContext;
+import java.util.Collections;
+import java.util.List;
+
+public class RNSkiaModulePackage implements JSIModulePackage {
+  @Override
+  public List<JSIModuleSpec> getJSIModules(ReactApplicationContext reactApplicationContext, JavaScriptContextHolder jsContext) {
+    RNSkiaModule.initializeSkiaManager(reactApplicationContext);
+    return Collections.emptyList();
+  }
+}

--- a/package/cpp/rnskia/RNSkManager.cpp
+++ b/package/cpp/rnskia/RNSkManager.cpp
@@ -41,39 +41,13 @@ void RNSkManager::unregisterSkiaDrawView(size_t nativeId) {
 }
 
 void RNSkManager::installBindings() {
-  // Create the Skia API object and install it on the global object in the
-  // provided runtime.
-  //
-  // This must be done on the Javascript thread to avoid threading issues
-  // when accessing the javascript objects from a thread not being the JS
-  // thread. On Android this is actually necessary, since we need to set up the
-  // API before the javascript starts to execute!
-#ifndef ANDROID
-  std::mutex mu;
-  std::condition_variable cond;
+  auto skiaApi = std::make_shared<JsiSkApi>(*_jsRuntime, _platformContext);
+  _jsRuntime->global().setProperty(
+      *_jsRuntime, "SkiaApi",
+      jsi::Object::createFromHostObject(*_jsRuntime, std::move(skiaApi)));
 
-  bool isInstalled = false;
-  std::unique_lock<std::mutex> lock(mu);
-
-  _platformContext->runOnJavascriptThread([&]() {
-    std::lock_guard<std::mutex> lock(mu);
-#endif
-
-    auto skiaApi = std::make_shared<JsiSkApi>(*_jsRuntime, _platformContext);
-    _jsRuntime->global().setProperty(
-        *_jsRuntime, "SkiaApi",
-        jsi::Object::createFromHostObject(*_jsRuntime, std::move(skiaApi)));
-
-    _jsRuntime->global().setProperty(
-        *_jsRuntime, "SkiaViewApi",
-        jsi::Object::createFromHostObject(*_jsRuntime, _viewApi));
-
-#ifndef ANDROID
-    isInstalled = true;
-    cond.notify_one();
-  });
-
-  cond.wait(lock, [&]() { return isInstalled; });
-#endif
+  _jsRuntime->global().setProperty(
+      *_jsRuntime, "SkiaViewApi",
+      jsi::Object::createFromHostObject(*_jsRuntime, _viewApi));
 }
 } // namespace RNSkia


### PR DESCRIPTION
This removes the Mutex (that deadlocks in my app and causes the app to never start) and instead calls the `installBindings` function at the correct point in time. 

### Changes

* Make Skia Manager shared and static
* Initialize bindings in `getJSIModules` callback from React

> ⚠️ Requires the user to do additional installation steps on Android (adding Skia to `MainApplication.java`) - these are the same steps as in react-native-mmkv and react-native-reanimated.