### PR TITLE
fix(docs): correct BlendColor component name

### DIFF
--- a/docs/docs/color-filters.md
+++ b/docs/docs/color-filters.md
@@ -47,7 +47,7 @@ const MatrixColorFilter = () => {
 
 ![Matrix Color Filter](assets/color-filters/matrix.png)
 
-## Blend
+## BlendColor
 
 Creates a color filter with the given color and blend mode.
 


### PR DESCRIPTION
There are two components `Blend` and `BlendColor`. I believe there should be component called `BlendColor` instead of `Blend` because using `Blend` in color filter context fill cause runtime error.