### PR TITLE
Handle symlink error when copying files from cpp to android/cpp

### DIFF
--- a/package/scripts/install-npm.js
+++ b/package/scripts/install-npm.js
@@ -3,22 +3,20 @@ const path = require("path");
 
 console.log("Updating symlinks for Android build...");
 
+const isExists = (path) => {
+  return fs.existsSync(path)
+}
+
 const createSymlink = (p) => {
+  console.log(`Creating symlink to ${p}`, __dirname, process.cwd());
   const srcDir = path.resolve(`./cpp/${p}`);
   const dstDir = path.resolve(`./android/cpp/${p}`);
 
-  try {
-    console.log(`Creating symlink to ${p}`, __dirname, process.cwd());
-
-    fs.symlinkSync(srcDir, dstDir, "dir");
-  } catch (err) {
-    if (err && err.code === "EEXIST") {
-      console.log("Directory already exists:", dstDir);
-      return;
-    }
-
-    throw err;
+  if (isExists(dstDir)) {
+    fs.unlinkSync(dstDir);
   }
+
+  fs.symlinkSync(srcDir, dstDir, "dir");
 };
 
 // Copy common cpp files from the package root to the android folder

--- a/package/scripts/install-npm.js
+++ b/package/scripts/install-npm.js
@@ -4,7 +4,7 @@ const path = require("path");
 console.log("Updating symlinks for Android build...");
 
 const isExists = (path) => {
-  return fs.existsSync(path)
+  return fs.existsSync(path);
 }
 
 const createSymlink = (p) => {

--- a/package/scripts/install-npm.js
+++ b/package/scripts/install-npm.js
@@ -3,16 +3,12 @@ const path = require("path");
 
 console.log("Updating symlinks for Android build...");
 
-const isExists = (path) => {
-  return fs.existsSync(path);
-}
-
 const createSymlink = (p) => {
   console.log(`Creating symlink to ${p}`, __dirname, process.cwd());
   const srcDir = path.resolve(`./cpp/${p}`);
   const dstDir = path.resolve(`./android/cpp/${p}`);
 
-  if (isExists(dstDir)) {
+  if (fs.existsSync(dstDir)) {
     fs.unlinkSync(dstDir);
   }
 

--- a/package/scripts/install-npm.js
+++ b/package/scripts/install-npm.js
@@ -4,12 +4,21 @@ const path = require("path");
 console.log("Updating symlinks for Android build...");
 
 const createSymlink = (p) => {
-  console.log(`Creating symlink to ${p}`, __dirname, process.cwd());
-  fs.symlinkSync(
-    path.resolve(`./cpp/${p}`),
-    path.resolve(`./android/cpp/${p}`),
-    "dir"
-  );
+  const srcDir = path.resolve(`./cpp/${p}`);
+  const dstDir = path.resolve(`./android/cpp/${p}`);
+
+  try {
+    console.log(`Creating symlink to ${p}`, __dirname, process.cwd());
+
+    fs.symlinkSync(srcDir, dstDir, "dir");
+  } catch (err) {
+    if (err && err.code === "EEXIST") {
+      console.log("Directory already exists:", dstDir);
+      return;
+    }
+
+    throw err;
+  }
 };
 
 // Copy common cpp files from the package root to the android folder


### PR DESCRIPTION
## Description
Faced with symlink error after run ```cd package && yarn```

<img width="814" alt="err" src="https://user-images.githubusercontent.com/25579397/146635214-85394e44-e639-4ba6-9a23-e0c6f102d479.png">

### Linked issues
- #48