### PR TITLE
Implement Masking

### DIFF
--- a/example/src/Examples/API/Clipping2.tsx
+++ b/example/src/Examples/API/Clipping2.tsx
@@ -6,6 +6,12 @@ import {
   Canvas,
   Image,
   Group,
+  Circle,
+  Paint,
+  LumaColorFilter,
+  LinearGradient,
+  vec,
+  Rect,
 } from "@shopify/react-native-skia";
 import { useImage } from "@shopify/react-native-skia/src/skia/Image/useImage";
 
@@ -70,6 +76,22 @@ export const Clipping = () => {
             height={SIZE}
             fit="cover"
           />
+        </Group>
+      </Canvas>
+      <Canvas style={{ width, height: 200 }}>
+        <Group>
+          <Paint>
+            <LumaColorFilter />
+            <LinearGradient
+              start={vec(0, 0)}
+              end={vec(200, 200)}
+              colors={["white", "#ffffff00"]}
+            />
+          </Paint>
+          <Circle cx={100} cy={100} r={100} />
+        </Group>
+        <Group blendMode="srcIn">
+          <Rect x={0} y={0} width={200} height={200} color="red" />
         </Group>
       </Canvas>
     </ScrollView>

--- a/example/src/Examples/API/List.tsx
+++ b/example/src/Examples/API/List.tsx
@@ -16,7 +16,7 @@ const examples = [
   },
   {
     screen: "Clipping",
-    title: "✂️ Clipping",
+    title: "✂️ & 🎭 Clipping & Masking",
   },
   {
     screen: "PathEffect",

--- a/package/cpp/api/JsiSkColorFilterFactory.h
+++ b/package/cpp/api/JsiSkColorFilterFactory.h
@@ -8,6 +8,7 @@
 #pragma clang diagnostic ignored "-Wdocumentation"
 
 #include <SkColorFilter.h>
+#include <SkLumaColorFilter.h>
 
 #pragma clang diagnostic pop
 
@@ -59,12 +60,12 @@ public:
                      getContext(), SkColorFilters::Lerp(t, dst, src)));
   }
 
-  JSI_HOST_FUNCTION(MakeSRGBToLinearGamma) {
-    // Return the newly constructed object
-    return jsi::Object::createFromHostObject(
-        runtime, std::make_shared<JsiSkColorFilter>(
-                     getContext(), SkColorFilters::SRGBToLinearGamma()));
-  }
+    JSI_HOST_FUNCTION(MakeSRGBToLinearGamma) {
+      // Return the newly constructed object
+      return jsi::Object::createFromHostObject(
+              runtime, std::make_shared<JsiSkColorFilter>(
+                      getContext(), SkColorFilters::SRGBToLinearGamma()));
+    }
 
   JSI_HOST_FUNCTION(MakeLinearToSRGBGamma) {
     // Return the newly constructed object
@@ -73,14 +74,22 @@ public:
                      getContext(), SkColorFilters::LinearToSRGBGamma()));
   }
 
-  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkColorFilterFactory, MakeMatrix),
-                       JSI_EXPORT_FUNC(JsiSkColorFilterFactory, MakeBlend),
-                       JSI_EXPORT_FUNC(JsiSkColorFilterFactory, MakeCompose),
-                       JSI_EXPORT_FUNC(JsiSkColorFilterFactory, MakeLerp),
-                       JSI_EXPORT_FUNC(JsiSkColorFilterFactory,
-                                       MakeSRGBToLinearGamma),
-                       JSI_EXPORT_FUNC(JsiSkColorFilterFactory,
-                                       MakeLinearToSRGBGamma))
+  JSI_HOST_FUNCTION(MakeLumaColorFilter) {
+    // Return the newly constructed object
+    return jsi::Object::createFromHostObject(
+        runtime, std::make_shared<JsiSkColorFilter>(
+                     getContext(), SkLumaColorFilter::Make()));
+  }
+
+  JSI_EXPORT_FUNCTIONS(
+    JSI_EXPORT_FUNC(JsiSkColorFilterFactory, MakeMatrix),
+    JSI_EXPORT_FUNC(JsiSkColorFilterFactory, MakeBlend),
+    JSI_EXPORT_FUNC(JsiSkColorFilterFactory, MakeCompose),
+    JSI_EXPORT_FUNC(JsiSkColorFilterFactory, MakeLerp),
+    JSI_EXPORT_FUNC(JsiSkColorFilterFactory, MakeSRGBToLinearGamma),
+    JSI_EXPORT_FUNC(JsiSkColorFilterFactory, MakeLinearToSRGBGamma),
+    JSI_EXPORT_FUNC(JsiSkColorFilterFactory, MakeLumaColorFilter)
+  )
 
   JsiSkColorFilterFactory(std::shared_ptr<RNSkPlatformContext> context)
       : JsiSkHostObject(context) {}

