### PR TITLE
Minor refactoring the matrix3 API

### DIFF
--- a/example/src/Examples/Drawing/Context/functions/resizeElements.ts
+++ b/example/src/Examples/Drawing/Context/functions/resizeElements.ts
@@ -1,4 +1,4 @@
-import { Skia } from "@shopify/react-native-skia";
+import { processTransform2d, skiaMatrix3 } from "@shopify/react-native-skia";
 import type { IRect } from "@shopify/react-native-skia";
 
 import type { DrawingElements, ResizeMode } from "../types";
@@ -37,14 +37,13 @@ export const resizeElementsBy = (
     return;
   }
 
-  const matrix = Skia.Matrix();
   const scaleX = dest.width / source.width;
   const scaleY = dest.height / source.height;
-  matrix.setScaleX(scaleX);
-  matrix.setScaleY(scaleY);
-  matrix.setTranslateX(dest.x - source.x * scaleX);
-  matrix.setTranslateY(dest.y - source.y * scaleY);
-
+  const translateX = dest.x - source.x * scaleX;
+  const translateY = dest.y - source.y * scaleY;
+  const matrix = skiaMatrix3(
+    processTransform2d([{ translateX }, { translateY }, { scaleX }, { scaleY }])
+  );
   // use to scale elements
   for (let i = 0; i < elements.length; i++) {
     const element = elements[i];

--- a/example/src/Examples/Drawing/Context/functions/resizeElements.ts
+++ b/example/src/Examples/Drawing/Context/functions/resizeElements.ts
@@ -1,4 +1,4 @@
-import { processTransform2d, skiaMatrix3 } from "@shopify/react-native-skia";
+import { processTransform2d } from "@shopify/react-native-skia";
 import type { IRect } from "@shopify/react-native-skia";
 
 import type { DrawingElements, ResizeMode } from "../types";
@@ -41,9 +41,12 @@ export const resizeElementsBy = (
   const scaleY = dest.height / source.height;
   const translateX = dest.x - source.x * scaleX;
   const translateY = dest.y - source.y * scaleY;
-  const matrix = skiaMatrix3(
-    processTransform2d([{ translateX }, { translateY }, { scaleX }, { scaleY }])
-  );
+  const matrix = processTransform2d([
+    { translateX },
+    { translateY },
+    { scaleX },
+    { scaleY },
+  ]);
   // use to scale elements
   for (let i = 0; i < elements.length; i++) {
     const element = elements[i];

--- a/package/cpp/api/JsiSkMatrix.h
+++ b/package/cpp/api/JsiSkMatrix.h
@@ -16,126 +16,6 @@ using namespace facebook;
 
 class JsiSkMatrix : public JsiSkWrappingSharedPtrHostObject<SkMatrix> {
 public:
-  // TODO-API: Properties?
-  JSI_HOST_FUNCTION(set) {
-    auto i = arguments[0].asNumber();
-    auto v = arguments[1].asNumber();
-    getObject()->set(i, v);
-    return jsi::Value::undefined();
-  }
-
-  JSI_HOST_FUNCTION(get) {
-    auto i = arguments[0].asNumber();
-    auto v = getObject()->get(i);
-    return jsi::Value(SkScalarToDouble(v));
-  }
-
-  JSI_HOST_FUNCTION(setScaleX) {
-    auto v = arguments[0].asNumber();
-    getObject()->setScaleX(v);
-    return jsi::Value::undefined();
-  }
-
-  JSI_HOST_FUNCTION(getScaleX) {
-    auto v = getObject()->getScaleX();
-    return jsi::Value(SkScalarToDouble(v));
-  }
-
-  JSI_HOST_FUNCTION(setScaleY) {
-    auto v = arguments[0].asNumber();
-    getObject()->setScaleY(v);
-    return jsi::Value::undefined();
-  }
-
-  JSI_HOST_FUNCTION(getScaleY) {
-    auto v = getObject()->getScaleY();
-    return jsi::Value(SkScalarToDouble(v));
-  }
-
-  JSI_HOST_FUNCTION(setSkewX) {
-    auto v = arguments[0].asNumber();
-    getObject()->setSkewX(v);
-    return jsi::Value::undefined();
-  }
-
-  JSI_HOST_FUNCTION(getSkewX) {
-    auto v = getObject()->getSkewX();
-    return jsi::Value(SkScalarToDouble(v));
-  }
-
-  JSI_HOST_FUNCTION(setSkewY) {
-    auto v = arguments[0].asNumber();
-    getObject()->setSkewY(v);
-    return jsi::Value::undefined();
-  }
-
-  JSI_HOST_FUNCTION(getSkewY) {
-    auto v = getObject()->getSkewY();
-    return jsi::Value(SkScalarToDouble(v));
-  }
-
-  JSI_HOST_FUNCTION(setTranslateX) {
-    auto v = arguments[0].asNumber();
-    getObject()->setTranslateX(v);
-    return jsi::Value::undefined();
-  }
-
-  JSI_HOST_FUNCTION(getTranslateX) {
-    auto v = getObject()->getTranslateX();
-    return jsi::Value(SkScalarToDouble(v));
-  }
-
-  JSI_HOST_FUNCTION(setTranslateY) {
-    auto v = arguments[0].asNumber();
-    getObject()->setTranslateY(v);
-    return jsi::Value::undefined();
-  }
-
-  JSI_HOST_FUNCTION(getTranslateY) {
-    auto v = getObject()->getTranslateY();
-    return jsi::Value(SkScalarToDouble(v));
-  }
-
-  JSI_HOST_FUNCTION(setPerspX) {
-    auto v = arguments[0].asNumber();
-    getObject()->setPerspX(v);
-    return jsi::Value::undefined();
-  }
-
-  JSI_HOST_FUNCTION(getPerspX) {
-    auto v = getObject()->getPerspX();
-    return jsi::Value(SkScalarToDouble(v));
-  }
-
-  JSI_HOST_FUNCTION(setPerspY) {
-    auto v = arguments[0].asNumber();
-    getObject()->setPerspY(v);
-    return jsi::Value::undefined();
-  }
-
-  JSI_HOST_FUNCTION(getPerspY) {
-    auto v = getObject()->getPerspX();
-    return jsi::Value(SkScalarToDouble(v));
-  }
-
-  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkMatrix, getPerspY),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, setPerspY),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, getPerspX),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, setPerspX),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, getTranslateY),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, setTranslateY),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, getTranslateX),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, setTranslateX),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, getSkewY),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, setSkewY),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, getSkewX),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, setSkewX),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, getScaleY),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, setScaleY),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, getScaleX),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, setScaleX),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, get),
-                       JSI_EXPORT_FUNC(JsiSkMatrix, set))
 
   JsiSkMatrix(std::shared_ptr<RNSkPlatformContext> context, SkMatrix m)
       : JsiSkWrappingSharedPtrHostObject<SkMatrix>(
@@ -146,10 +26,28 @@ Returns the underlying object from a host object of this type
 */
   static std::shared_ptr<SkMatrix> fromValue(jsi::Runtime &runtime,
                                              const jsi::Value &obj) {
-    return obj.asObject(runtime)
-        .asHostObject<JsiSkMatrix>(runtime)
-        .get()
-        ->getObject();
+    const auto object = obj.asObject(runtime);
+    if (object.isHostObject(runtime)) {
+      return object
+              .asHostObject<JsiSkMatrix>(runtime)
+              .get()
+              ->getObject();
+    } else {
+      auto array = object.asArray(runtime);
+      auto scaleX = array.getValueAtIndex(runtime, 0).asNumber();
+      auto skewX = array.getValueAtIndex(runtime, 1).asNumber();
+      auto transX = array.getValueAtIndex(runtime, 2).asNumber();
+      auto skewY = array.getValueAtIndex(runtime, 3).asNumber();
+      auto scaleY = array.getValueAtIndex(runtime, 4).asNumber();
+      auto transY = array.getValueAtIndex(runtime, 5).asNumber();
+      auto pers0 = array.getValueAtIndex(runtime, 6).asNumber();
+      auto pers1 = array.getValueAtIndex(runtime, 7).asNumber();
+      auto pers2 = array.getValueAtIndex(runtime, 8).asNumber();
+      return std::make_shared<SkMatrix>(SkMatrix::MakeAll(
+        scaleX, skewX, transX,
+        skewY,  scaleY, transY,
+        pers0,  pers1,  pers2));
+    }
   }
 
   static const jsi::HostFunctionType

--- a/package/src/renderer/processors/Transform.ts
+++ b/package/src/renderer/processors/Transform.ts
@@ -1,7 +1,7 @@
 import type { DrawingContext } from "../DrawingContext";
 import type { IMatrix } from "../../skia/Matrix";
 
-import { neg, skiaMatrix3, processTransform2d } from "./math";
+import { neg, processTransform2d } from "./math";
 import type { Transforms2d, Vector } from "./math";
 
 export interface TransformProps {
@@ -21,18 +21,16 @@ export const processTransform = (
       const m3 = processTransform2d(
         origin ? transformOrigin(origin, transform) : transform
       );
-      const sm = skiaMatrix3(m3);
-      canvas.concat(sm);
+      canvas.concat(m3);
     }
   }
 };
 
 export const localMatrix = ({ transform, origin }: TransformProps) => {
   if (transform) {
-    const m3 = processTransform2d(
+    return processTransform2d(
       origin ? transformOrigin(origin, transform) : transform
     );
-    return skiaMatrix3(m3);
   }
   return undefined;
 };

--- a/package/src/renderer/processors/Transform.ts
+++ b/package/src/renderer/processors/Transform.ts
@@ -1,25 +1,29 @@
 import type { DrawingContext } from "../DrawingContext";
+import type { IMatrix } from "../../skia/Matrix";
 
 import { neg, skiaMatrix3, processTransform2d } from "./math";
 import type { Transforms2d, Vector } from "./math";
 
-// TODO: 1. Add support for supplying the matrix directly
-// TODO: 2. Add direct constructor of the matrix via jsiskmatrix::fromValue
 export interface TransformProps {
   transform?: Transforms2d;
   origin?: Vector;
+  matrix?: IMatrix;
 }
 
 export const processTransform = (
   { canvas }: DrawingContext,
-  { transform, origin }: TransformProps
+  { transform, origin, matrix }: TransformProps
 ) => {
   if (transform) {
-    const m3 = processTransform2d(
-      origin ? transformOrigin(origin, transform) : transform
-    );
-    const sm = skiaMatrix3(m3);
-    canvas.concat(sm);
+    if (matrix) {
+      canvas.concat(matrix);
+    } else {
+      const m3 = processTransform2d(
+        origin ? transformOrigin(origin, transform) : transform
+      );
+      const sm = skiaMatrix3(m3);
+      canvas.concat(sm);
+    }
   }
 };
 

--- a/package/src/renderer/processors/math/Matrix3.ts
+++ b/package/src/renderer/processors/math/Matrix3.ts
@@ -1,5 +1,5 @@
-import { Skia } from "../../../skia";
 import { exhaustiveCheck } from "../../typeddash";
+import type { IMatrix } from "../../../skia/Matrix";
 
 export type Vec3 = readonly [number, number, number];
 
@@ -105,24 +105,18 @@ export const multiply3 = (m1: Matrix3, m2: Matrix3) => {
   ] as const;
 };
 
