### PR TITLE
Fixed regression on Android for canvas size

### DIFF
--- a/package/android/cpp/rnskia-android/RNSkDrawViewImpl.cpp
+++ b/package/android/cpp/rnskia-android/RNSkDrawViewImpl.cpp
@@ -16,8 +16,8 @@ namespace RNSkia {
         _releaseSurfaceCallback(std::move(releaseSurfaceCallback)) {}
 
     void RNSkDrawViewImpl::surfaceAvailable(ANativeWindow* surface, int width, int height) {
-        _width = width;
-        _height = height;
+        _scaledWidth = width;
+        _scaledHeight = height;
 
         if (_renderer == nullptr)
         {
@@ -53,8 +53,8 @@ namespace RNSkia {
     }
 
     void RNSkDrawViewImpl::surfaceSizeChanged(int width, int height) {
-        _width = width;
-        _height = height;
+        _scaledWidth = width;
+        _scaledHeight = height;
 
         // Redraw after size change
         requestRedraw();
@@ -62,7 +62,7 @@ namespace RNSkia {
 
     void RNSkDrawViewImpl::drawPicture(const sk_sp <SkPicture> picture) {
         if(_renderer != nullptr) {
-            _renderer->run(picture, _width, _height);
+            _renderer->run(picture, _scaledWidth, _scaledHeight);
         }
     }
 }

--- a/package/android/cpp/rnskia-android/RNSkDrawViewImpl.h
+++ b/package/android/cpp/rnskia-android/RNSkDrawViewImpl.h
@@ -28,9 +28,9 @@ namespace RNSkia {
         }
 
     protected:
-        int getWidth() override { return _width * getPlatformContext()->getPixelDensity(); };
+        float getScaledWidth() override { return _scaledWidth; };
 
-        int getHeight() override { return _height * getPlatformContext()->getPixelDensity(); };
+        float getScaledHeight() override { return _scaledHeight; };
 
         void drawPicture(const sk_sp <SkPicture> picture) override;
 
@@ -40,8 +40,8 @@ namespace RNSkia {
         std::unique_ptr<SkiaOpenGLRenderer> _renderer = nullptr;
 
         int _nativeId;
-        int _width = -1;
-        int _height = -1;
+        float _scaledWidth = -1;
+        float _scaledHeight = -1;
 
         std::function<void()> _releaseSurfaceCallback;
     };

--- a/package/cpp/rnskia/RNSkDrawView.cpp
+++ b/package/cpp/rnskia/RNSkDrawView.cpp
@@ -157,7 +157,7 @@ void RNSkDrawView::drawInCanvas(std::shared_ptr<JsiSkCanvas> canvas,
 
 sk_sp<SkImage> RNSkDrawView::makeImageSnapshot(std::shared_ptr<SkRect> bounds) {
   // Assert width/height
-  auto surface = SkSurface::MakeRasterN32Premul(getWidth(), getHeight());
+  auto surface = SkSurface::MakeRasterN32Premul(getScaledWidth(), getScaledHeight());
   auto canvas = surface->getCanvas();
   auto jsiCanvas = std::make_shared<JsiSkCanvas>(_platformContext);
   jsiCanvas->setCanvas(canvas);
@@ -165,7 +165,7 @@ sk_sp<SkImage> RNSkDrawView::makeImageSnapshot(std::shared_ptr<SkRect> bounds) {
   milliseconds ms = duration_cast<milliseconds>(
       system_clock::now().time_since_epoch());
   
-  drawInCanvas(jsiCanvas, getWidth(), getHeight(), ms.count() / 1000);
+  drawInCanvas(jsiCanvas, getScaledWidth(), getScaledHeight(), ms.count() / 1000);
   
   if(bounds != nullptr) {
     SkIRect b = SkIRect::MakeXYWH(bounds->x(), bounds->y(), bounds->width(), bounds->height());
@@ -188,7 +188,7 @@ void RNSkDrawView::performDraw() {
   // move the actual drawing onto the render thread later
   SkPictureRecorder recorder;
   SkRTreeFactory factory;
-  SkCanvas* canvas = recorder.beginRecording(getWidth(), getHeight(), &factory);
+  SkCanvas* canvas = recorder.beginRecording(getScaledWidth(), getScaledHeight(), &factory);
   _jsiCanvas->setCanvas(canvas);
   
   // Get current milliseconds
@@ -197,7 +197,7 @@ void RNSkDrawView::performDraw() {
   
   try {
     // Perform the javascript drawing
-    drawInCanvas(_jsiCanvas, getWidth(), getHeight(), ms.count() / 1000.0);
+    drawInCanvas(_jsiCanvas, getScaledWidth(), getScaledHeight(), ms.count() / 1000.0);
   } catch(...) {
     _jsTimingInfo.stopTiming();
     _jsDrawingLock->unlock();

--- a/package/cpp/rnskia/RNSkDrawView.h
+++ b/package/cpp/rnskia/RNSkDrawView.h
@@ -97,12 +97,12 @@ protected:
   /**
    Returns the scaled width of the view
    */
-  virtual int getWidth() { return -1; };
+  virtual float getScaledWidth() = 0;
   
   /**
    Returns the scaled height of the view
    */
-  virtual int getHeight() { return -1; };
+  virtual float getScaledHeight() = 0;
   
   /**
    Override to render picture to GPU

--- a/package/ios/RNSkia-iOS/RNSkDrawViewImpl.h
+++ b/package/ios/RNSkia-iOS/RNSkDrawViewImpl.h
@@ -28,16 +28,16 @@ public:
   void setSize(int width, int height);
 
 protected:
-  int getWidth() override { return _width * _context->getPixelDensity(); };
-  int getHeight() override { return _height * _context->getPixelDensity(); };  
+  float getScaledWidth() override { return _width * _context->getPixelDensity(); };
+  float getScaledHeight() override { return _height * _context->getPixelDensity(); };
   
 private:
   void drawPicture(const sk_sp<SkPicture> picture) override;
   bool createSkiaSurface();
 
   int _nativeId;
-  int _width = -1;
-  int _height = -1;
+  float _width = -1;
+  float _height = -1;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"


### PR DESCRIPTION
After #435 we've seen a regression on canvas size on Android:

Android receives width/height as scaled values, while iOS gets them as normalized without scaling.

This PR clarifies this relationship by changing some names of methods to explicitly declare what these methods are doing, and also changes names to indicate what kind of values they hold.