### PR TITLE
RNWeb preps: Moved Skia types to separate file

### DIFF
--- a/package/src/skia/Skia.ts
+++ b/package/src/skia/Skia.ts
@@ -1,33 +1,8 @@
 import { Platform, processColor } from "react-native";
 
 /*global SkiaApi*/
-import type { ImageFilterFactory } from "./ImageFilter";
-import type { PathFactory } from "./Path";
-import type { ColorFilterFactory } from "./ColorFilter";
-import type { SkFont } from "./Font";
-import type { SkTypeface, TypefaceFactory } from "./Typeface";
-import type { ImageFactory } from "./Image";
-import type { MaskFilterFactory } from "./MaskFilter";
-import type { SkPaint } from "./Paint";
-import type { SkRect } from "./Rect";
-import type { SkRRect } from "./RRect";
-import type { RuntimeEffectFactory } from "./RuntimeEffect";
-import type { ShaderFactory } from "./Shader";
-import type { SkMatrix } from "./Matrix";
-import type { PathEffectFactory } from "./PathEffect";
-import type { SkPoint } from "./Point";
-import type { SkVertices, VertexMode } from "./Vertices/Vertices";
-import type { DataFactory } from "./Data";
-import type { SVGFactory } from "./SVG";
-import type { TextBlobFactory } from "./TextBlob";
-import type { FontMgrFactory } from "./FontMgr/FontMgrFactory";
-import type { SurfaceFactory } from "./Surface";
-import "./NativeSetup";
-import type { SkRSXform } from "./RSXform";
-import type { SkPath } from "./Path/Path";
-import type { SkContourMeasureIter } from "./ContourMeasure";
-import type { PictureFactory, SkPictureRecorder } from "./Picture";
-import type { Color, SkColor } from "./Color";
+import type { Color } from "./Color";
+import type { ISkiaApi } from "./types";
 
 /*
  * Parse CSS colors
@@ -68,64 +43,10 @@ const SkiaColor = (cl: Color) => {
 };
 
 /**
- * Declares the interface for the native Skia API
- */
-export interface Skia {
-  Point: (x: number, y: number) => SkPoint;
-  XYWHRect: (x: number, y: number, width: number, height: number) => SkRect;
-  RRectXY: (rect: SkRect, rx: number, ry: number) => SkRRect;
-  RSXform: (scos: number, ssin: number, tx: number, ty: number) => SkRSXform;
-  Color: (color: Color) => SkColor;
-  parseColorString: (color: string) => SkColor | undefined;
-  ContourMeasureIter: (
-    path: SkPath,
-    forceClosed: boolean,
-    resScale: number
-  ) => SkContourMeasureIter;
-  Paint: () => SkPaint;
-  PictureRecorder: () => SkPictureRecorder;
-  Picture: PictureFactory;
-  Path: PathFactory;
-  Matrix: () => SkMatrix;
-  ColorFilter: ColorFilterFactory;
-  Font: (typeface?: SkTypeface, size?: number) => SkFont;
-  Typeface: TypefaceFactory;
-  MaskFilter: MaskFilterFactory;
-  RuntimeEffect: RuntimeEffectFactory;
-  ImageFilter: ImageFilterFactory;
-  Shader: ShaderFactory;
-  PathEffect: PathEffectFactory;
-  /**
-   * Returns an Vertices based on the given positions and optional parameters.
-   * See SkVertices.h (especially the Builder) for more details.
-   * @param mode
-   * @param positions
-   * @param textureCoordinates
-   * @param colors - either a list of int colors or a flattened color array.
-   * @param indices
-   * @param isVolatile
-   */
-  MakeVertices(
-    mode: VertexMode,
-    positions: SkPoint[],
-    textureCoordinates?: SkPoint[] | null,
-    colors?: SkColor[],
-    indices?: number[] | null,
-    isVolatile?: boolean
-  ): SkVertices;
-  Data: DataFactory;
-  Image: ImageFactory;
-  SVG: SVGFactory;
-  FontMgr: FontMgrFactory;
-  TextBlob: TextBlobFactory;
-  Surface: SurfaceFactory;
-}
-
-/**
  * Declares the SkiaApi as an available object in the global scope
  */
 declare global {
-  var SkiaApi: Skia;
+  var SkiaApi: ISkiaApi;
 }
 
 /**

--- a/package/src/skia/types.ts
+++ b/package/src/skia/types.ts
@@ -1,0 +1,80 @@
+import type { SVGFactory } from "react";
+
+import type { Color, SkColor } from "./Color";
+import type { ColorFilterFactory } from "./ColorFilter";
+import type { SkContourMeasureIter } from "./ContourMeasure";
+import type { DataFactory } from "./Data";
+import type { SkFont } from "./Font";
+import type { FontMgrFactory } from "./FontMgr";
+import type { ImageFactory } from "./Image";
+import type { ImageFilterFactory } from "./ImageFilter";
+import type { MaskFilterFactory } from "./MaskFilter";
+import type { SkMatrix } from "./Matrix";
+import type { SkPaint } from "./Paint";
+import type { SkPath, PathFactory } from "./Path";
+import type { PathEffectFactory } from "./PathEffect";
+import type { SkPictureRecorder, PictureFactory } from "./Picture";
+import type { SkPoint } from "./Point";
+import type { SkRect } from "./Rect";
+import type { SkRRect } from "./RRect";
+import type { SkRSXform } from "./RSXform";
+import type { RuntimeEffectFactory } from "./RuntimeEffect";
+import type { ShaderFactory } from "./Shader";
+import type { SurfaceFactory } from "./Surface";
+import type { TextBlobFactory } from "./TextBlob";
+import type { SkTypeface, TypefaceFactory } from "./Typeface";
+import type { VertexMode, SkVertices } from "./Vertices";
+
+/**
+ * Declares the interface for the native Skia API
+ */
+export interface ISkiaApi {
+  Point: (x: number, y: number) => SkPoint;
+  XYWHRect: (x: number, y: number, width: number, height: number) => SkRect;
+  RRectXY: (rect: SkRect, rx: number, ry: number) => SkRRect;
+  RSXform: (scos: number, ssin: number, tx: number, ty: number) => SkRSXform;
+  Color: (color: Color) => SkColor;
+  parseColorString: (color: string) => SkColor | undefined;
+  ContourMeasureIter: (
+    path: SkPath,
+    forceClosed: boolean,
+    resScale: number
+  ) => SkContourMeasureIter;
+  Paint: () => SkPaint;
+  PictureRecorder: () => SkPictureRecorder;
+  Picture: PictureFactory;
+  Path: PathFactory;
+  Matrix: () => SkMatrix;
+  ColorFilter: ColorFilterFactory;
+  Font: (typeface?: SkTypeface, size?: number) => SkFont;
+  Typeface: TypefaceFactory;
+  MaskFilter: MaskFilterFactory;
+  RuntimeEffect: RuntimeEffectFactory;
+  ImageFilter: ImageFilterFactory;
+  Shader: ShaderFactory;
+  PathEffect: PathEffectFactory;
+  /**
+   * Returns an Vertices based on the given positions and optional parameters.
+   * See SkVertices.h (especially the Builder) for more details.
+   * @param mode
+   * @param positions
+   * @param textureCoordinates
+   * @param colors - either a list of int colors or a flattened color array.
+   * @param indices
+   * @param isVolatile
+   */
+  MakeVertices(
+    mode: VertexMode,
+    positions: SkPoint[],
+    textureCoordinates?: SkPoint[] | null,
+    colors?: SkColor[],
+    indices?: number[] | null,
+    isVolatile?: boolean
+  ): SkVertices;
+  Data: DataFactory;
+  Image: ImageFactory;
+  SVG: SVGFactory;
+  FontMgr: FontMgrFactory;
+  TextBlob: TextBlobFactory;
+  Surface: SurfaceFactory;
+}


### PR DESCRIPTION
Moved Skia types to separate file to align with other API declarations, and to make sure we can have multiple implementations of the same type (RN Web)