### PR TITLE
Fixes for `useDerivedValue`

### DIFF
--- a/package/src/values/hooks/useDerivedValue.ts
+++ b/package/src/values/hooks/useDerivedValue.ts
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 
 import type { SkiaReadonlyValue } from "../types";
 import { ValueApi } from "../api";
-import { useValue } from "./useValue";
 
 type CreateDerivedvalue = typeof ValueApi.createDerivedValue;
 
@@ -19,3 +18,4 @@ export const useDerivedValue: CreateDerivedvalue = <R, A extends Array<unknown> 
 ): SkiaReadonlyValue<R> => {
   return useMemo(() => ValueApi.createDerivedValue(cb, values), values);
 };
+ 


### PR DESCRIPTION
There are 2 issues with `useDerivedValue`, as I see it:

1. The use of `useMemo` is incorrect. 
 
`useMemo`'s dependencies include the `callback`, and the `values` array. Both of these get recreated on each render, causing `useMemo` to do nothing. In this PR, I replaced the `useMemo` dependency array with the `values` array directly (assuming this is the desire).

2. There is currently no typesafety for the dependencies you pass in the `values` array.

I fixed that by inferring the `Args`. Here is a video of what it looks like after my changes with proper typesafety:

https://www.loom.com/share/ec227a15f3f9450f873e2c7e5ec61b14