### PR TITLE
All animation Config interfaces should use optional values

### DIFF
--- a/package/src/values/animation/timing/functions/getResolvedParams.ts
+++ b/package/src/values/animation/timing/functions/getResolvedParams.ts
@@ -42,8 +42,8 @@ export const getResolvedParams = (
 
   const resolvedConfig: Required<TimingConfig> = { ...DefaultTimingConfig };
   if (config) {
-    resolvedConfig.duration = config.duration;
-    resolvedConfig.easing = config.easing ?? ((t) => t);
+    resolvedConfig.duration = config.duration ?? DefaultTimingConfig.duration;
+    resolvedConfig.easing = config.easing ?? DefaultTimingConfig.easing;
   }
 
   return { ...resolvedParameters, ...resolvedConfig };

--- a/package/src/values/animation/types.ts
+++ b/package/src/values/animation/types.ts
@@ -1,12 +1,12 @@
 export interface SpringConfig {
-  mass: number;
-  stiffness: number;
-  damping: number;
-  velocity: number;
+  mass?: number;
+  stiffness?: number;
+  damping?: number;
+  velocity?: number;
 }
 
 export interface TimingConfig {
-  duration: number;
+  duration?: number;
   easing?: (t: number) => number;
 }
 


### PR DESCRIPTION
I noticed that `runSpring` wanted values for all the `SpringConfig` options, but the other animation config types supporting optional values.