### PR TITLE
Fixed podspec to play nicer with other native libraries

### DIFF
--- a/package/react-native-skia.podspec
+++ b/package/react-native-skia.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/shopify/react-native-skia/react-native-skia.git", :tag => "#{s.version}" }
 
   s.requires_arc = true
-  s.xcconfig = {
+  s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SK_GL=1 SK_METAL=1',
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17'
   }


### PR DESCRIPTION
There was an issue with including both RN Skia / Renanimated where running pod install failed with the following error message:

`Can't merge user_target_xcconfig for pod targets:....`

This was caused by both RN Skia and Reanimated trying to set the active C++ version to two different versions.

Running `npx pod install ios` worked - but the error is visible when installing with local cocoapods: `pod install ios` in the root of  a new project.

Moving setting the xcconfig variables to the `pod_target_xcconfig` solved the issue.

Tested in iOS on a new project using local cocoapods. Also verified that the included settings from the podspec file are set correctly in Xcode.

Fixed #405 