### PR TITLE
perf: Cache Paths

### DIFF
--- a/package/src/renderer/components/shapes/Path.tsx
+++ b/package/src/renderer/components/shapes/Path.tsx
@@ -18,13 +18,21 @@ export interface PathProps extends CustomPaintProps, StrokeOpts {
   end: number;
 }
 
+const pathCache: { [key: string]: IPath | null } = {};
+const getCachedPath = (p: string): IPath => {
+  if (pathCache[p] == null) {
+    pathCache[p] = Skia.Path.MakeFromSVGString(p);
+  }
+  return pathCache[p]!;
+};
+
 export const Path = (props: AnimatedProps<PathProps>) => {
   const onDraw = useDrawing(
     props,
     ({ canvas, paint }, { start, end, ...pathProps }) => {
       const path =
         typeof pathProps.path === "string"
-          ? Skia.Path.MakeFromSVGString(pathProps.path)
+          ? getCachedPath(pathProps.path)
           : pathProps.path.copy();
       if (path === null) {
         throw new Error("Invalid path:  " + pathProps.path);

--- a/package/src/renderer/components/shapes/Path.tsx
+++ b/package/src/renderer/components/shapes/Path.tsx
@@ -18,12 +18,12 @@ export interface PathProps extends CustomPaintProps, StrokeOpts {
   end: number;
 }
 
-const pathCache: { [key: string]: IPath | null } = {};
-const getCachedPath = (p: string): IPath => {
-  if (pathCache[p] == null) {
-    pathCache[p] = Skia.Path.MakeFromSVGString(p);
+const pathCache = new Map<string, IPath | null>()
+const getCachedPath = (p: string): IPath | null => {
+  if (!pathCache.has(p)) {
+    pathCache.set(p, Skia.Path.MakeFromSVGString(p));
   }
-  return pathCache[p]!;
+  return pathCache.get(p)!;
 };
 
 export const Path = (props: AnimatedProps<PathProps>) => {


### PR DESCRIPTION
Avoids constant re-creation of paths by caching them in a map. Improves repeated render times of the same path.

It is most efficient to do this on the JS side, since when doing it over JSI there is always a (small) overhead involved of calling through the C++ APIs. A simple JavaScript object (or `Map<K, V>`) should be the simplest, yet fastest solution possible. (See https://bugs.webkit.org/show_bug.cgi?id=203463)