### PR TITLE
Fixed regression on Androd after merging std::move branch

### DIFF
--- a/package/cpp/api/JsiSkSVGFactory.h
+++ b/package/cpp/api/JsiSkSVGFactory.h
@@ -13,7 +13,6 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
 
-#include <SkSVGDOM.h>
 #include <SkStream.h>
 
 #pragma clang diagnostic pop


### PR DESCRIPTION
After merging native fix for move semantics (#340) we got a small regression on Android which is fixed by this build.

The failure was that Android was not building due to a missing include file.