--- a/package/src/renderer/components/colorFilters/Compose.ts
+++ b/package/src/renderer/components/colorFilters/Compose.ts
@@ -1,9 +1,9 @@
-import type { IColorFilter } from "../../../skia";
+import type { SkColorFilter } from "../../../skia";
 import { isColorFilter, isImageFilter, Skia } from "../../../skia";
 import type { DeclarationResult } from "../../nodes";
 
 export const composeColorFilter = (
-  cf: IColorFilter,
+  cf: SkColorFilter,
   children: DeclarationResult[]
 ) => {
   const [col] = children.filter(isColorFilter);

--- a/package/src/renderer/components/colorFilters/LumaColorFilter.tsx
+++ b/package/src/renderer/components/colorFilters/LumaColorFilter.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import { Skia } from "../../../skia";
+import { useDeclaration } from "../../nodes/Declaration";
+import type { AnimatedProps } from "../../processors/Animations/Animations";
+
+import { composeColorFilter } from "./Compose";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface LumaColorFilterProps {}
+
+export const LumaColorFilter = (props: AnimatedProps<LumaColorFilterProps>) => {
+  const declaration = useDeclaration(props, (_props, children) => {
+    const cf = Skia.ColorFilter.MakeLumaColorFilter();
+    return composeColorFilter(cf, children);
+  });
+  return <skDeclaration declaration={declaration} {...props} />;
+};

--- a/package/src/renderer/components/colorFilters/index.ts
+++ b/package/src/renderer/components/colorFilters/index.ts
@@ -3,3 +3,4 @@ export * from "./Blend";
 export * from "./Lerp";
 export * from "./LinearToSRGBGamma";
 export * from "./SRGBToLinearGamma";
+export * from "./LumaColorFilter";

--- a/package/src/skia/ColorFilter/ColorFilter.ts
+++ b/package/src/skia/ColorFilter/ColorFilter.ts
@@ -2,6 +2,6 @@ import type { SkJSIInstance } from "../JsiInstance";
 
 export const isColorFilter = (
   obj: SkJSIInstance<string> | null
-): obj is IColorFilter => obj !== null && obj.__typename__ === "ColorFilter";
+): obj is SkColorFilter => obj !== null && obj.__typename__ === "ColorFilter";
 
-export type IColorFilter = SkJSIInstance<"ColorFilter">;
+export type SkColorFilter = SkJSIInstance<"ColorFilter">;

--- a/package/src/skia/ColorFilter/ColorFilterFactory.ts
+++ b/package/src/skia/ColorFilter/ColorFilterFactory.ts
@@ -1,7 +1,7 @@
 import type { SkColor } from "../Color";
 import type { BlendMode } from "../Paint/BlendMode";
 
-import type { IColorFilter } from "./ColorFilter";
+import type { SkColorFilter } from "./ColorFilter";
 
 export type InputColorMatrix = number[];
 
