### PR TITLE
Fix example app android build fail in Linux

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -129,6 +129,7 @@ def reactNativeArchitectures() {
 }
 
 android {
+
      packagingOptions {
         pickFirst "lib/**/libfbjni.so"
         pickFirst "lib/**/libjsi.so"


### PR DESCRIPTION
# Complete installation instruction for react native new architecture for Android on Linux

For running the example app without building rn-skia locally, change the ` "@shopify/react-native-skia": "link:../package/` in package.json to ` "@shopify/react-native-skia": "^0.1.118"` or to any latest version.

After installing the package for fresh project and upon first build we get the below error:

```
Execution failed for task ':shopify_react-native-skia:configureCMakeDebug'.
> C/C++: /home/niraj/Documents/react-native-skia/package/android/CMakeLists.txt debug|armeabi-v7a : CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
  Please set them or make sure they are set and tested correctly in the CMake files:
  FBJNI_LIBRARY
      linked by target "reactskia" in directory /home/niraj/Documents/react-native-skia/package/android
  JSI_LIB
      linked by target "reactskia" in directory /home/niraj/Documents/react-native-skia/package/android
  REACT_LIB
      linked by target "reactskia" in directory /home/niraj/Documents/react-native-skia/package/android
  TURBOMODULES_LIB
      linked by target "reactskia" in directory /home/niraj/Documents/react-native-skia/package/android

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

```

Fix: Go to project structure -> Modules -> Select shopify_react_native -> Select NDK Dropdown and choose one (21.4.7075529) and apply the changes as suggested in the documentation in homepage. Clean the project and run again. (I found out that you need to run from Android Studio instead of rn-cli here and if you get same error re-running again will make this error go away)

The next error show below that we get seems to be weird and random. Just re-building the app will make it go away.

```
Build command failed.
Error while executing process /home/niraj/Android/Sdk/cmake/3.10.2.4988404/bin/ninja with arguments {-C /home/niraj/Documents/react-native-skia/example/node_modules/@shopify/react-native-skia/android/.cxx/Debug/5i13315m/x86 reactskia}
ninja: Entering directory `/home/niraj/Documents/react-native-skia/example/node_modules/@shopify/react-native-skia/android/.cxx/Debug/5i13315m/x86'

ninja: error: '../../../../build/fbjni-0.2.2.aar/jni/x86/libfbjni.so', needed by '../../../../build/intermediates/cxx/Debug/5i13315m/obj/x86/libreactskia.so', missing and no known rule to make it

```

After this fix we get another error:

```
2 files found with path 'lib/x86/libfbjni.so' from inputs:
 - /home/niraj/Documents/react-native-skia/example/node_modules/@shopify/react-native-skia/android/build/intermediates/library_jni/debug/jni/x86/libfbjni.so
 - /home/niraj/.gradle/caches/transforms-3/c8cd7762549206b8f00b1019bb506472/transformed/jetified-react-native-0.68.0/jni/x86/libfbjni.so
If you are using jniLibs and CMake IMPORTED targets, see
https://developer.android.com/r/tools/jniLibs-vs-imported-targets

```

After doing some digging I found [this](https://issuetracker.google.com/issues/157901344#comment4) issue tracker that suggested this fix. So go to `/android/app/build.gradle` and add the following lines:

```
android {
     packagingOptions {
        pickFirst "lib/**/libfbjni.so"
    }
    ...
}
```

You will get same error for next 3 files `libjsi.so`, `libreact_nativemodule_core.so`, `libturbomodulejsijni`. So add those as well. Final code would be:

```
android {
     packagingOptions {
        pickFirst "lib/**/libfbjni.so"
        pickFirst "lib/**/libjsi.so"
        pickFirst "lib/**/libreact_nativemodule_core.so"
        pickFirst "lib/**/libturbomodulejsijni.so"
    }
    ...
}
```

Now the app builds and runs successfully 🚀.
