### PR TITLE
Fixes animations stops after a while

### DIFF
--- a/package/cpp/rnskia/RNSkAnimation.h
+++ b/package/cpp/rnskia/RNSkAnimation.h
@@ -32,8 +32,6 @@ public:
     _args[1] = jsi::Value::undefined();
   }
   
-  virtual ~RNSkAnimation() {}
-  
   JSI_HOST_FUNCTION(cancel) {
     stopClock();
     return jsi::Value::undefined();

--- a/package/cpp/rnskia/RNSkValueApi.h
+++ b/package/cpp/rnskia/RNSkValueApi.h
@@ -34,8 +34,12 @@ public:
   }
   
   JSI_HOST_FUNCTION(createDerivedValue) {
-    return jsi::Object::createFromHostObject(runtime,
-      std::make_shared<RNSkDerivedValue>(_platformContext, runtime, arguments, count));
+    // Creation and initialization is done in two steps to be able to use weak references when setting
+    // up dependencies - since weak_from_this needs our instance to be a shared_ptr before calling
+    // weak_from_this().
+    auto derivedValue = std::make_shared<RNSkDerivedValue>(_platformContext, runtime, arguments, count);
+    derivedValue->initializeDependencies(runtime, arguments, count);
+    return jsi::Object::createFromHostObject(runtime, derivedValue);
   }
   
   JSI_HOST_FUNCTION(createAnimation) {

--- a/package/cpp/rnskia/values/RNSkClockValue.h
+++ b/package/cpp/rnskia/values/RNSkClockValue.h
@@ -32,7 +32,6 @@ public:
                  size_t count) : RNSkReadonlyValue(platformContext),
         _runtime(runtime),
         _identifier(identifier) {
-    
     // Start by updating to zero (start value)
     update(_runtime, static_cast<double>(0));
   }
@@ -72,6 +71,7 @@ public:
     _start += timeSinceStop;
     
     _state = RNSkClockState::Running;
+    
     getContext()->beginDrawLoop(_identifier, [weakSelf = weak_from_this()](bool invalidated){
       auto self = weakSelf.lock();
       if(self) {
@@ -135,7 +135,7 @@ protected:
   size_t _identifier;
   std::chrono::time_point<std::chrono::steady_clock> _start;
   std::chrono::time_point<std::chrono::steady_clock> _stop;
-  std::atomic<RNSkClockState> _state;
+  std::atomic<RNSkClockState> _state = { RNSkClockState::NotStarted };
 };
 
 }

--- a/package/cpp/rnskia/values/RNSkReadonlyValue.h
+++ b/package/cpp/rnskia/values/RNSkReadonlyValue.h
@@ -26,7 +26,7 @@ class RNSkReadonlyValue : public JsiSkHostObject,
 public:
   RNSkReadonlyValue(std::shared_ptr<RNSkPlatformContext> platformContext)
       : JsiSkHostObject(platformContext),
-    _propNameId(jsi::PropNameID::forUtf8(*platformContext->getJsRuntime(), "value")) {}
+    _propNameId(jsi::PropNameID::forUtf8(*platformContext->getJsRuntime(), "value")) { }
   
   virtual ~RNSkReadonlyValue() { }
 
@@ -106,6 +106,7 @@ public:
   }
   
 protected:
+  
   /**
     Notifies listeners about changes
    @param runtime Current JS Runtime

--- a/package/cpp/rnskia/values/RNSkValue.h
+++ b/package/cpp/rnskia/values/RNSkValue.h
@@ -76,11 +76,16 @@ public:
 
 private:
   void subscribe(std::shared_ptr<RNSkAnimation> animation) {
-    unsubscribe();
     if(animation != nullptr) {
       _animation = animation;
-      auto dispatch = std::bind(&RNSkValue::animationDidUpdate, this, std::placeholders::_1);
-      _unsubscribe = std::make_shared<std::function<void()>>(_animation->addListener(dispatch));
+      _unsubscribe = std::make_shared<std::function<void()>>(
+        _animation->addListener([weakSelf = weak_from_this()](jsi::Runtime &runtime) {
+        auto self = weakSelf.lock();
+        if(self) {
+          auto selfAsThis = std::dynamic_pointer_cast<RNSkValue>(self);
+          selfAsThis->animationDidUpdate(runtime);
+        }
+      }));
       // Start the animation
       _animation->startClock();
     }


### PR DESCRIPTION
Fixed default value on state in RNSkClockValue.

This was the actual reason for the animation eventually stopping - or it was not started since the initial state of the clock could potentially be wrong since a member not initialized will result in undefined behaviour.

Updated derived value to use weak references and correct initialization of listeners on dependencies.

Also updated ValueApi to use the two-step initialization of dependencies:

Creation and initialization is done in two steps to be able to use weak references when setting
up dependencies - since weak_from_this needs our instance to be a shared_ptr before calling weak_from_this().

Removed unused destructor in RNSkAnimation

Fixes #464