### PR TITLE
Fixed tearing down the RNSkDrawView when bridge is teared down.

### DIFF
--- a/package/ios/RNSkia-iOS/SkiaDrawView.mm
+++ b/package/ios/RNSkia-iOS/SkiaDrawView.mm
@@ -34,10 +34,9 @@
                     object:nil
                      queue:nil
                 usingBlock:^(NSNotification *notification){
-      // Remove local variables
-      if(weakSelf != nullptr) {
-        weakSelf->_manager = nullptr;
-      }
+      // Remove local variables when the bridge is teared down.
+      weakSelf->_impl = nullptr;
+      weakSelf->_manager = nullptr;
     }];
   }
   return self;


### PR DESCRIPTION
To avoid crashing in JSC with dangling JS pointers we need to make sure we remove the RNSkDrawView on iOS when the bridge is teared down. By setting the impl to null we'll make sure the destructor is called.