### PR TITLE
Fix back button not showing in RNWeb

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -44,6 +44,7 @@ const imageLoaderConfiguration = {
     loader: "url-loader",
     options: {
       name: "[name].[ext]",
+      esModule: false,
     },
   },
 };


### PR DESCRIPTION
Back-button in React Navigation on RNWeb does not show up correctly.

This is related to this issue in React Navigation:
https://github.com/react-navigation/react-navigation/issues/9655

This PR adds the necessary config fix to webpack.config.js.