### PR TITLE
Added id field to touch events so that we can track touch events across time

### DIFF
--- a/example/src/Examples/API/List.tsx
+++ b/example/src/Examples/API/List.tsx
@@ -19,6 +19,10 @@ const examples = [
     title: "✂️ & 🎭 Clipping & Masking",
   },
   {
+    screen: "Touch",
+    title: "🖱 Touch Handling",
+  },
+  {
     screen: "PathEffect",
     title: "⭐️ Path Effect",
   },

--- a/example/src/Examples/API/Routes.ts
+++ b/example/src/Examples/API/Routes.ts
@@ -10,6 +10,7 @@ export type Routes = {
   ImageFilters: undefined;
   Gradients: undefined;
   SVG: undefined;
+  Touch: undefined;
   BlendModes: undefined;
   Data: undefined;
   Picture: undefined;

--- a/example/src/Examples/API/Touch.tsx
+++ b/example/src/Examples/API/Touch.tsx
@@ -1,0 +1,106 @@
+import React, { useCallback, useRef } from "react";
+import { StyleSheet, View } from "react-native";
+import type { SkColor, TouchInfo } from "@shopify/react-native-skia";
+import {
+  Fill,
+  Canvas,
+  Drawing,
+  Skia,
+  PaintStyle,
+  usePaint,
+  TouchType,
+} from "@shopify/react-native-skia";
+import type { DrawingContext } from "@shopify/react-native-skia/src/renderer/DrawingContext";
+
+import { Title } from "./components/Title";
+
+const Colors = [
+  "#2D4CD2",
+  "#3CF2B5",
+  "#A80DD8",
+  "#36B6D9",
+  "#37FF5E",
+  "#CF0CAA",
+  "#AFF12D",
+  "#D35127",
+  "#D01252",
+  "#DABC2D",
+  "#5819D7",
+] as const;
+
+export const Touch = () => {
+  const paint = usePaint((p) => {
+    p.setStyle(PaintStyle.Stroke);
+    p.setStrokeWidth(8);
+  });
+  const currentTouches = useRef<Array<TouchInfo & { color: SkColor }>>([]);
+
+  const handleTouches = useCallback((touchInfo: Array<Array<TouchInfo>>) => {
+    // Loop through touch event history since last repaint (usually just one)
+    touchInfo.forEach((touches) => {
+      // Add all touches to the current touches array and set a random color
+      // on each touch
+      touches
+        .filter((t) => t.type === TouchType.Start)
+        .forEach((t) => {
+          const color = Skia.Color(
+            Colors[Math.round(Math.random() * (Colors.length - 1))]
+          );
+          currentTouches.current.push({ ...t, color });
+        });
+
+      // Remove touch events for end / cancel
+      touches
+        .filter(
+          (t) => t.type === TouchType.End || t.type === TouchType.Cancelled
+        )
+        .forEach((t) => {
+          currentTouches.current = currentTouches.current.filter(
+            (p) => p.id !== t.id
+          );
+        });
+
+      // Update all remaining active touches
+      touches
+        .filter((t) => t.type === TouchType.Active)
+        .forEach((t) => {
+          const index = currentTouches.current.findIndex((p) => p.id === t.id);
+          if (index >= 0) {
+            currentTouches.current[index] = {
+              ...currentTouches.current[index],
+              ...t,
+            };
+          }
+        });
+    });
+  }, []);
+
+  const handleDraw = useCallback(
+    (ctx: DrawingContext) => {
+      // Draw an indicator for all of the active touches
+      currentTouches.current.forEach((t) => {
+        if (t.type === TouchType.Active || t.type === TouchType.Start) {
+          paint.setColor(t.color);
+          ctx.canvas.drawCircle(t.x, t.y, 40, paint);
+        }
+      });
+    },
+    [paint]
+  );
+
+  return (
+    <View style={styles.container}>
+      <Title>Touch handling</Title>
+      <Canvas style={styles.container} onTouch={handleTouches}>
+        <Fill color="white" />
+        <Drawing drawing={handleDraw} />
+      </Canvas>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/example/src/Examples/API/index.tsx
+++ b/example/src/Examples/API/index.tsx
@@ -18,6 +18,7 @@ import { PictureExample } from "./Picture";
 import { ImageFilters } from "./ImageFilters";
 import { UseCanvas } from "./UseCanvas";
 import { FreezeExample } from "./Freeze";
+import { Touch } from "./Touch";
 
 const Stack = createNativeStackNavigator<Routes>();
 export const API = () => {
@@ -99,6 +100,13 @@ export const API = () => {
         component={SVG}
         options={{
           title: "🖋 SVG",
+        }}
+      />
+      <Stack.Screen
+        name="Touch"
+        component={Touch}
+        options={{
+          title: "🖱 Touch Handling",
         }}
       />
       <Stack.Screen

--- a/package/android/cpp/jni/JniSkiaDrawView.cpp
+++ b/package/android/cpp/jni/JniSkiaDrawView.cpp
@@ -76,14 +76,15 @@ namespace RNSkia
         std::vector<RNSkia::RNSkTouchPoint> points;
         auto pin = touches.pin();
         auto scale = _drawView->getPixelDensity();
-        points.reserve(pin.size() / 4);
-        for (size_t i = 0; i < pin.size(); i += 4)
+        points.reserve(pin.size() / 5);
+        for (size_t i = 0; i < pin.size(); i += 5)
         {
             RNSkTouchPoint point;
             point.x = pin[i] / scale;
             point.y = pin[i + 1] / scale;
             point.force = pin[i + 2];
             point.type = (RNSkia::RNSkTouchType)pin[i + 3];
+            point.id = pin[i + 4];
             points.push_back(point);
         }
         _drawView->updateTouchState(std::move(points));

--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDrawView.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDrawView.java
@@ -59,7 +59,7 @@ public class SkiaDrawView extends TextureView implements TextureView.SurfaceText
         int action = ev.getAction();
         int count = ev.getPointerCount();
         MotionEvent.PointerCoords r = new MotionEvent.PointerCoords();
-        double[] points = new double[count*4];
+        double[] points = new double[count*5];
         for (int i = 0; i < count; i++) {
             ev.getPointerCoords(i, r);
             points[i] = r.x;
@@ -81,6 +81,7 @@ public class SkiaDrawView extends TextureView implements TextureView.SurfaceText
                     points[i+3] = 3;
                     break;
             }
+            points[i+4] = ev.getPointerId(i);
         }
         updateTouchPoints(points);
         return true;

--- a/package/cpp/rnskia/RNSkInfoParameter.h
+++ b/package/cpp/rnskia/RNSkInfoParameter.h
@@ -23,6 +23,7 @@ using RNSkTouchPoint = struct {
   double y;
   double force;
   RNSkTouchType type;
+  size_t id;
   long timestamp;
 };
 
@@ -45,6 +46,7 @@ public:
         touchObj.setProperty(runtime, "force", t.force);
         touchObj.setProperty(runtime, "type", (double)t.type);
         touchObj.setProperty(runtime, "timestamp", (double)t.timestamp / 1000.0);
+        touchObj.setProperty(runtime, "id", (double)t.id);
         touches.setValueAtIndex(runtime, n, touchObj);
       }
       ops.setValueAtIndex(runtime, i, touches);

--- a/package/ios/RNSkia-iOS/SkiaDrawView.mm
+++ b/package/ios/RNSkia-iOS/SkiaDrawView.mm
@@ -137,7 +137,8 @@
       RNSkia::RNSkTouchPoint nextTouch;
       nextTouch.x = position.x;
       nextTouch.y = position.y;
-      nextTouch.force = [touch force];
+      nextTouch.force = [touch force];    
+      nextTouch.id = [touch hash];
       auto phase = [touch phase];
       switch(phase) {
         case UITouchPhaseBegan:

--- a/package/src/views/types.ts
+++ b/package/src/views/types.ts
@@ -22,6 +22,7 @@ export interface TouchInfo {
   y: number;
   force: number;
   type: TouchType;
+  id: number;
   timestamp: number;
 }
 


### PR DESCRIPTION
When starting to implement touches on RN Web it was clear that having an ID that could follow a given touch point (and track f.ex a specific finger) was missing from the current API. This PR adds support for the ID field on a touch event and is part of preparations for RNWeb touch handling.

Road to #200
Relates to #539

- Implemented support for id field on Android/iOS native
- Added id field type in Typescript
- Added API example showing how to track mouse gestures on all platforms