### PR TITLE
Fix calling asObject twice for JsiSkRect::fromValue conversion

### DIFF
--- a/package/cpp/api/JsiSkRect.h
+++ b/package/cpp/api/JsiSkRect.h
@@ -62,7 +62,7 @@ public:
                                            const jsi::Value &obj) {
     const auto object = obj.asObject(runtime);
     if (object.isHostObject(runtime)) {
-      return obj.asObject(runtime)
+      return object
               .asHostObject<JsiSkRect>(runtime)
               .get()
               ->getObject();


### PR DESCRIPTION
When converting from a JS object to a SkRect, we use the static function JsiSkxxxx::fromValue to get to the underlying host object. In the JsiSkRect implementation we test the incoming object to see if it is a host object or a rect-like object. A small mistake was made that caused the JSI asObject method to be called twice, which is noticeable in the instrumentation/profiling of an app using a lot of rects.

This pull request fixes this by removing the redundant call.

Fixes #79 