### PR TITLE
Fixes Crash on reload on iOS

### DIFF
--- a/package/ios/RNSkia-iOS/SkiaDrawView.mm
+++ b/package/ios/RNSkia-iOS/SkiaDrawView.mm
@@ -28,7 +28,10 @@
     _drawingMode = RNSkia::RNSkDrawingMode::Default;
     
     // Listen to notifications about module invalidation
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(willInvalidateModules) name:RCTBridgeWillInvalidateModulesNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(willInvalidateModules)
+                                                 name:RCTBridgeWillInvalidateModulesNotification
+                                               object:nil];
   }
   return self;
 }

--- a/package/ios/RNSkia-iOS/SkiaDrawView.mm
+++ b/package/ios/RNSkia-iOS/SkiaDrawView.mm
@@ -28,18 +28,14 @@
     _drawingMode = RNSkia::RNSkDrawingMode::Default;
     
     // Listen to notifications about module invalidation
-    __unsafe_unretained SkiaDrawView *weakSelf = self;
-    auto nc = [NSNotificationCenter defaultCenter];
-    [nc addObserverForName:RCTBridgeWillInvalidateModulesNotification
-                    object:nil
-                     queue:nil
-                usingBlock:^(NSNotification *notification){
-      // Remove local variables when the bridge is teared down.
-      weakSelf->_impl = nullptr;
-      weakSelf->_manager = nullptr;
-    }];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(willInvalidateModules) name:RCTBridgeWillInvalidateModulesNotification object:nil];
   }
   return self;
+}
+
+- (void) willInvalidateModules {
+  _impl = nullptr;
+  _manager = nullptr;
 }
 
 #pragma mark Lifecycle
@@ -71,8 +67,6 @@
 }
 
 - (void) dealloc {
-  auto nc = [NSNotificationCenter defaultCenter];
-  [nc removeObserver:self name:RCTBridgeWillInvalidateModulesNotification object:nil];
   if(_manager != nullptr && _nativeId != 0) {
     _manager->unregisterSkiaDrawView(_nativeId);
   }


### PR DESCRIPTION
Fixed subscription to bridge teardown message in SkiaDrawView. Also added subscription to the same notification in PlatformContext so that it can notify any listeners and invalidate.

Fixes #450 

I believe it is still possible in some circumstances to provoke the crash, but it should be happening a lot more seldom.

The reason for this crash is that objects living in the Javascript world (both Javascript primitives and RNSkia's host objects) they might not be freed correctly when the bridge is teared down - causing the exception described above. The error basically says that there were some Host objects (C++ backed Javascript objects) that wasn't freed correctly when the Javascript engine (JSC, not Hermes) was deleted.