### PR TITLE
Fixed unlocking when an error occurs in the js drawing code.

### DIFF
--- a/package/cpp/rnskia/RNSkDrawView.cpp
+++ b/package/cpp/rnskia/RNSkDrawView.cpp
@@ -204,8 +204,14 @@ void RNSkDrawView::performDraw() {
   milliseconds ms = duration_cast<milliseconds>(
           system_clock::now().time_since_epoch());
   
-  // Perform the javascript drawing
-  drawInCanvas(_jsiCanvas, getWidth(), getHeight(), ms.count() / 1000.0);
+  try {
+    // Perform the javascript drawing
+    drawInCanvas(_jsiCanvas, getWidth(), getHeight(), ms.count() / 1000.0);
+  } catch(...) {
+    _jsTimingInfo.stopTiming();
+    _jsDrawingLock->unlock();
+    throw;
+  }
   
   // Finish drawing operations
   auto p = recorder.finishRecordingAsPicture();


### PR DESCRIPTION
When an exception occurs in the javascript rendering code, we are not catching it in the C++ code, meaning that any drawing locks being held will not be released. This PR fixes this by catching any error, unlocking and then throwing again so the error will be visible to the user.

closes #302 