### PR TITLE
Added fix to make sure the python command is valid

### DIFF
--- a/externals/bin/python
+++ b/externals/bin/python
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/python3 "$@"


### PR DESCRIPTION
On MacOS 12.3 Python2 was deprecated and removed. We now only have Python3 to use.

When building with ninja the Skia build system is setup to use python a lot of places through shebangs like ` #!/usr/bin/env python`.

This doesn't work anymore, and this PR has added a few fixes to avoid this issue on newer machines:

- Updated call to git-sync-deps to use python3
- Added bash script mapping python -> python3
- Added this bash script to path
- Added --script-executable argument to gn gen to make sure it uses python3 as its script interpreter.

Fixes #329 