### PR TITLE
cache default font manager in canvas

### DIFF
--- a/package/src/renderer/Canvas.tsx
+++ b/package/src/renderer/Canvas.tsx
@@ -89,6 +89,8 @@ export interface CanvasProps extends ComponentProps<typeof SkiaView> {
   fontMgr?: FontMgr;
 }
 
+const defaultFontMgr = Skia.FontMgr.RefDefault();
+
 export const Canvas = forwardRef<SkiaView, CanvasProps>(
   ({ children, style, debug, mode, onTouch, fontMgr }, forwardedRef) => {
     const innerRef = useCanvasRef();
@@ -136,7 +138,7 @@ export const Canvas = forwardRef<SkiaView, CanvasProps>(
           opacity: 1,
           ref,
           center: vec(width / 2, height / 2),
-          fontMgr: fontMgr ?? Skia.FontMgr.RefDefault(),
+          fontMgr: fontMgr ?? defaultFontMgr,
         };
         canvasCtx.current = ctx;
         container.draw(ctx);


### PR DESCRIPTION
`Skia.FontMgr.RefDefault()` creates a new JSI host object everytime it is called.
By caching the default font manager, Canvas avoids creation of this wrapper object upon every render.