### PR TITLE
Fixed context for the requestAnimationFrame usage in animations

### DIFF
--- a/package/src/values/web/api.ts
+++ b/package/src/values/web/api.ts
@@ -23,11 +23,11 @@ export const ValueApi: ISkiaValueApi = {
     return new RNSkDerivedValue(cb, values);
   },
   createClockValue: function (): SkiaClockValue {
-    return new RNSkClockValue(requestAnimationFrame);
+    return new RNSkClockValue(requestAnimationFrame.bind(window));
   },
   createAnimation: function <S extends AnimationState = AnimationState>(
     cb: (t: number, state: S | undefined) => S
   ): SkiaAnimation {
-    return new RNSkAnimation(cb, requestAnimationFrame);
+    return new RNSkAnimation(cb, requestAnimationFrame.bind(window));
   },
 };


### PR DESCRIPTION
When testing the JS animations in RNWeb there is an error caused by a missing bind when using the `requestAnimationFrame` function.

This PR fixes this by binding the function to the window object.