### PR TITLE
Fix Skia type implementation

### DIFF
--- a/example/src/Examples/API/Data.tsx
+++ b/example/src/Examples/API/Data.tsx
@@ -20,7 +20,7 @@ for (let x = 0; x < 256 * 4; x++) {
   }
 }
 const data = Skia.Data.fromBytes(pixels);
-const img = Skia.MakeImage(
+const img = Skia.Image.MakeImage(
   {
     width: 256,
     height: 256,

--- a/package/src/skia/Skia.ts
+++ b/package/src/skia/Skia.ts
@@ -8,39 +8,4 @@ declare global {
   var SkiaApi: SkSkiaApi;
 }
 
-/**
- * Declares the implemented API with overrides.
- */
-export const Skia = {
-  // Factories
-  Typeface: SkiaApi.Typeface,
-  MaskFilter: SkiaApi.MaskFilter,
-  RuntimeEffect: SkiaApi.RuntimeEffect,
-  Shader: SkiaApi.Shader,
-  ImageFilter: SkiaApi.ImageFilter,
-  PathEffect: SkiaApi.PathEffect,
-  Data: SkiaApi.Data,
-  SVG: SkiaApi.SVG,
-  FontMgr: SkiaApi.FontMgr,
-  TextBlob: SkiaApi.TextBlob,
-  // Constructors
-  Matrix: SkiaApi.Matrix,
-  Font: SkiaApi.Font,
-  Point: SkiaApi.Point,
-  XYWHRect: SkiaApi.XYWHRect,
-  RRectXY: SkiaApi.RRectXY,
-  RuntimeShaderBuilder: SkiaApi.RuntimeShaderBuilder,
-  Paint: SkiaApi.Paint,
-  PictureRecorder: SkiaApi.PictureRecorder,
-  Picture: SkiaApi.Picture,
-  Path: SkiaApi.Path,
-  ColorFilter: SkiaApi.ColorFilter,
-  ContourMeasureIter: SkiaApi.ContourMeasureIter,
-  Color: SkiaApi.Color,
-  RSXform: SkiaApi.RSXform,
-  // For the following methods the factory symmetry is broken to be comptatible with CanvasKit
-  MakeSurface: SkiaApi.Surface.Make,
-  MakeImageFromEncoded: SkiaApi.Image.MakeImageFromEncoded,
-  MakeImage: SkiaApi.Image.MakeImage,
-  MakeVertices: SkiaApi.MakeVertices,
-};
+export const Skia = SkiaApi;

--- a/package/src/skia/Skia.ts
+++ b/package/src/skia/Skia.ts
@@ -1,5 +1,5 @@
 /*global SkiaApi*/
-import type { SkiaApi as SkSkiaApi } from "./types";
+import type { Skia as SkSkiaApi } from "./types";
 
 /**
  * Declares the SkiaApi as an available object in the global scope

--- a/package/src/skia/core/Image.ts
+++ b/package/src/skia/core/Image.ts
@@ -7,4 +7,4 @@ import { useRawData } from "./Data";
  * Returns a Skia Image object
  * */
 export const useImage = (source: DataSource, onError?: (err: Error) => void) =>
-  useRawData(source, Skia.MakeImageFromEncoded, onError);
+  useRawData(source, Skia.Image.MakeImageFromEncoded, onError);

--- a/package/src/skia/types/Skia.ts
+++ b/package/src/skia/types/Skia.ts
@@ -32,7 +32,7 @@ import type {
 /**
  * Declares the interface for the native Skia API
  */
-export interface SkiaApi {
+export interface Skia {
   Point: (x: number, y: number) => SkPoint;
   XYWHRect: (x: number, y: number, width: number, height: number) => SkRect;
   RuntimeShaderBuilder: (rt: SkRuntimeEffect) => SkRuntimeShaderBuilder;

--- a/package/src/skia/types/Skia.ts
+++ b/package/src/skia/types/Skia.ts
@@ -39,7 +39,6 @@ export interface SkiaApi {
   RRectXY: (rect: SkRect, rx: number, ry: number) => SkRRect;
   RSXform: (scos: number, ssin: number, tx: number, ty: number) => SkRSXform;
   Color: (color: Color) => SkColor;
-  parseColorString: (color: string) => SkColor | undefined;
   ContourMeasureIter: (
     path: SkPath,
     forceClosed: boolean,


### PR DESCRIPTION
The Skia object was not implementing `SkiaApi`. 
This was testable by writing the following:
```ts
declare global {
  var SkiaApi: SkSkiaApi;
}

export const Skia: SkSkiaApi = {
  // ...
};
```