### PR TITLE
Fix mismatch in package.json fields in npm package

### DIFF
--- a/scripts/build-npm-package.ts
+++ b/scripts/build-npm-package.ts
@@ -72,9 +72,9 @@ const majorMinor = pck.version.split(".").slice(0, 2).join(".");
 const nextVersion = majorMinor + "." + process.env.GITHUB_RUN_NUMBER;
 pck.version = nextVersion;
 pck.types = "lib/typescript/index.d.ts";
-pck.main = "lib/module/index.js";
+pck.main = "lib/commonjs/index.js";
 pck.module = "lib/module/index.js";
-pck["react-native"] = "lib/module/index.js";
+pck["react-native"] = "./index.ts";
 pck.scripts.postinstall = "node scripts/install-npm.js";
 console.log("Building version:", nextVersion);
 

--- a/scripts/build-npm-package.ts
+++ b/scripts/build-npm-package.ts
@@ -74,7 +74,7 @@ pck.version = nextVersion;
 pck.types = "lib/typescript/index.d.ts";
 pck.main = "lib/commonjs/index.js";
 pck.module = "lib/module/index.js";
-pck["react-native"] = "./index.ts";
+pck["react-native"] = "src/index.ts";
 pck.scripts.postinstall = "node scripts/install-npm.js";
 console.log("Building version:", nextVersion);
 


### PR DESCRIPTION
Added a fix to the script that updates the package.json file when building npm package

The current solution uses the wrong path for the main field in the package.json file, and also uses the wrong path for the react-native field.

This is related to #548

**Test:**
Ran build-npm script and verified that it could be installed successfully in new iOS/Android React Native project.