### PR TITLE
💄update default tile mode for backdrop filter

### DIFF
--- a/package/src/renderer/components/backdrop/BackdropBlur.tsx
+++ b/package/src/renderer/components/backdrop/BackdropBlur.tsx
@@ -16,7 +16,7 @@ export const BackdropBlur = ({
   ...props
 }: AnimatedProps<BackdropBlurProps>) => {
   return (
-    <BackdropFilter filter={<Blur blur={blur} />} {...props}>
+    <BackdropFilter filter={<Blur blur={blur} mode="clamp" />} {...props}>
       {children}
     </BackdropFilter>
   );


### PR DESCRIPTION
While "decal" is the expected default when blurring (an image for instance), "clamp" is always used for backdrop filters.
This came up in https://github.com/Shopify/react-native-skia/discussions/226 which yield "strange" results.