### PR TITLE
docs: fix offset filter svg counterpart url

### DIFF
--- a/docs/docs/image-filters/offset.md
+++ b/docs/docs/image-filters/offset.md
@@ -5,7 +5,7 @@ sidebar_label: Offset
 slug: /image-filters/offset
 ---
 
-This offset filter is identical to its [SVG counterpart](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDisplacementMap). It allows offsetting the filtered image. 
+This offset filter is identical to its [SVG counterpart](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feOffset). It allows offsetting the filtered image. 
 
 | Name      | Type           |  Description                               |
 |:----------|:---------------|:-------------------------------------------|


### PR DESCRIPTION
Clicking the `SVG Counterpart` of Offset filter redirects to [feDisplacementMap](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDisplacementMap). This fixes it.