### PR TITLE
Export DependencyManager

### DIFF
--- a/package/src/renderer/index.ts
+++ b/package/src/renderer/index.ts
@@ -2,3 +2,4 @@ export * from "./Canvas";
 export * from "./components";
 export * from "./nodes";
 export * from "./useContextBridge";
+export * from "./DependencyManager";


### PR DESCRIPTION
Hey,
react-native-skia exports `skiaReconciler` and `Container` so `DependencyManager` is the only missing class for building custom Canvas/SkiaView-like components