### PR TITLE
Fix rectangle processing

### DIFF
--- a/docs/docs/shapes/polygons.md
+++ b/docs/docs/shapes/polygons.md
@@ -15,8 +15,6 @@ Draws a rectangle.
 | y      | `number` | Y coordinate.                                                 |
 | width  | `number` | Width of the rectangle.                                       |
 | height | `number` | Height of the rectangle.                                      |
-| rx?    | `number` | Horizontal corner radius. Defaults to `ry` if specified or 0. |
-| ry?    | `number` | Vertical corner radius. Defaults to `rx` if specified or 0.   |
 
 ```tsx twoslash
 import {Canvas, Rect} from "@shopify/react-native-skia";
@@ -25,6 +23,37 @@ const RectDemo = () => {
   return (
     <Canvas style={{ flex: 1}}>
       <Rect
+        x={0}
+        y={0}
+        width={256}
+        height={256}
+        color="lightblue"
+      />
+    </Canvas>
+  );
+};
+```
+
+## RRect
+
+Draws a rounded rectangle.
+
+| Name   | Type     |  Description                                                  |
+|:-------|:---------|:--------------------------------------------------------------|
+| x      | `number` | X coordinate.                                                 |
+| y      | `number` | Y coordinate.                                                 |
+| width  | `number` | Width of the rectangle.                                       |
+| height | `number` | Height of the rectangle.                                      |
+| rx?    | `number` | Horizontal corner radius. Defaults to `ry` if specified or 0. |
+| ry?    | `number` | Vertical corner radius. Defaults to `rx` if specified or 0.   |
+
+```tsx twoslash
+import {Canvas, RRect} from "@shopify/react-native-skia";
+
+const RectDemo = () => {
+  return (
+    <Canvas style={{ flex: 1}}>
+      <RRect
         x={0}
         y={0}
         width={256}

--- a/example/src/Examples/API/Shapes2.tsx
+++ b/example/src/Examples/API/Shapes2.tsx
@@ -16,6 +16,7 @@ import {
   rrect,
   Paint,
   DashPathEffect,
+  RRect,
 } from "@shopify/react-native-skia";
 
 import { Title } from "./components/Title";
@@ -65,7 +66,7 @@ export const Shapes = () => {
       <Canvas style={styles.container}>
         <Group color="#61DAFB">
           <Rect rect={{ x: PADDING, y: PADDING, width: 100, height: 100 }} />
-          <Rect
+          <RRect
             x={SIZE + 2 * PADDING}
             y={PADDING}
             width={SIZE}

--- a/package/src/renderer/components/shaders/Shader.tsx
+++ b/package/src/renderer/components/shaders/Shader.tsx
@@ -6,10 +6,11 @@ import type { IRuntimeEffect } from "../../../skia";
 import type { Vector, AnimatedProps, TransformProps } from "../../processors";
 import { useDeclaration } from "../../nodes/Declaration";
 import { localMatrix } from "../../processors";
-import { hasProperty } from "../../typeddash";
 
+// We need to use any here because hasOwnProperty doesn't work on JSI instances
 const isVector = (obj: unknown): obj is Vector =>
-  hasProperty(obj, "x") && hasProperty(obj, "y");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (obj as any).x !== undefined && (obj as any).y !== undefined;
 
 type Uniform = number | number[] | Vector;
 

--- a/package/src/renderer/components/shapes/Rect.tsx
+++ b/package/src/renderer/components/shapes/Rect.tsx
@@ -1,23 +1,27 @@
 import React from "react";
 
 import type { CustomPaintProps } from "../../processors";
-import type { RectOrRRectDef } from "../../processors/Shapes";
-import { isRRect } from "../../processors/Shapes";
-import type { IRect } from "../../../skia/Rect";
-import { processRectOrRRect } from "../../processors";
+import type { RectDef, RRectDef } from "../../processors/Shapes";
+import { processRect, processRRect } from "../../processors/Shapes";
 import type { AnimatedProps } from "../../processors/Animations/Animations";
 import { useDrawing } from "../../nodes/Drawing";
 
-export type RectProps = RectOrRRectDef & CustomPaintProps;
+export type RectProps = RectDef & CustomPaintProps;
 
 export const Rect = (props: AnimatedProps<RectProps>) => {
   const onDraw = useDrawing(props, ({ canvas, paint }, rectProps) => {
-    const rect = processRectOrRRect(rectProps);
-    if (isRRect(rect)) {
-      canvas.drawRRect(rect, paint);
-    } else {
-      canvas.drawRect(rect as IRect, paint);
-    }
+    const rect = processRect(rectProps);
+    canvas.drawRect(rect, paint);
+  });
+  return <skDrawing onDraw={onDraw} {...props} />;
+};
+
+export type RRectProps = RRectDef & CustomPaintProps;
+
+export const RRect = (props: AnimatedProps<RRectProps>) => {
+  const onDraw = useDrawing(props, ({ canvas, paint }, rectProps) => {
+    const rrect = processRRect(rectProps);
+    canvas.drawRRect(rrect, paint);
   });
   return <skDrawing onDraw={onDraw} {...props} />;
 };

--- a/package/src/renderer/typeddash.ts
+++ b/package/src/renderer/typeddash.ts
@@ -1,8 +1,5 @@
 export const mapKeys = <T>(obj: T) => Object.keys(obj) as (keyof T)[];
 
-export const hasProperty = (obj: unknown, key: string) =>
-  !!(typeof obj === "object" && obj !== null && key in obj);
-
 export const exhaustiveCheck = (a: never): never => {
   throw new Error(`Unexhaustive handling for ${a}`);
 };


### PR DESCRIPTION
fixes #81 

We used to rely on the `key in obj` syntax to detect the shape of rectangle. Unfortunately, this syntax doesn't work on JSI instance.

There are two orthogonal things here:
1. remove the hasProperty which was broken for JSI instance
2. make RRect clearly separated from Rect since they have two different level of performance to make it more explicit (no strong opinon, we could still keep them together)