@@ -10,21 +10,21 @@ export interface ColorFilterFactory {
    * Creates a color filter using the provided color matrix.
    * @param cMatrix
    */
-  MakeMatrix(cMatrix: InputColorMatrix): IColorFilter;
+  MakeMatrix(cMatrix: InputColorMatrix): SkColorFilter;
 
   /**
    * Makes a color filter with the given color and blend mode.
    * @param color
    * @param mode
    */
-  MakeBlend(color: SkColor, mode: BlendMode): IColorFilter;
+  MakeBlend(color: SkColor, mode: BlendMode): SkColorFilter;
 
   /**
    * Makes a color filter composing two color filters.
    * @param outer
    * @param inner
    */
-  MakeCompose(outer: IColorFilter, inner: IColorFilter): IColorFilter;
+  MakeCompose(outer: SkColorFilter, inner: SkColorFilter): SkColorFilter;
 
   /**
    * Makes a color filter that is linearly interpolated between two other color filters.
@@ -32,15 +32,21 @@ export interface ColorFilterFactory {
    * @param dst
    * @param src
    */
-  MakeLerp(t: number, dst: IColorFilter, src: IColorFilter): IColorFilter;
+  MakeLerp(t: number, dst: SkColorFilter, src: SkColorFilter): SkColorFilter;
 
   /**
    * Makes a color filter that converts between linear colors and sRGB colors.
    */
-  MakeLinearToSRGBGamma(): IColorFilter;
+  MakeLinearToSRGBGamma(): SkColorFilter;
 
   /**
    * Makes a color filter that converts between sRGB colors and linear colors.
    */
-  MakeSRGBToLinearGamma(): IColorFilter;
+  MakeSRGBToLinearGamma(): SkColorFilter;
+
+  /**
+   * Makes a color filter that multiplies the luma of its input into the alpha channel,
+   * and sets the red, green, and blue channels to zero.
+   */
+  MakeLumaColorFilter(): SkColorFilter;
 }

--- a/package/src/skia/ImageFilter/ImageFilterFactory.ts
+++ b/package/src/skia/ImageFilter/ImageFilterFactory.ts
@@ -1,5 +1,5 @@
 import type { SkColor } from "../Color";
-import type { IColorFilter } from "../ColorFilter/ColorFilter";
+import type { SkColorFilter } from "../ColorFilter/ColorFilter";
 import type { IShader } from "../Shader/Shader";
 
 import type { SkImageFilter, TileMode } from "./ImageFilter";
@@ -68,7 +68,10 @@ export interface ImageFilterFactory {
    * @param cf
    * @param input - if null, it will use the dynamic source image (e.g. a saved layer)
    */
-  MakeColorFilter(cf: IColorFilter, input: SkImageFilter | null): SkImageFilter;
+  MakeColorFilter(
+    cf: SkColorFilter,
+    input: SkImageFilter | null
+  ): SkImageFilter;
 
   /**
    * Create a filter that composes 'inner' with 'outer', such that the results of 'inner' are

--- a/package/src/skia/Paint/Paint.ts
+++ b/package/src/skia/Paint/Paint.ts
@@ -1,6 +1,6 @@
 import type { SkImageFilter } from "../ImageFilter";
 import type { IMaskFilter } from "../MaskFilter";
-import type { IColorFilter } from "../ColorFilter";
+import type { SkColorFilter } from "../ColorFilter";
 import type { IShader } from "../Shader";
 import type { SkColor } from "../Color";
 import type { IPathEffect } from "../PathEffect";
@@ -95,7 +95,7 @@ export interface SkPaint extends SkJSIInstance<"Paint"> {
    * Sets the current color filter, replacing the existing one if there was one.
    * @param filter
    */
-  setColorFilter(filter: IColorFilter | null): void;
+  setColorFilter(filter: SkColorFilter | null): void;
 
   /**
    * Sets the current image filter, replacing the existing one if there was one.


### PR DESCRIPTION
The recipe was taken from the SVG implementation:
https://github.com/google/skia/blob/main/modules/svg/src/SkSVGRenderContext.cpp#L349
https://github.com/google/skia/blob/main/modules/svg/src/SkSVGMask.cpp

My impression so is that masks are not really useful in Skia.
* In SVG they can be useful sometimes. For instance you implement things like a two colors angular gradient with a mask. But in Skia you would have the capabilities to do it with shaders and other means.
* In Figma, mask are used for clipping, but in 99% of use-cases, what you want to do is clipping. In fact in the mask documentation of Figma, most of the use-cases presented are clipping, while the masking example is quite marginal.
* In this article: https://css-tricks.com/clipping-masking-css/, the masking use-cases feel a bit marginal and Skia would have other means to implement them.

However, because they can be so present in SVG, it feel important to have a way to provide the matching feature.
 
* [ ] Factorize into single component
* [ ] Document
* [ ] Offer different mask type? (SVG & Figma have opposite pixel visibility)