### PR TITLE
Added package/scripts to exclude to avoid error message in tsconfig.j…

### DIFF
--- a/package/tsconfig.json
+++ b/package/tsconfig.json
@@ -28,5 +28,12 @@
     "noImplicitThis": true, /* Raise error on 'this' expressions with an implied 'any' type. */
     "alwaysStrict": true, /* Parse in strict mode and emit "use strict" for each source file. */
   },
-  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js", "lib"]
+  "exclude": [
+    "node_modules",
+    "babel.config.js",
+    "metro.config.js",
+    "jest.config.js",
+    "lib",
+    "scripts"
+  ]
 }


### PR DESCRIPTION
We're seeing an error message in VSCode in `package/tsconfig.json`. This error complains about having problems writing to the file `scripts/install-npm.js`. This is a file that is not used in the development of the package - only on installation, so this file should be excluded from `tsconfig.json` - which is what this PR does :)