### PR TITLE
Fix crashes in android when removing/recreating views and surfaces

### DIFF
--- a/package/android/cpp/jni/JniSkiaDrawView.cpp
+++ b/package/android/cpp/jni/JniSkiaDrawView.cpp
@@ -251,7 +251,9 @@ namespace RNSkia
             return false;
         }
 
-        if (!_skRenderTarget.isValid() || _prevWidth != _width ||
+        if (_skSurface == nullptr ||
+            !_skRenderTarget.isValid() ||
+            _prevWidth != _width ||
             _prevHeight != _height)
         {
             RNSkMeasureTime measure =

--- a/package/android/src/main/java/com/shopify/reactnative/skia/RNSkiaViewManager.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/RNSkiaViewManager.java
@@ -1,6 +1,5 @@
 package com.shopify.reactnative.skia;
 
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.LayoutShadowNode;
@@ -10,10 +9,11 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.HashMap;
+
 public class RNSkiaViewManager extends BaseViewManager<SkiaDrawView, LayoutShadowNode> {
 
-    private SkiaDrawView mView;
-    private int mNativeId;
+    final private HashMap<SkiaDrawView, Integer> mViewMapping = new HashMap();
 
     @NonNull
     @Override
@@ -38,9 +38,10 @@ public class RNSkiaViewManager extends BaseViewManager<SkiaDrawView, LayoutShado
     @Override
     public void setNativeId(@NonNull SkiaDrawView view, @Nullable String nativeId) {
         super.setNativeId(view, nativeId);
-        mNativeId = Integer.parseInt(nativeId);
-        RNSkiaModule skiaModule = ((ReactContext)mView.getContext()).getNativeModule(RNSkiaModule.class);
-        skiaModule.getSkiaManager().register(mNativeId, mView);
+        int nativeIdResolved = Integer.parseInt(nativeId);
+        RNSkiaModule skiaModule = ((ReactContext)view.getContext()).getNativeModule(RNSkiaModule.class);
+        skiaModule.getSkiaManager().register(nativeIdResolved, view);
+        mViewMapping.put(view, nativeIdResolved);
     }
 
     @ReactProp(name = "mode")
@@ -57,14 +58,15 @@ public class RNSkiaViewManager extends BaseViewManager<SkiaDrawView, LayoutShado
     public void onDropViewInstance(@NonNull SkiaDrawView view) {
         super.onDropViewInstance(view);
         RNSkiaModule skiaModule = ((ReactContext)view.getContext()).getNativeModule(RNSkiaModule.class);
-        skiaModule.getSkiaManager().unregister(mNativeId);
+        Integer nativeId = mViewMapping.get(view);
+        skiaModule.getSkiaManager().unregister(nativeId);
+        mViewMapping.remove(view);
         view.onRemoved();
     }
 
     @NonNull
     @Override
     protected SkiaDrawView createViewInstance(@NonNull ThemedReactContext reactContext) {
-        mView = new SkiaDrawView(reactContext);
-        return mView;
+        return new SkiaDrawView(reactContext);
     }
 }

--- a/package/cpp/rnskia/RNSkDrawView.cpp
+++ b/package/cpp/rnskia/RNSkDrawView.cpp
@@ -134,6 +134,10 @@ void RNSkDrawView::drawInSurface(sk_sp<SkSurface> surface, int width,
                                  std::shared_ptr<RNSkPlatformContext> context) {
 
   try {
+    if(getIsRemoved()) {
+      return;
+    }
+
     // Get the canvas
     auto skCanvas = surface->getCanvas();
     _jsiCanvas->setCanvas(skCanvas);


### PR DESCRIPTION
# Problem(s)
On Android there is a bug in the viewManager where the nativeId and view was stored as private variables in the manager. This is of course totally wrong - since a view manager manages multiple views.

In addition the Android view crashes from time to time after it is removed in the `drawFrame` method, and it is currently not possible for a view to continue redrawing after its underlying surface has been removed/recreated,

# Solutions
This PR fixes this ViewManager issue by storing a map of views and nativeIds instead of the private variables.

It also contains a fix to the `drawFrame` method so that it checks to see if the view is removed before drawing.

A check for a nullptr has been added to the `ensureSkiaRenderTarget` in the´JniSkiaDrawView` class to make sure a view can have its underlying texture surface destroyed and recreated without the view crashing. 

Fixes #15 