-export const transformSvg = (transform: Transforms2d) =>
-  serializeToSVG(processTransform2d(transform));
-
-export const serializeToSVG = (m: Matrix3) =>
-  `matrix(${m[0][0]}, ${m[1][0]}, ${m[0][1]}, ${m[1][1]}, ${m[0][2]}, ${m[1][2]})`;
-
-export const skiaMatrix3 = (m: Matrix3) => {
-  const r = Skia.Matrix();
-  r.set(0, m[0][0]);
-  r.set(1, m[0][1]);
-  r.set(2, m[0][2]);
-  r.set(3, m[1][0]);
-  r.set(4, m[1][1]);
-  r.set(5, m[1][2]);
-  r.set(6, m[2][0]);
-  r.set(7, m[2][1]);
-  r.set(8, m[2][2]);
-  return r;
+export const skiaMatrix3 = (m: Matrix3): IMatrix => {
+  return [
+    m[0][0],
+    m[0][1],
+    m[0][2],
+    m[1][0],
+    m[1][1],
+    m[1][2],
+    m[2][0],
+    m[2][1],
+    m[2][2],
+  ];
 };
 
 export const processTransform2d = (transforms: Transforms2d) =>

--- a/package/src/renderer/processors/math/Matrix3.ts
+++ b/package/src/renderer/processors/math/Matrix3.ts
@@ -88,13 +88,10 @@ const rotateZMatrix = (r: number): Matrix3 => [
   [0, 0, 1],
 ];
 
-export const dot3 = (row: Vec3, col: Vec3) =>
+const dot3 = (row: Vec3, col: Vec3) =>
   row[0] * col[0] + row[1] * col[1] + row[2] * col[2];
 
-export const matrixVecMul3 = (m: Matrix3, v: Vec3) =>
-  [dot3(m[0], v), dot3(m[1], v), dot3(m[2], v)] as const;
-
-export const multiply3 = (m1: Matrix3, m2: Matrix3) => {
+const multiply3 = (m1: Matrix3, m2: Matrix3) => {
   const col0 = [m2[0][0], m2[1][0], m2[2][0]] as const;
   const col1 = [m2[0][1], m2[1][1], m2[2][1]] as const;
   const col2 = [m2[0][2], m2[1][2], m2[2][2]] as const;
@@ -105,7 +102,7 @@ export const multiply3 = (m1: Matrix3, m2: Matrix3) => {
   ] as const;
 };
 
-export const skiaMatrix3 = (m: Matrix3): IMatrix => {
+const skiaMatrix3 = (m: Matrix3): IMatrix => {
   return [
     m[0][0],
     m[0][1],
@@ -120,66 +117,34 @@ export const skiaMatrix3 = (m: Matrix3): IMatrix => {
 };
 
 export const processTransform2d = (transforms: Transforms2d) =>
-  transforms.reduce((acc, transform) => {
-    const key = Object.keys(transform)[0] as Transform2dName;
-    const value = (transform as Pick<Transformations, typeof key>)[key];
-    if (key === "translateX") {
-      return multiply3(acc, translateXMatrix(value));
-    }
-    if (key === "translateY") {
-      return multiply3(acc, translateYMatrix(value));
-    }
-    if (key === "scale") {
-      return multiply3(acc, scaleMatrix(value));
-    }
-    if (key === "scaleX") {
-      return multiply3(acc, scaleXMatrix(value));
-    }
-    if (key === "scaleY") {
-      return multiply3(acc, scaleYMatrix(value));
-    }
-    if (key === "skewX") {
-      return multiply3(acc, skewXMatrix(value));
-    }
-    if (key === "skewY") {
-      return multiply3(acc, skewYMatrix(value));
-    }
-    if (key === "rotate" || key === "rotateZ") {
-      return multiply3(acc, rotateZMatrix(value));
-    }
-    return exhaustiveCheck(key);
-  }, identityMatrix);
-
-const isMatrix3 = (arg: Matrix3 | Transforms2d): arg is Matrix3 =>
-  arg.length === 3 && arg[0] instanceof Array;
-
-// https://math.stackexchange.com/questions/13150/extracting-rotation-scale-values-from-2d-transformation-matrix
-export const decompose2d = (arg: Matrix3 | Transforms2d) => {
-  const m = isMatrix3(arg) ? arg : processTransform2d(arg);
-  const a = m[0][0];
-  const b = m[1][0];
-  const c = m[0][1];
-  const d = m[1][1];
-  const translateX = m[0][2];
-  const translateY = m[1][2];
-  const E = (a + d) / 2;
-  const F = (a - d) / 2;
-  const G = (c + b) / 2;
-  const H = (c - b) / 2;
-  const Q = Math.sqrt(Math.pow(E, 2) + Math.pow(H, 2));
-  const R = Math.sqrt(Math.pow(F, 2) + Math.pow(G, 2));
-  const scaleX = Q + R;
-  const scaleY = Q - R;
-  const a1 = Math.atan2(G, F);
-  const a2 = Math.atan2(H, E);
-  const theta = (a2 - a1) / 2;
-  const phi = (a2 + a1) / 2;
-  return [
-    { translateX },
-    { translateY },
-    { rotateZ: -1 * theta },
-    { scaleX },
-    { scaleY },
-    { rotateZ: -1 * phi },
-  ] as const;
-};
+  skiaMatrix3(
+    transforms.reduce((acc, transform) => {
+      const key = Object.keys(transform)[0] as Transform2dName;
+      const value = (transform as Pick<Transformations, typeof key>)[key];
+      if (key === "translateX") {
+        return multiply3(acc, translateXMatrix(value));
+      }
+      if (key === "translateY") {
+        return multiply3(acc, translateYMatrix(value));
+      }
+      if (key === "scale") {
+        return multiply3(acc, scaleMatrix(value));
+      }
+      if (key === "scaleX") {
+        return multiply3(acc, scaleXMatrix(value));
+      }
+      if (key === "scaleY") {
+        return multiply3(acc, scaleYMatrix(value));
+      }
+      if (key === "skewX") {
+        return multiply3(acc, skewXMatrix(value));
+      }
+      if (key === "skewY") {
+        return multiply3(acc, skewYMatrix(value));
+      }
+      if (key === "rotate" || key === "rotateZ") {
+        return multiply3(acc, rotateZMatrix(value));
+      }
+      return exhaustiveCheck(key);
+    }, identityMatrix)
+  );

--- a/package/src/skia/Canvas.ts
+++ b/package/src/skia/Canvas.ts
@@ -8,7 +8,7 @@ import type { Color } from "./Color";
 import type { IRRect } from "./RRect";
 import type { BlendMode } from "./Paint/BlendMode";
 import type { IPoint, PointMode } from "./Point";
-import type { Matrix } from "./Matrix";
+import type { IMatrix } from "./Matrix";
 import type { IImageFilter } from "./ImageFilter";
 import type { MipmapMode, FilterMode } from "./Image/Image";
 import type { Vertices } from "./Vertices";
@@ -454,5 +454,5 @@ export interface ICanvas {
    * Replaces current matrix with m premultiplied with the existing matrix.
    * @param m
    */
-  concat(m: Matrix): void;
+  concat(m: IMatrix): void;
 }

--- a/package/src/skia/Image/Image.ts
+++ b/package/src/skia/Image/Image.ts
@@ -1,6 +1,6 @@
 import type { TileMode } from "../ImageFilter";
 import type { IShader } from "../Shader";
-import type { Matrix } from "../Matrix";
+import type { IMatrix } from "../Matrix";
 import type { SkJSIInstance } from "../JsiInstance";
 
 export enum FilterMode {
@@ -45,7 +45,7 @@ export interface IImage extends SkJSIInstance<"Image"> {
     ty: TileMode,
     fm: FilterMode,
     mm: MipmapMode,
-    localMatrix?: Matrix
+    localMatrix?: IMatrix
   ): IShader;
 
   /**
@@ -61,7 +61,7 @@ export interface IImage extends SkJSIInstance<"Image"> {
     ty: TileMode,
     B: number,
     C: number,
-    localMatrix?: Matrix
+    localMatrix?: IMatrix
   ): IShader;
 
   /** Encodes Image pixels, returning result as UInt8Array. Returns existing

--- a/package/src/skia/Matrix.ts
+++ b/package/src/skia/Matrix.ts
@@ -1,5 +1,3 @@
-import type { SkJSIInstance } from "./JsiInstance";
-
 export enum MatrixIndex {
   ScaleX = 0,
   SkewX = 1,
@@ -12,31 +10,14 @@ export enum MatrixIndex {
   persp2 = 8,
 }
 
-export interface Matrix extends SkJSIInstance<"Matrix"> {
-  set(i: number, v: number): void;
-  get(i: number): number;
-
-  setScaleX(sx: number): void;
-  getScaleX(): number;
-
-  setScaleY(sy: number): void;
-  getScaleY(): number;
-
-  setSkewX(sx: number): void;
-  getSkewX(): number;
-
-  setSkewY(sy: number): void;
-  getSkewY(): number;
-
-  setTranslateX(tx: number): void;
-  getTranslateX(): number;
-
-  setTranslateY(ty: number): void;
-  getTranslateY(): number;
-
-  setPerspX(px: number): void;
-  getPerspX(): number;
-
-  setPerspY(px: number): void;
-  getPerspY(): number;
+export interface IMatrix {
+  0: number;
+  1: number;
+  2: number;
+  3: number;
+  4: number;
+  5: number;
+  6: number;
+  7: number;
+  8: number;
 }

--- a/package/src/skia/Path/Path.ts
+++ b/package/src/skia/Path/Path.ts
@@ -3,7 +3,7 @@ import type { IRect } from "../Rect";
 import type { IPoint } from "../Point";
 import type { IRRect } from "../RRect";
 import type { StrokeJoin, StrokeCap } from "../Paint";
-import type { Matrix } from "../Matrix";
+import type { IMatrix } from "../Matrix";
 import type { SkJSIInstance } from "../JsiInstance";
 
 /**
@@ -498,7 +498,7 @@ export interface IPath extends SkJSIInstance<"Path"> {
   /**
    * Transforms the path by the specified matrix.
    */
-  transform(m3: Matrix): void;
+  transform(m3: IMatrix): void;
 
   /**
    * Converts the text to a path with the given font at location x / y.

--- a/package/src/skia/RuntimeEffect/RuntimeEffect.ts
+++ b/package/src/skia/RuntimeEffect/RuntimeEffect.ts
@@ -1,6 +1,6 @@
 import type { IShader } from "../Shader";
 import type { SkJSIInstance } from "../JsiInstance";
-import type { Matrix } from "../Matrix";
+import type { IMatrix } from "../Matrix";
 
 export interface SkSLUniform {
   columns: number;
@@ -20,7 +20,7 @@ export interface IRuntimeEffect extends SkJSIInstance<"RuntimeEffect"> {
   makeShader(
     uniforms: number[],
     isOpaque?: boolean,
-    localMatrix?: Matrix
+    localMatrix?: IMatrix
   ): IShader;
 
   /**
@@ -34,7 +34,7 @@ export interface IRuntimeEffect extends SkJSIInstance<"RuntimeEffect"> {
     uniforms: number[],
     isOpaque?: boolean,
     children?: IShader[],
-    localMatrix?: Matrix
+    localMatrix?: IMatrix
   ): IShader;
 
   /**

--- a/package/src/skia/Shader/ShaderFactory.ts
+++ b/package/src/skia/Shader/ShaderFactory.ts
@@ -1,6 +1,6 @@
 import type { TileMode } from "../ImageFilter";
 import type { IPoint } from "../Point";
-import type { Matrix } from "../Matrix";
+import type { IMatrix } from "../Matrix";
 import type { Color } from "../Color";
 import type { BlendMode } from "../Paint/BlendMode";
 
@@ -28,7 +28,7 @@ export interface ShaderFactory {
     colors: Color[],
     pos: number[] | null,
     mode: TileMode,
-    localMatrix?: Matrix,
+    localMatrix?: IMatrix,
     flags?: number
     // colorSpace: ColorSpace
   ): IShader;
@@ -51,7 +51,7 @@ export interface ShaderFactory {
     colors: Color[],
     pos: number[] | null,
     mode: TileMode,
-    localMatrix?: Matrix,
+    localMatrix?: IMatrix,
     flags?: number
     // colorSpace?: ColorSpace
   ): IShader;
@@ -77,7 +77,7 @@ export interface ShaderFactory {
     colors: Color[],
     pos: number[] | null,
     mode: TileMode,
-    localMatrix?: Matrix,
+    localMatrix?: IMatrix,
     flags?: number
     //  colorSpace?: ColorSpace
   ): IShader;
@@ -102,7 +102,7 @@ export interface ShaderFactory {
     colors: Color[],
     pos: number[] | null,
     mode: TileMode,
-    localMatrix?: Matrix | null,
+    localMatrix?: IMatrix | null,
     flags?: number,
     startAngleInDegrees?: number,
     endAngleInDegrees?: number

--- a/package/src/skia/Skia.ts
+++ b/package/src/skia/Skia.ts
@@ -12,7 +12,7 @@ import type { IRRect } from "./RRect";
 import type { RuntimeEffectFactory } from "./RuntimeEffect";
 import type { ShaderFactory } from "./Shader";
 import { Color } from "./Color";
-import type { Matrix } from "./Matrix";
+import type { IMatrix } from "./Matrix";
 import type { PathEffectFactory } from "./PathEffect";
 import type { IPoint } from "./Point";
 import type { Vertices, VertexMode } from "./Vertices/Vertices";
@@ -31,7 +31,7 @@ export interface Skia {
   RRectXY: (rect: IRect, rx: number, ry: number) => IRRect;
   Paint: () => IPaint;
   Path: PathFactory;
-  Matrix: () => Matrix;
+  Matrix: () => IMatrix;
   ColorFilter: ColorFilterFactory;
   Font: (typeface?: Typeface, size?: number) => Font;
   Typeface: TypefaceFactory;


### PR DESCRIPTION
The goal of this PR is a slight improvement of the Matrix3 API:
* No more need to invoke `skiaMatrix3`
* Add support for supplying the matrix directly in the transform properties
* Add direct constructor of the matrix via j`siskmatrix::fromValue`