### PR TITLE
fix: Add `length` getter property and remove `countPoints()` function

### DIFF
--- a/example/src/Examples/Graphs/Slider.tsx
+++ b/example/src/Examples/Graphs/Slider.tsx
@@ -95,7 +95,7 @@ const getPointAtPositionInPath = (
   const index = Math.max(0, Math.floor(x / (width / steps)));
   const fraction = (x / (width / steps)) % 1;
   const p1 = path.getPoint(index);
-  if (index < path.countPoints() - 1) {
+  if (index < path.length - 1) {
     const p2 = path.getPoint(index + 1);
     // Interpolate between p1 and p2
     return {

--- a/package/cpp/api/JsiSkPath.h
+++ b/package/cpp/api/JsiSkPath.h
@@ -32,12 +32,12 @@ using namespace facebook;
 class JsiSkPath : public JsiSkWrappingSharedPtrHostObject<SkPath> {
 public:
 
-    // TODO: declare in JsiSkWrappingSkPtrHostObject via extra template parameter?
-    JSI_PROPERTY_GET(__typename__) {
-      return jsi::String::createFromUtf8(runtime, "Path");
-    }
+  // TODO: declare in JsiSkWrappingSkPtrHostObject via extra template parameter?
+  JSI_PROPERTY_GET(__typename__) {
+    return jsi::String::createFromUtf8(runtime, "Path");
+  }
 
-    JSI_HOST_FUNCTION(addArc) {
+  JSI_HOST_FUNCTION(addArc) {
     auto rect = JsiSkRect::fromValue(runtime, arguments[0]).get();
     auto start = arguments[1].asNumber();
     auto sweep = arguments[2].asNumber();
@@ -435,7 +435,7 @@ public:
     return jsi::Value(false);
   }
 
-  JSI_HOST_FUNCTION(countPoints) {
+  JSI_PROPERTY_GET(length) {
     auto points = getObject()->countPoints();
     return jsi::Value(points);
   }

--- a/package/cpp/api/JsiSkPath.h
+++ b/package/cpp/api/JsiSkPath.h
@@ -484,7 +484,10 @@ public:
             runtime, std::make_shared<JsiSkPath>(getContext(), std::move(result)));
   }
 
-  JSI_EXPORT_PROPERTY_GETTERS(JSI_EXPORT_PROP_GET(JsiSkPath, __typename__))
+  JSI_EXPORT_PROPERTY_GETTERS(
+    JSI_EXPORT_PROP_GET(JsiSkPath, __typename__),
+    JSI_EXPORT_PROP_GET(JsiSkPath, length)
+  )
 
   JSI_EXPORT_FUNCTIONS(
     JSI_EXPORT_FUNC(JsiSkPath, addArc), JSI_EXPORT_FUNC(JsiSkPath, addOval),
@@ -516,7 +519,7 @@ public:
     JSI_EXPORT_FUNC(JsiSkPath, addCircle),
     JSI_EXPORT_FUNC(JsiSkPath, getLastPt), JSI_EXPORT_FUNC(JsiSkPath, close),
     JSI_EXPORT_FUNC(JsiSkPath, simplify),
-    JSI_EXPORT_FUNC(JsiSkPath, countPoints), JSI_EXPORT_FUNC(JsiSkPath, copy),
+    JSI_EXPORT_FUNC(JsiSkPath, copy),
     JSI_EXPORT_FUNC(JsiSkPath, fromText), JSI_EXPORT_FUNC(JsiSkPath, op),
     JSI_EXPORT_FUNC(JsiSkPath, isInterpolatable), JSI_EXPORT_FUNC(JsiSkPath, interpolate)
   )

--- a/package/src/skia/Path/Path.ts
+++ b/package/src/skia/Path/Path.ts
@@ -72,7 +72,7 @@ export interface SkPath extends SkJSIInstance<"Path"> {
   /**
    * Returns the number of points in this path. Initially zero.
    */
-  countPoints(): number;
+  length: number;
 
   /**
    * Adds contour created from array of n points, adding (count - 1) line segments.
@@ -429,7 +429,7 @@ export interface SkPath extends SkJSIInstance<"Path"> {
 
   /**
    * Returns the Point at index in Point array. Valid range for index is
-   * 0 to countPoints() - 1.
+   * 0 to length - 1.
    * @param index
    */
   getPoint(index: number): SkPoint;
@@ -524,7 +524,7 @@ export interface SkPath extends SkJSIInstance<"Path"> {
    * @param ending  path to interpolate with
    * @param weight  contribution of this path, and
    *                 one minus contribution of ending path
-   * @return        Path replaced by interpolated averages or undefined if 
+   * @return        Path replaced by interpolated averages or undefined if
    *                not interpolatable
    * */
   interpolate(end: SkPath, weight: number): SkPath;


### PR DESCRIPTION
Seems to be more semantically correct in my opinion.

## Before

```ts
for (let i = 0; i < path.countPoints(); i++) {
  // do stuff
}
```
## After

```ts
for (let i = 0; i < path.length; i++) {
  // do stuff
}
```