### PR TITLE
Update installation instructions to clarify current constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You will need to disable Bitcode in order to create a release build: `Build Sett
 
 ### Android
 
-> **Version compatibility**: `react-native@>=66` is required.
+> **Version compatibility**: `react-native@>=0.66` is required.
 
 Currently, you will need Android NDK to be installed.
 If you have Android Studio installed, make sure `$ANDROID_NDK` is available.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ $ npm install https://github.com/Shopify/react-native-skia/releases/download/v0.
 
 Run `pod install` on the `ios/` directory.
 
+You will need to disable Bitcode in order to create a release build: `Build Settings > Build Options > Enable Bitcode -> Release -> No`. In Expo managed apps, set `ios.bitcode` to `false` in `app.json`.
+
 ### Android
+
+> **Version compatibility**: `react-native@>=66` is required.
 
 Currently, you will need Android NDK to be installed.
 If you have Android Studio installed, make sure `$ANDROID_NDK` is available.

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -33,7 +33,11 @@ $ npm install https://github.com/Shopify/react-native-skia/releases/download/v0.
 
 Run `pod install` on the `ios/` directory.
 
+You will need to disable Bitcode in order to create a release build: `Build Settings > Build Options > Enable Bitcode -> Release -> No`. In Expo managed apps, set `ios.bitcode` to `false` in `app.json`.
+
 ## Android
+
+> **Version compatibility**: `react-native@>=66` is required.
 
 Currently, you will need Android NDK to be installed.
 If you have Android Studio installed, make sure `$ANDROID_NDK` is available.

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -37,7 +37,7 @@ You will need to disable Bitcode in order to create a release build: `Build Sett
 
 ## Android
 
-> **Version compatibility**: `react-native@>=66` is required.
+> **Version compatibility**: `react-native@>=0.66` is required.
 
 Currently, you will need Android NDK to be installed.
 If you have Android Studio installed, make sure `$ANDROID_NDK` is available.


### PR DESCRIPTION
I tried the library out in a new Expo managed project with expo-dev-client and found that:

- It did not compile on Android. The same applied to a React Native 64 and 65 project initialized via `npx react-native init SkiaTest --version 0.64.3` and `npx react-native init SkiaTest --version 0.65.2`. React Native 66 worked as expected.
- iOS release builds fail when Bitcode is enabled:

```
node_modules/@shopify/react-native-skia/libs/ios/libskia.a(raw.SkRawCodec.o)' does not contain bitcode.
You must rebuild it with bitcode enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from the
vendor, or disable bitcode for this target. for architecture arm64
```