### PR TITLE
Fix ios race conditions

### DIFF
--- a/package/android/cpp/jni/JniSkiaDrawView.cpp
+++ b/package/android/cpp/jni/JniSkiaDrawView.cpp
@@ -251,7 +251,9 @@ namespace RNSkia
             return false;
         }
 
-        if (!_skRenderTarget.isValid() || _prevWidth != _width ||
+        if (_skSurface == nullptr ||
+            !_skRenderTarget.isValid() ||
+            _prevWidth != _width ||
             _prevHeight != _height)
         {
             RNSkMeasureTime measure =

--- a/package/android/cpp/jni/include/JniSkiaDrawView.h
+++ b/package/android/cpp/jni/include/JniSkiaDrawView.h
@@ -44,7 +44,7 @@ namespace RNSkia
 
         void updateTouchPoints(jni::JArrayDouble touches);
 
-        void setIsRemovedExternal() { setIsRemoved(); }
+        void setIsRemovedExternal() { invalidate(); }
 
         ~JniSkiaDrawView() {
         }

--- a/package/android/src/main/java/com/shopify/reactnative/skia/RNSkiaViewManager.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/RNSkiaViewManager.java
@@ -1,6 +1,5 @@
 package com.shopify.reactnative.skia;
 
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.LayoutShadowNode;
@@ -10,10 +9,11 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.HashMap;
+
 public class RNSkiaViewManager extends BaseViewManager<SkiaDrawView, LayoutShadowNode> {
 
-    private SkiaDrawView mView;
-    private int mNativeId;
+    final private HashMap<SkiaDrawView, Integer> mViewMapping = new HashMap();
 
     @NonNull
     @Override
@@ -38,9 +38,10 @@ public class RNSkiaViewManager extends BaseViewManager<SkiaDrawView, LayoutShado
     @Override
     public void setNativeId(@NonNull SkiaDrawView view, @Nullable String nativeId) {
         super.setNativeId(view, nativeId);
-        mNativeId = Integer.parseInt(nativeId);
-        RNSkiaModule skiaModule = ((ReactContext)mView.getContext()).getNativeModule(RNSkiaModule.class);
-        skiaModule.getSkiaManager().register(mNativeId, mView);
+        int nativeIdResolved = Integer.parseInt(nativeId);
+        RNSkiaModule skiaModule = ((ReactContext)view.getContext()).getNativeModule(RNSkiaModule.class);
+        skiaModule.getSkiaManager().register(nativeIdResolved, view);
+        mViewMapping.put(view, nativeIdResolved);
     }
 
     @ReactProp(name = "mode")
@@ -57,14 +58,15 @@ public class RNSkiaViewManager extends BaseViewManager<SkiaDrawView, LayoutShado
     public void onDropViewInstance(@NonNull SkiaDrawView view) {
         super.onDropViewInstance(view);
         RNSkiaModule skiaModule = ((ReactContext)view.getContext()).getNativeModule(RNSkiaModule.class);
-        skiaModule.getSkiaManager().unregister(mNativeId);
+        Integer nativeId = mViewMapping.get(view);
+        skiaModule.getSkiaManager().unregister(nativeId);
+        mViewMapping.remove(view);
         view.onRemoved();
     }
 
     @NonNull
     @Override
     protected SkiaDrawView createViewInstance(@NonNull ThemedReactContext reactContext) {
-        mView = new SkiaDrawView(reactContext);
-        return mView;
+        return new SkiaDrawView(reactContext);
     }
 }

--- a/package/cpp/rnskia/RNSkDrawView.cpp
+++ b/package/cpp/rnskia/RNSkDrawView.cpp
@@ -134,6 +134,10 @@ void RNSkDrawView::drawInSurface(sk_sp<SkSurface> surface, int width,
                                  std::shared_ptr<RNSkPlatformContext> context) {
 
   try {
+    if(getIsRemoved()) {
+      return;
+    }
+
     // Get the canvas
     auto skCanvas = surface->getCanvas();
     _jsiCanvas->setCanvas(skCanvas);

--- a/package/cpp/rnskia/RNSkDrawView.cpp
+++ b/package/cpp/rnskia/RNSkDrawView.cpp
@@ -5,8 +5,7 @@
 #include "RNSkDrawView.h"
 
 #include <chrono>
-#include <condition_variable>
-#include <mutex>
+#include <functional>
 
 #include "RNSkLog.h"
 
@@ -29,34 +28,24 @@ RNSkDrawView::RNSkDrawView(std::shared_ptr<RNSkPlatformContext> context)
     : _jsiCanvas(std::make_shared<JsiSkCanvas>(context)),
       _platformContext(context),
       _infoObject(std::make_shared<RNSkInfoObject>()),
-      _timingInfo(std::make_shared<RNSkTimingInfo>())
+      _timingInfo(std::make_shared<RNSkTimingInfo>()),
+      _isDrawing(new std::timed_mutex())
       {}
 
 RNSkDrawView::~RNSkDrawView() {
   invalidate();
-  // This is a very simple fix to an issue where the view posts a redraw
-  // function to the javascript thread, and the object is destroyed and then
-  // the redraw function is called and ends up executing on a destroyed draw
-  // view. Since _isDrawing is an atomic bool we know that as long as it is
-  // true we are drawing and should wait.
-  // It is limited to only wait for 500 milliseconds - if it is stuck we
-  // might have gotten an exception that caused the flag to never be set.
-  milliseconds start = std::chrono::duration_cast<milliseconds>(
-      system_clock::now().time_since_epoch());
   
-  while (_isDrawing == true) {
-    milliseconds now = std::chrono::duration_cast<milliseconds>(
-        system_clock::now().time_since_epoch());
-    if (now.count() - start.count() > 500) {
-      RNSkLogger::logToConsole("Timed out waiting for RNSkDrawView delete...");
-      break;
-    }
+  // Wait for the drawing lock (if set)
+  if(!_isDrawing->try_lock_for(system_clock::now().time_since_epoch() + milliseconds(500))) {
+    RNSkLogger::logToConsole("Failed to delete since drawing is still locked for native view with id %i", _nativeId);
   }
+  
+  delete _isDrawing;  
 }
 
 void RNSkDrawView::invalidate() {
-  _isValid = false;
   endDrawingLoop();
+  _isValid = false;
 }
 
 void RNSkDrawView::setDrawCallback(std::shared_ptr<jsi::Function> callback) {
@@ -172,48 +161,49 @@ void RNSkDrawView::updateTouchState(const std::vector<RNSkTouchPoint> &points) {
   }
 }
 
+void RNSkDrawView::performDraw() {
+  if(isValid()) {
+    // Calculate milliseconds since start
+    milliseconds ms = duration_cast<milliseconds>(
+        system_clock::now().time_since_epoch());
+    
+    // Call draw frame method in sub class
+    drawFrame(ms.count() / 1000.0);
+    
+    // Unlock the drawing lock
+    _isDrawing->unlock();
+    
+    // Should we request a new redraw?
+    if(_drawingMode != RNSkDrawingMode::Continuous && _redrawRequestCounter > 0) {
+      _redrawRequestCounter = 0;
+      requestRedraw();
+    }
+  } else {
+    _isDrawing->unlock();
+  }
+}
+
 void RNSkDrawView::requestRedraw() {
   if (!isReadyToDraw()) {
+    return;
+  }
+  
+  // If we are in continuous mode, we can just start the drawing loop
+  if (_drawingMode == RNSkDrawingMode::Continuous) {
+    beginDrawingLoop();
+    return;
+  }
+  
+  // Check if we are already in a draw
+  if(!_isDrawing->try_lock()) {
     _redrawRequestCounter++;
     return;
   }
   
-  _isDrawing = true;
-  
-  auto performDraw = [this]() {
-    if(!isValid()) {
-      RNSkLogger::logToConsole("Warning: Trying to redraw after delete!");
-      _isDrawing = false;
-      return;
-    }
-
-    if (_drawingMode == RNSkDrawingMode::Continuous) {
-      _isDrawing = false;
-      beginDrawingLoop();
-      return;
-    }
-    
-    milliseconds ms = std::chrono::duration_cast<milliseconds>(
-        system_clock::now().time_since_epoch());
-
-    drawFrame(ms.count() / 1000.0);
-
-    _isDrawing = false;
-
-    if(_redrawRequestCounter > 0) {
-      _redrawRequestCounter = 0;
-      requestRedraw();
-    }
-  };
-
-  _platformContext->runOnJavascriptThread(performDraw);
+  _platformContext->runOnJavascriptThread(std::bind(&RNSkDrawView::performDraw, this));
 }
 
 bool RNSkDrawView::isReadyToDraw() {
-  if (_isDrawing) {
-    return false;
-  }
-
   if(!isValid()) {
     return false;
   }
@@ -243,49 +233,29 @@ void RNSkDrawView::beginDrawingLoop() {
   // Set to zero to avoid calling beginDrawLoop before we return
   _drawingLoopId =
       _platformContext->beginDrawLoop(_nativeId, [this]() {
-        auto performDraw = [&]() {
-          if(!isValid()) {
-            _isDrawing = false;
-            return;
-          }
-
-          milliseconds ms = std::chrono::duration_cast<milliseconds>(
-              system_clock::now().time_since_epoch());
-
-          // Only redraw if view is still alive
-          drawFrame(ms.count() / 1000.0);
-
-          _isDrawing = false;
-        };
-
-        if (!isReadyToDraw()) {
-          return;
+        if(_isDrawing->try_lock()) {
+          _platformContext->runOnJavascriptThread(std::bind(&RNSkDrawView::performDraw, this));
         }
-        
-        _isDrawing = true;
-        _platformContext->runOnJavascriptThread(performDraw);
       });
 }
 
 void RNSkDrawView::endDrawingLoop() {
   if(_drawingLoopId != 0) {
-    _platformContext->endDrawLoop(_nativeId);
     _drawingLoopId = 0;
+    _platformContext->endDrawLoop(_nativeId);
   }
 }
 
 void RNSkDrawView::setDrawingMode(RNSkDrawingMode mode) {
-  if(!isValid()) {
+  if(!isValid() || mode == _drawingMode || _nativeId == 0) {
     return;
   }
-  if(mode != _drawingMode) {
-    _drawingMode = mode;
-    if(mode == RNSkDrawingMode::Default) {
-      endDrawingLoop();
-    } else {
-      beginDrawingLoop();
-      requestRedraw();
-    }
+  _drawingMode = mode;
+  if(mode == RNSkDrawingMode::Default) {
+    endDrawingLoop();
+  } else {
+    beginDrawingLoop();
+    requestRedraw();
   }
 }
 

--- a/package/cpp/rnskia/RNSkDrawView.h
+++ b/package/cpp/rnskia/RNSkDrawView.h
@@ -41,6 +41,11 @@ public:
    * thread and js runtime.
    */
   void requestRedraw();
+  
+  /**
+   Calls the drawing callback on the javascript thread
+   */
+  void performDraw();
 
   /**
    * Installs the draw callback for the view
@@ -85,7 +90,7 @@ protected:
   /**
    * Setup and draw the frame
    */
-  virtual void drawFrame(double time) = 0;
+  virtual void drawFrame(double time) {};
 
   /**
    * Mark view as invalidated
@@ -140,9 +145,9 @@ private:
   std::shared_ptr<JsiSkCanvas> _jsiCanvas;
 
   /**
-   * is drawing flag
+   * drawing mutex
    */
-  std::atomic<bool> _isDrawing{false};
+  std::timed_mutex* _isDrawing;
 
   /**
    * Pointer to the platform context

--- a/package/cpp/rnskia/RNSkDrawView.h
+++ b/package/cpp/rnskia/RNSkDrawView.h
@@ -88,14 +88,14 @@ protected:
   virtual void drawFrame(double time) = 0;
 
   /**
-   * Mark view as removed from the RN view stack
+   * Mark view as invalidated
    */
-  void setIsRemoved();
+  void invalidate();
 
   /**
    * @return True if the view was marked as deleted
    */
-  bool getIsRemoved() { return _isRemoved; }
+  bool isValid() { return _isValid; }
 
   /**
    Updates the last duration value
@@ -178,9 +178,9 @@ private:
    */
   std::atomic<int> _redrawRequestCounter;
   /**
-   Flag indicating that the view is no longer available
+   Flag indicating that the view is valid / invalid
    */
-  std::atomic<bool> _isRemoved;
+  std::atomic<bool> _isValid { true };
 
   /**
    * Native id

--- a/package/cpp/rnskia/RNSkDrawView.h
+++ b/package/cpp/rnskia/RNSkDrawView.h
@@ -45,7 +45,17 @@ public:
   /**
    * Installs the draw callback for the view
    */
-  void setDrawCallback(size_t nativeId, std::shared_ptr<jsi::Function> callback);
+  void setDrawCallback(std::shared_ptr<jsi::Function> callback);
+  
+  /**
+   Sets the native id of the view
+   */
+  void setNativeId(size_t nativeId) { _nativeId = nativeId; }
+  
+  /**
+   Returns the native id
+   */
+  size_t getNativeId() { return _nativeId; }
 
   /**
    * Call this method with a valid Skia surface to let the draw drawCallback do
@@ -152,7 +162,7 @@ private:
   /**
    * True if the drawing loop has been requested
    */
-  size_t _drawingLoopId = -1;
+  size_t _drawingLoopId = 0;
 
   /**
    * Info object parameter

--- a/package/cpp/rnskia/RNSkJsiViewApi.h
+++ b/package/cpp/rnskia/RNSkJsiViewApi.h
@@ -61,7 +61,8 @@ public:
 
     // Update view if set
     if (info->view != nullptr && info->drawCallback != nullptr) {
-      info->view->setDrawCallback(nativeId, info->drawCallback);
+      info->view->setNativeId(nativeId);
+      info->view->setDrawCallback(info->drawCallback);
     }
 
     return jsi::Value::undefined();
@@ -144,6 +145,7 @@ public:
     for (auto info : tempList) {
       unregisterSkiaDrawView(info.first);
     }
+    _callbackInfos.clear();
   }
 
   /**
@@ -155,7 +157,8 @@ public:
     auto info = getEnsuredCallbackInfo(nativeId);
     info->view = view;
     if (info->drawCallback != nullptr) {
-      info->view->setDrawCallback(nativeId, info->drawCallback);
+      info->view->setNativeId(nativeId);
+      info->view->setDrawCallback(info->drawCallback);
     }
   }
 
@@ -169,11 +172,31 @@ public:
     }
     auto info = getEnsuredCallbackInfo(nativeId);
     if (info->view != nullptr) {
-      info->view->setDrawCallback(nativeId, nullptr);
+      info->view->setDrawCallback(nullptr);
     }
     info->view = nullptr;
     info->drawCallback = nullptr;
     _callbackInfos.erase(nativeId);
+  }
+  
+  /**
+   Sets a skia draw view for the given id. This function can be used
+   to mark that an underlying SkiaView is not available (it could be
+   removed due to ex. a transition). The view can be set to a nullptr
+   or a valid view, effectively toggling the view's availability. If
+   a valid view is set, the setDrawCallback method is called on the
+   view (if a valid callback exists).
+   */
+  void setSkiaDrawView(size_t nativeId, RNSkDrawView *view) {
+    if (_callbackInfos.count(nativeId) == 0) {
+      return;
+    }
+    auto info = getEnsuredCallbackInfo(nativeId);
+    info->view = view;
+    if (view != nullptr && info->drawCallback != nullptr) {
+      info->view->setNativeId(nativeId);
+      info->view->setDrawCallback(info->drawCallback);
+    }
   }
 
 private:

--- a/package/cpp/rnskia/RNSkManager.cpp
+++ b/package/cpp/rnskia/RNSkManager.cpp
@@ -1,7 +1,5 @@
 #include "RNSkManager.h"
 
-#include <mutex>
-
 #include <JsiSkApi.h>
 #include <RNSkJsiViewApi.h>
 
@@ -21,13 +19,22 @@ RNSkManager::RNSkManager(
 }
 
 RNSkManager::~RNSkManager() {
-  // We need to unregister all views when we get here
-  _viewApi->unregisterAll();
+  invalidate();
   // Free up any references
   _viewApi = nullptr;
   _jsRuntime = nullptr;
   _platformContext = nullptr;
   _jsCallInvoker = nullptr;
+}
+
+void RNSkManager::invalidate() {
+  if(!_isValid) {
+    return;
+  }
+  _isValid = false;
+  // We need to unregister all views when we get here
+  _viewApi->unregisterAll();
+  _platformContext->invalidate();
 }
 
 void RNSkManager::registerSkiaDrawView(size_t nativeId, RNSkDrawView *view) {
@@ -40,40 +47,23 @@ void RNSkManager::unregisterSkiaDrawView(size_t nativeId) {
     _viewApi->unregisterSkiaDrawView(nativeId);
 }
 
+void RNSkManager::setSkiaDrawView(size_t nativeId, RNSkDrawView *view) {
+  if (_viewApi != nullptr)
+    _viewApi->setSkiaDrawView(nativeId, view);
+}
+
 void RNSkManager::installBindings() {
   // Create the Skia API object and install it on the global object in the
   // provided runtime.
-  //
-  // This must be done on the Javascript thread to avoid threading issues
-  // when accessing the javascript objects from a thread not being the JS
-  // thread. On Android this is actually necessary, since we need to set up the
-  // API before the javascript starts to execute!
-#ifndef ANDROID
-  std::mutex mu;
-  std::condition_variable cond;
 
-  bool isInstalled = false;
-  std::unique_lock<std::mutex> lock(mu);
+  auto skiaApi = std::make_shared<JsiSkApi>(*_jsRuntime, _platformContext);
+  _jsRuntime->global().setProperty(
+      *_jsRuntime, "SkiaApi",
+      jsi::Object::createFromHostObject(*_jsRuntime, std::move(skiaApi)));
 
-  _platformContext->runOnJavascriptThread([&]() {
-    std::lock_guard<std::mutex> lock(mu);
-#endif
+  _jsRuntime->global().setProperty(
+      *_jsRuntime, "SkiaViewApi",
+      jsi::Object::createFromHostObject(*_jsRuntime, _viewApi));
 
-    auto skiaApi = std::make_shared<JsiSkApi>(*_jsRuntime, _platformContext);
-    _jsRuntime->global().setProperty(
-        *_jsRuntime, "SkiaApi",
-        jsi::Object::createFromHostObject(*_jsRuntime, std::move(skiaApi)));
-
-    _jsRuntime->global().setProperty(
-        *_jsRuntime, "SkiaViewApi",
-        jsi::Object::createFromHostObject(*_jsRuntime, _viewApi));
-
-#ifndef ANDROID
-    isInstalled = true;
-    cond.notify_one();
-  });
-
-  cond.wait(lock, [&]() { return isInstalled; });
-#endif
 }
 } // namespace RNSkia

--- a/package/cpp/rnskia/RNSkManager.h
+++ b/package/cpp/rnskia/RNSkManager.h
@@ -27,6 +27,11 @@ public:
               std::shared_ptr<RNSkPlatformContext> platformContext);
 
   ~RNSkManager();
+  
+  /**
+   Invalidates the Skia Manager
+   */
+  void invalidate();
 
   /**
    * Registers a RNSkDrawView with the given native id
@@ -40,6 +45,13 @@ public:
    * @param nativeId Native view Id
    */
   void unregisterSkiaDrawView(size_t nativeId);
+  
+  /**
+   Sets the view pointed to by nativeId to the provided value.
+   Used when we want to remove a view without unregistering it
+   - this happens typically on iOS.
+   */
+  void setSkiaDrawView(size_t nativeId, RNSkDrawView *view);
 
   /**
    * @return The platform context
@@ -60,6 +72,7 @@ private:
   std::shared_ptr<RNSkPlatformContext> _platformContext;
   std::shared_ptr<facebook::react::CallInvoker> _jsCallInvoker;
   std::shared_ptr<RNSkJsiViewApi> _viewApi;
+  bool _isValid = true;
 };
 
 } // namespace RNSkia

--- a/package/ios/RNSkia-iOS/RNSkDrawViewImpl.h
+++ b/package/ios/RNSkia-iOS/RNSkDrawViewImpl.h
@@ -17,12 +17,6 @@ public:
                    std::shared_ptr<RNSkia::RNSkPlatformContext> context);
   ~RNSkDrawViewImpl();
 
-  void remove();
-
-  void setOnRemoved(std::shared_ptr<std::function<void()>> func) {
-    _onRemove = func;
-  }
-
   void setSize(int width, int height);
 
 protected:
@@ -50,6 +44,4 @@ private:
 
   GrBackendRenderTarget _skRenderTarget;
   sk_sp<SkSurface> _skSurface;
-
-  std::shared_ptr<std::function<void()>> _onRemove;
 };

--- a/package/ios/RNSkia-iOS/RNSkDrawViewImpl.h
+++ b/package/ios/RNSkia-iOS/RNSkDrawViewImpl.h
@@ -15,8 +15,7 @@ class RNSkDrawViewImpl : public RNSkia::RNSkDrawView {
 public:
   RNSkDrawViewImpl(SkiaDrawView *view,
                    std::shared_ptr<RNSkia::RNSkPlatformContext> context);
-  ~RNSkDrawViewImpl();
-
+  
   void setSize(int width, int height);
 
 protected:
@@ -42,6 +41,5 @@ private:
 
   std::shared_ptr<RNSkia::RNSkPlatformContext> _context;
 
-  GrBackendRenderTarget _skRenderTarget;
-  sk_sp<SkSurface> _skSurface;
+  GrBackendRenderTarget _skRenderTarget;  
 };

--- a/package/ios/RNSkia-iOS/RNSkDrawViewImpl.mm
+++ b/package/ios/RNSkia-iOS/RNSkDrawViewImpl.mm
@@ -88,19 +88,3 @@ void RNSkDrawViewImpl::drawFrame(double time) {
   auto stop = std::chrono::high_resolution_clock::now();
   setLastFrameDuration(std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count());
 }
-
-void RNSkDrawViewImpl::remove() {
-  // Call onRemove callback to unregister view
-  if(_onRemove != nullptr) {
-    (*_onRemove.get())();
-    _onRemove = nullptr;
-  }
-  
-  // Set view to null
-  _view = nullptr;
-  
-  // Tear down Skia drawing
-  _skSurface = nullptr;
-  
-  
-}

--- a/package/ios/RNSkia-iOS/RNSkDrawViewImpl.mm
+++ b/package/ios/RNSkia-iOS/RNSkDrawViewImpl.mm
@@ -30,8 +30,6 @@ RNSkDrawViewImpl::RNSkDrawViewImpl(SkiaDrawView* view, std::shared_ptr<RNSkia::R
     [_view.layer addSublayer:_layer];
 }
 
-RNSkDrawViewImpl::~RNSkDrawViewImpl() {}
-
 void RNSkDrawViewImpl::setSize(int width, int height) {
   _width = width;
   _height = height;
@@ -60,20 +58,20 @@ void RNSkDrawViewImpl::drawFrame(double time) {
                                   sampleCount,
                                   fbInfo);
 
-  _skSurface = SkSurface::MakeFromBackendRenderTarget(_skContext.get(),
-                                                      backendRT,
-                                                      kTopLeft_GrSurfaceOrigin,
-                                                      kBGRA_8888_SkColorType,
-                                                      nullptr,
-                                                      nullptr);
+  auto skSurface = SkSurface::MakeFromBackendRenderTarget(_skContext.get(),
+                                                          backendRT,
+                                                          kTopLeft_GrSurfaceOrigin,
+                                                          kBGRA_8888_SkColorType,
+                                                          nullptr,
+                                                          nullptr);
   
-  if(_skSurface == nullptr) {
+  if(skSurface == nullptr || skSurface->getCanvas() == nullptr) {
     RNSkia::RNSkLogger::logToConsole("Skia surface could not be created from parameters.");
     return;
   }
   
-  _skSurface->getCanvas()->clear(SK_AlphaTRANSPARENT);
-  drawInSurface(_skSurface,
+  skSurface->getCanvas()->clear(SK_AlphaTRANSPARENT);
+  drawInSurface(skSurface,
                 _width * _context->getPixelDensity(),
                 _height * _context->getPixelDensity(),
                 time,

--- a/package/ios/RNSkia-iOS/SkiaDrawView.h
+++ b/package/ios/RNSkia-iOS/SkiaDrawView.h
@@ -1,16 +1,19 @@
 #pragma once
 
 #import <CoreFoundation/CoreFoundation.h>
-#import <PlatformContext.h>
+#import <RNSkManager.h>
 #import <UIKit/UIKit.h>
 
 class RNSkDrawViewImpl;
 
 @interface SkiaDrawView : UIView
 
-- (instancetype)initWithContext:
-    (std::shared_ptr<RNSkia::RNSkPlatformContext>)context;
+- (instancetype)initWithManager: (RNSkia::RNSkManager*)manager;
 
 - (RNSkDrawViewImpl *)impl;
+
+- (void) setDrawingMode:(std::string) mode;
+- (void) setDebugMode:(bool) debugMode;
+- (void) setNativeId:(size_t) nativeId;
 
 @end

--- a/package/ios/RNSkia-iOS/SkiaDrawViewManager.mm
+++ b/package/ios/RNSkia-iOS/SkiaDrawViewManager.mm
@@ -11,41 +11,19 @@
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(nativeID, NSNumber, SkiaDrawView) {
-  // Get parameters
+  // Get parameter
   int nativeId = [[RCTConvert NSString:json] intValue];
-      
-  // Get the skManager
-  auto skManager = [_skiaManager skManager];
-  skManager->registerSkiaDrawView(nativeId, [(SkiaDrawView*)view impl]);
-  
-  auto onRemoved = std::make_shared<std::function<void()>>([skManager, nativeId]() {
-    skManager->unregisterSkiaDrawView(nativeId);
-  });
-  
-  // Set a callback for when the view was removed
-  [(SkiaDrawView*)view impl]->setOnRemoved(std::move(onRemoved));
+  [(SkiaDrawView*)view setNativeId:nativeId];            
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(mode, NSString, SkiaDrawView) {
-  if(json != NULL) {
-    std::string mode = [[RCTConvert NSString:json] UTF8String];
-    if(mode.compare("continuous") == 0) {
-      [(SkiaDrawView*)view impl]->setDrawingMode(RNSkia::RNSkDrawingMode::Continuous);
-    } else {
-      [(SkiaDrawView*)view impl]->setDrawingMode(RNSkia::RNSkDrawingMode::Default);
-    }
-  } else {
-    [(SkiaDrawView*)view impl]->setDrawingMode(RNSkia::RNSkDrawingMode::Default);
-  }
+  std::string mode = json != NULL ? [[RCTConvert NSString:json] UTF8String] : "default";
+  [(SkiaDrawView*)view setDrawingMode: mode];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(debug, BOOL, SkiaDrawView) {
-  if(json != NULL) {
-    bool show = [RCTConvert BOOL:json];
-    [(SkiaDrawView*)view impl]->setShowDebugOverlays(show);
-  } else {
-    [(SkiaDrawView*)view impl]->setShowDebugOverlays(false);
-  }
+  bool debug = json != NULL ? [RCTConvert BOOL:json] : false;
+  [(SkiaDrawView*)view setDebugMode: debug];
 }
 
 RCT_EXPORT_MODULE(ReactNativeSkiaView)
@@ -53,7 +31,8 @@ RCT_EXPORT_MODULE(ReactNativeSkiaView)
 - (UIView *)view
 {
   auto skManager = [_skiaManager skManager];
-  return [[SkiaDrawView alloc] initWithContext:skManager->getPlatformContext()];
+  // Pass SkManager as a raw pointer to avoid circular dependenciesr
+  return [[SkiaDrawView alloc] initWithManager:skManager.get()];
 }
 
 - (void) setBridge:(RCTBridge *)bridge {

--- a/package/ios/RNSkia-iOS/SkiaManager.mm
+++ b/package/ios/RNSkia-iOS/SkiaManager.mm
@@ -21,10 +21,10 @@
 
 - (void) invalidate {
   if(_skManager != nullptr) {
-    _skManager->getPlatformContext()->stopDrawLoop();
+    _skManager->invalidate();
   }
   _skManager = nullptr;
-  _platformContext = nullptr;    
+  _platformContext = nullptr;
 }
 
 - (instancetype) initWithBridge:(RCTBridge*)bridge {


### PR DESCRIPTION
## Problem:
On iOS the process of removing and unregistering a SkiaView is a bit more complicated than on Android, since the iOS RCTViewManager does not have a notification for a view removal. This causes a memory leak and we need to track adding/removing the SkiaView by using the willMoveToWindow on the wrapping UIView. This causes some issues with the implementation of the RNSkDrawView not being available when we create/remove the view (ex. in navigation transitions). In addition all of this can cause a race condition where the view is removed while it has a pending draw request that will be executed after the view was removed.

## Fixes
- Implements correct tracking of view add/remove using the willMoveToWindow method
- Refactored some of the RNSk code to support adding removing an implementation view without removing callbacks etc
- Refactored how we track removal and draw requests to support this scheme

Fixes #71