### PR TITLE
Fixed issue with symlink already exists error on Android

### DIFF
--- a/package/scripts/install-npm.js
+++ b/package/scripts/install-npm.js
@@ -8,11 +8,9 @@ const createSymlink = (p) => {
   const srcDir = path.resolve(`./cpp/${p}`);
   const dstDir = path.resolve(`./android/cpp/${p}`);
 
-  if (fs.existsSync(dstDir)) {
-    fs.unlinkSync(dstDir);
+  if (!fs.existsSync(dstDir)) {
+    fs.symlinkSync(srcDir, dstDir, "dir");
   }
-
-  fs.symlinkSync(srcDir, dstDir, "dir");
 };
 
 // Copy common cpp files from the package root to the android folder


### PR DESCRIPTION
Instead of deleting and creating if the symlink exists, we now only creates it if the symlink does not exist.

This problem might occur if the `symlinkSync` command  is called immediately after `deleteSymlink` - due to some file system synchronisation. It is better to only create when it does not exist.

#closes #158