### PR TITLE
fix: Fix iOS crash/freeze when navigating away

### DIFF
--- a/package/ios/RNSkia-iOS/SkiaDrawView.mm
+++ b/package/ios/RNSkia-iOS/SkiaDrawView.mm
@@ -25,16 +25,6 @@
   }
 }
 
-
-- (void) willMoveToWindow:(UIWindow *)newWindow {
-  [super willMoveToWindow: newWindow];
-  if (newWindow == nil && _impl != nullptr) {
-    _impl->remove();
-    delete _impl;
-    _impl = nullptr;
-  }
-}
-
 #pragma mark Layout
 
 - (void) layoutSubviews {
@@ -89,7 +79,7 @@
           nextTouch.type = RNSkia::RNSkTouchType::Active;
           break;
       }
-      
+
       nextTouches.push_back(nextTouch);
     }
     _impl->updateTouchState(nextTouches);


### PR DESCRIPTION
`willMoveToWindow:nil` gets called when the view gets hidden, e.g. when navigating away. The problem here is, that you can navigate back and the view should be active again, but we completely destroy a reference to it in this method.

Instead, we should only destroy the reference in `dealloc`.

To be a bit more efficient on the CPU we can also think about **pausing** redraws if `willMoveToWindow` gets called with a `nil` window **and** a `nil` superview, but deleting the reference just causes the app to crash/the view to freeze and no longer update.