### PR TITLE
fix(android): build.gradle correct node_modules path in monorepo

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -175,7 +175,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     extractJNI("com.facebook.fbjni:fbjni:0.2.2")
 
-    def rnAAR = fileTree("${rootDir}/../node_modules/react-native/android").matching({ it.include "**/**/*.aar" }).singleFile
+    def rnAAR = fileTree("${nodeModules}/react-native/android").matching({ it.include "**/**/*.aar" }).singleFile
     extractJNI(files(rnAAR))
 }
 


### PR DESCRIPTION
There is error during Android build when library is used in monorepo:

```
FAILURE: Build failed with an exception.

* Where:
Build file 'myProject/node_modules/@shopify/react-native-skia/android/build.gradle' line: 178

* What went wrong:
A problem occurred evaluating project ':shopify_react-native-skia'.
> Expected directory 'myProject/packages/suite-native/android/../node_modules/react-native/android' to contain exactly one file, however, it contains no files.
```

This PR should solve the issue.