### PR TITLE
Fix renders pile on top of each other on iOS

### DIFF
--- a/package/ios/RNSkia-iOS/RNSkDrawViewImpl.h
+++ b/package/ios/RNSkia-iOS/RNSkDrawViewImpl.h
@@ -18,14 +18,13 @@
 
 #pragma clang diagnostic pop
 
-@class SkiaDrawView;
-
 class RNSkDrawViewImpl : public RNSkia::RNSkDrawView {
 public:
-  RNSkDrawViewImpl(SkiaDrawView *view,
-                   std::shared_ptr<RNSkia::RNSkPlatformContext> context);
+  RNSkDrawViewImpl(std::shared_ptr<RNSkia::RNSkPlatformContext> context);
   
   void setSize(int width, int height);
+  
+  CALayer* getLayer() { return _layer; };
 
 protected:
   int getWidth() override { return _width * _context->getPixelDensity(); };
@@ -41,8 +40,6 @@ private:
   int _nativeId;
   int _width = -1;
   int _height = -1;
-
-  SkiaDrawView *_view;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"

--- a/package/ios/RNSkia-iOS/RNSkDrawViewImpl.mm
+++ b/package/ios/RNSkia-iOS/RNSkDrawViewImpl.mm
@@ -17,8 +17,8 @@ id<MTLCommandQueue> RNSkDrawViewImpl::_commandQueue = id<MTLCommandQueue>(CFReta
 
 sk_sp<GrDirectContext> RNSkDrawViewImpl::_skContext = nullptr;
 
-RNSkDrawViewImpl::RNSkDrawViewImpl(SkiaDrawView* view, std::shared_ptr<RNSkia::RNSkPlatformContext> context):
-  _view(view), _context(context), RNSkia::RNSkDrawView(context) {
+RNSkDrawViewImpl::RNSkDrawViewImpl(std::shared_ptr<RNSkia::RNSkPlatformContext> context):
+  _context(context), RNSkia::RNSkDrawView(context) {
     
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
@@ -30,8 +30,6 @@ RNSkDrawViewImpl::RNSkDrawViewImpl(SkiaDrawView* view, std::shared_ptr<RNSkia::R
     _layer.opaque = false;
     _layer.contentsScale = _context->getPixelDensity();
     _layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-    _layer.frame = _view.bounds;
-    [_view.layer addSublayer:_layer];
     
     setNativeDrawFunc(std::bind(&RNSkDrawViewImpl::drawFrame, this, std::placeholders::_1));
 }

--- a/package/ios/RNSkia-iOS/SkiaDrawView.mm
+++ b/package/ios/RNSkia-iOS/SkiaDrawView.mm
@@ -56,13 +56,14 @@
       if(_nativeId != 0 && _manager != nullptr) {
         _manager->setSkiaDrawView(_nativeId, nullptr);
       }
+      [_impl->getLayer() removeFromSuperlayer];
       _impl = nullptr;
     }
   } else {
     // Create implementation view when the parent view is set
     if(_impl == nullptr && _manager != nullptr) {
-      __weak decltype(self) weakSelf = self;
-      _impl = std::make_shared<RNSkDrawViewImpl>(weakSelf, _manager->getPlatformContext());
+      _impl = std::make_shared<RNSkDrawViewImpl>(_manager->getPlatformContext());
+      [self.layer addSublayer:_impl->getLayer()];
       if(_nativeId != 0) {
         _manager->setSkiaDrawView(_nativeId, _impl.get());
       }


### PR DESCRIPTION
The error was visible when using React Navigation and going back/forth between screens.

The fix was to make sure the layer of the UIView was removed correctly when unmounting the Skia view on iOS.

This is tested with the code snippet below on Android / iOS.

fixes #333 
fixes #183 