### PR TITLE
Moved initialization of dimensions to useWindowDimensions() hook

### DIFF
--- a/example/src/Examples/API/Clipping.tsx
+++ b/example/src/Examples/API/Clipping.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { StyleSheet, Dimensions, ScrollView } from "react-native";
+import React, { useMemo } from "react";
+import { ScrollView, useWindowDimensions } from "react-native";
 import {
   useLoop,
   Skia,
@@ -14,26 +14,30 @@ import {
   mix,
 } from "@shopify/react-native-skia";
 
-const { width } = Dimensions.get("window");
-const SIZE = width / 4;
-
 const star = Skia.Path.MakeFromSVGString(
   // eslint-disable-next-line max-len
   "M 293.4 16 C 266.3 16 244.4 37.9 244.4 65 C 244.4 92.1 266.3 114 293.4 114 C 320.4 114 342.4 92.1 342.4 65 C 342.4 37.9 320.4 16 293.4 16 Z M 311 90.6 L 293.4 81.1 L 275.7 90.6 L 279.2 70.9 L 264.8 57 L 284.6 54.2 L 293.4 36.2 L 302.1 54.2 L 321.9 57 L 307.5 70.9 L 311 90.6 V 90.6 Z"
 )!;
 const PADDING = 16;
-const clipRRect = Skia.RRectXY(
-  Skia.XYWHRect(
-    PADDING + SIZE + PADDING * 2,
-    PADDING * 2,
-    SIZE - 2 * PADDING,
-    SIZE - 2 * PADDING
-  ),
-  25,
-  25
-);
 
 export const Clipping = () => {
+  const { width } = useWindowDimensions();
+  const SIZE = width / 4;
+  const clipRRect = useMemo(
+    () =>
+      Skia.RRectXY(
+        Skia.XYWHRect(
+          PADDING + SIZE + PADDING * 2,
+          PADDING * 2,
+          SIZE - 2 * PADDING,
+          SIZE - 2 * PADDING
+        ),
+        25,
+        25
+      ),
+    [SIZE]
+  );
+
   const progress = useLoop({ duration: 3000 });
   const x = useDerivedValue(() => mix(progress.current, 0, 200), [progress]);
   const oslo = useImage(require("../../assets/oslo.jpg"));
@@ -42,7 +46,7 @@ export const Clipping = () => {
   }
   return (
     <ScrollView>
-      <Canvas style={styles.container}>
+      <Canvas style={{ width, height: SIZE + 32 }}>
         <Image
           image={oslo}
           x={PADDING}
@@ -101,10 +105,3 @@ export const Clipping = () => {
     </ScrollView>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    width,
-    height: SIZE + 32,
-  },
-});

--- a/example/src/Examples/API/ColorFilter.tsx
+++ b/example/src/Examples/API/ColorFilter.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { StyleSheet, Dimensions, ScrollView } from "react-native";
+import React, { useMemo } from "react";
+import { ScrollView, useWindowDimensions } from "react-native";
 import {
   Skia,
   useDrawCallback,
@@ -22,11 +22,6 @@ import { Title } from "./components/Title";
 
 const card = require("../../assets/zurich.jpg");
 
-const { width } = Dimensions.get("window");
-const aspectRatio = 3057 / 5435;
-const IMG_WIDTH = width / 2;
-const IMG_HEIGHT = IMG_WIDTH * aspectRatio;
-
 const paint = Skia.Paint();
 paint.setAntiAlias(true);
 paint.setColor(Skia.Color("#61DAFB"));
@@ -35,9 +30,21 @@ const strokePaint = paint.copy();
 strokePaint.setStyle(PaintStyle.Stroke);
 strokePaint.setStrokeWidth(2);
 
+const blackAndWhite = [
+  0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0,
+];
+const purple = [
+  1, -0.2, 0, 0, 0, 0, 1, 0, -0.1, 0, 0, 1.2, 1, 0.1, 0, 0, 0, 1.7, 1, 0,
+];
+
 // TODO: use examples from https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform
 // Once the Path API is available.
 export const ColorFilter = () => {
+  const { width } = useWindowDimensions();
+  const aspectRatio = 3057 / 5435;
+  const IMG_WIDTH = width / 2;
+  const IMG_HEIGHT = IMG_WIDTH * aspectRatio;
+
   const image = useImage(card);
 
   const onMatrixDraw = useDrawCallback(
@@ -104,24 +111,25 @@ export const ColorFilter = () => {
     },
     [image]
   );
+
+  const style = useMemo(
+    () => ({ width: width, height: IMG_HEIGHT * 2 }),
+    [IMG_HEIGHT, width]
+  );
+
   const r = IMG_HEIGHT;
   if (!image) {
     return null;
   }
-  const blackAndWhite = [
-    0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0,
-  ];
-  const purple = [
-    1, -0.2, 0, 0, 0, 0, 1, 0, -0.1, 0, 0, 1.2, 1, 0.1, 0, 0, 0, 1.7, 1, 0,
-  ];
+
   return (
     <ScrollView>
       <Title>Color Matrix Filter</Title>
-      <SkiaView style={styles.container} onDraw={onMatrixDraw} />
+      <SkiaView style={style} onDraw={onMatrixDraw} />
       <Title>Image Filter</Title>
-      <SkiaView style={styles.container} onDraw={onImageFilterDraw} />
+      <SkiaView style={style} onDraw={onImageFilterDraw} />
       <Title>Other</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={style}>
         <Group>
           <SRGBToLinearGamma>
             <BlendColor color="lightblue" mode="srcIn" />
@@ -130,7 +138,7 @@ export const ColorFilter = () => {
           <Circle cx={2 * r} cy={r} r={r} color="red" />
         </Group>
       </Canvas>
-      <Canvas style={styles.container}>
+      <Canvas style={style}>
         <Image x={0} y={0} width={256} height={256} image={image} fit="cover">
           <LinearToSRGBGamma>
             <Lerp t={0.5}>
@@ -143,10 +151,3 @@ export const ColorFilter = () => {
     </ScrollView>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    width: width,
-    height: IMG_HEIGHT * 2,
-  },
-});

--- a/example/src/Examples/API/Data.tsx
+++ b/example/src/Examples/API/Data.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, Dimensions } from "react-native";
+import { useWindowDimensions } from "react-native";
 import {
   AlphaType,
   Canvas,
@@ -7,9 +7,6 @@ import {
   Image,
   Skia,
 } from "@shopify/react-native-skia";
-
-const { width } = Dimensions.get("window");
-const SIZE = width;
 
 const pixels = new Uint8Array(256 * 256 * 4);
 pixels.fill(255);
@@ -32,16 +29,11 @@ const img = Skia.Image.MakeImage(
 )!;
 
 export const Data = () => {
+  const { width } = useWindowDimensions();
+  const SIZE = width;
   return (
-    <Canvas style={styles.container}>
+    <Canvas style={{ width: SIZE, height: SIZE }}>
       <Image image={img} x={0} y={0} width={256} height={256} fit="cover" />
     </Canvas>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    width: SIZE,
-    height: SIZE,
-  },
-});

--- a/example/src/Examples/API/Gradients.tsx
+++ b/example/src/Examples/API/Gradients.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { StyleSheet, Dimensions, ScrollView } from "react-native";
+import React, { useMemo } from "react";
+import { ScrollView, useWindowDimensions } from "react-native";
 import {
   bottomRight,
   center,
@@ -20,24 +20,25 @@ import {
 
 import { BilinearGradient } from "../Aurora/components/BilinearGradient";
 
-const { width } = Dimensions.get("window");
-const SIZE = width / 2;
-const R = SIZE / 2;
-
 const paint = Skia.Paint();
 paint.setAntiAlias(true);
-const r1 = rect(0, 0, SIZE, SIZE);
-const r2 = rect(SIZE, 0, SIZE, SIZE);
-const r3 = rect(0, SIZE, SIZE, SIZE);
-const r4 = rect(SIZE, SIZE, SIZE, SIZE);
-const r5 = rect(0, 2 * SIZE, SIZE, SIZE);
-const r6 = rect(SIZE, 2 * SIZE, SIZE, SIZE);
-const r7 = rect(0, 3 * SIZE, SIZE, SIZE);
 
 export const Gradients = () => {
+  const { width } = useWindowDimensions();
+  const SIZE = width / 2;
+  const R = SIZE / 2;
+
+  const r1 = useMemo(() => rect(0, 0, SIZE, SIZE), [SIZE]);
+  const r2 = useMemo(() => rect(SIZE, 0, SIZE, SIZE), [SIZE]);
+  const r3 = useMemo(() => rect(0, SIZE, SIZE, SIZE), [SIZE]);
+  const r4 = useMemo(() => rect(SIZE, SIZE, SIZE, SIZE), [SIZE]);
+  const r5 = useMemo(() => rect(0, 2 * SIZE, SIZE, SIZE), [SIZE]);
+  const r6 = useMemo(() => rect(SIZE, 2 * SIZE, SIZE, SIZE), [SIZE]);
+  const r7 = useMemo(() => rect(0, 3 * SIZE, SIZE, SIZE), [SIZE]);
+
   return (
     <ScrollView>
-      <Canvas style={styles.container}>
+      <Canvas style={{ width: SIZE * 2, height: SIZE * 4 }}>
         <Rect rect={r1}>
           <LinearGradient
             start={topLeft(r1)}
@@ -94,10 +95,3 @@ export const Gradients = () => {
     </ScrollView>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    width: SIZE * 2,
-    height: SIZE * 4,
-  },
-});

--- a/example/src/Examples/API/Images.tsx
+++ b/example/src/Examples/API/Images.tsx
@@ -1,13 +1,8 @@
-import React from "react";
-import { StyleSheet, Dimensions, ScrollView } from "react-native";
+import React, { useMemo } from "react";
+import { ScrollView, useWindowDimensions } from "react-native";
 import { useImage, Canvas, Image, Rect } from "@shopify/react-native-skia";
 
 import { Title } from "./components/Title";
-
-const { width: wWidth } = Dimensions.get("window");
-const SIZE = wWidth / 3;
-const S2 = 60;
-const PAD = (SIZE - S2) / 2;
 
 const fits = [
   "contain",
@@ -18,12 +13,6 @@ const fits = [
   "scaleDown",
   "none",
 ] as const;
-
-const rects = [
-  { x: 0, y: PAD, width: SIZE, height: S2 },
-  { x: SIZE + PAD, y: 0, width: S2, height: SIZE },
-  { x: 2 * SIZE, y: 0, width: SIZE, height: SIZE },
-];
 
 export const Images = () => {
   // Verifies that the error handler for images are working correctly.
@@ -48,12 +37,26 @@ export const Images = () => {
 
   const oslo = useImage(require("../../assets/oslo.jpg"));
 
+  const { width: wWidth } = useWindowDimensions();
+  const SIZE = wWidth / 3;
+  const S2 = 60;
+  const PAD = (SIZE - S2) / 2;
+
+  const rects = useMemo(
+    () => [
+      { x: 0, y: PAD, width: SIZE, height: S2 },
+      { x: SIZE + PAD, y: 0, width: S2, height: SIZE },
+      { x: 2 * SIZE, y: 0, width: SIZE, height: SIZE },
+    ],
+    [PAD, SIZE]
+  );
+
   return (
     <ScrollView>
       {fits.map((fit, i) => (
         <React.Fragment key={i}>
           <Title>{`fit="${fit}"`}</Title>
-          <Canvas style={styles.container} key={fit}>
+          <Canvas style={{ width: wWidth, height: SIZE }} key={fit}>
             {rects.map(({ x, y, width, height }, index) => {
               return (
                 <React.Fragment key={index}>
@@ -84,10 +87,3 @@ export const Images = () => {
     </ScrollView>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    width: wWidth,
-    height: SIZE,
-  },
-});

--- a/example/src/Examples/API/Path.tsx
+++ b/example/src/Examples/API/Path.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable max-len */
-import React from "react";
-import { StyleSheet, Dimensions, ScrollView, View } from "react-native";
+import React, { useMemo } from "react";
+import {
+  StyleSheet,
+  ScrollView,
+  View,
+  useWindowDimensions,
+} from "react-native";
 import {
   Skia,
   PathOp,
@@ -20,9 +25,6 @@ import {
   CARD_WIDTH,
 } from "./components/drawings/backface";
 
-const { width } = Dimensions.get("window");
-const SIZE = width;
-
 const strokeWidth = 10;
 const r = 32;
 const d = 2 * r;
@@ -36,16 +38,29 @@ s.stroke({
   width: 10,
 });
 
-const rect1 = Skia.Path.Make();
-rect1.addRect(
-  rect(strokeWidth / 2, (example1Height - d) / 2, SIZE - strokeWidth, 70)
-);
-const circle = Skia.Path.Make();
-circle.addCircle(SIZE / 2, example1Height / 2 - d / 2, r);
-const result = Skia.Path.MakeFromOp(rect1, circle, PathOp.Difference)!;
-result.simplify();
-
 export const PathExample = () => {
+  const { width } = useWindowDimensions();
+  const SIZE = width;
+  const rect1 = useMemo(() => {
+    const retVal = Skia.Path.Make();
+    retVal.addRect(
+      rect(strokeWidth / 2, (example1Height - d) / 2, SIZE - strokeWidth, 70)
+    );
+    return retVal;
+  }, [SIZE]);
+
+  const circle = useMemo(() => {
+    const c = Skia.Path.Make();
+    c.addCircle(SIZE / 2, example1Height / 2 - d / 2, r);
+    return c;
+  }, [SIZE]);
+
+  const result = useMemo(() => {
+    const rr = Skia.Path.MakeFromOp(rect1, circle, PathOp.Difference)!;
+    rr.simplify();
+    return rr;
+  }, [circle, rect1]);
+
   const font = useFont(require("./Roboto-Regular.otf"), 32);
   if (!font) {
     return null;
@@ -53,7 +68,7 @@ export const PathExample = () => {
   return (
     <ScrollView>
       <Title>Path Operations</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={{ ...styles.container, width: SIZE }}>
         <Group style="stroke" color="#fb61da" strokeWidth={2}>
           <Path
             path={result}
@@ -66,17 +81,17 @@ export const PathExample = () => {
         </Group>
       </Canvas>
       <Title>Paths</Title>
-      <View style={styles.cardContainer}>
+      <View style={{ ...styles.cardContainer, width: SIZE }}>
         <Canvas style={styles.card}>
           <Backface />
         </Canvas>
       </View>
       <Title>Stroke</Title>
-      <Canvas style={styles.stroke}>
+      <Canvas style={{ width: SIZE, height: SIZE }}>
         <Path path={s} color="black" style="stroke" strokeWidth={1} />
       </Canvas>
       <Title>Text Path</Title>
-      <Canvas style={styles.textPath}>
+      <Canvas style={{ width: SIZE, height: SIZE }}>
         <Group transform={[{ translateY: 25 }]}>
           <TextPath path={circle} font={font} text="Hello World!" />
         </Group>
@@ -93,23 +108,13 @@ export const PathExample = () => {
 
 const styles = StyleSheet.create({
   container: {
-    width: SIZE,
     height: example1Height,
   },
   cardContainer: {
-    width,
     padding: 16,
   },
   card: {
     width: CARD_WIDTH,
     height: CARD_HEIGHT,
-  },
-  stroke: {
-    width: SIZE,
-    height: SIZE,
-  },
-  textPath: {
-    width: SIZE,
-    height: SIZE,
   },
 });

--- a/example/src/Examples/API/PathEffect.tsx
+++ b/example/src/Examples/API/PathEffect.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { StyleSheet, Dimensions, ScrollView } from "react-native";
+import React, { useMemo } from "react";
+import { ScrollView, useWindowDimensions } from "react-native";
+import type { Vector } from "@shopify/react-native-skia";
 import {
   Rect,
   transformOrigin,
@@ -23,8 +24,6 @@ import {
 
 import { Title } from "./components/Title";
 
-const { width } = Dimensions.get("window");
-const SIZE = width;
 const path = Skia.Path.MakeFromSVGString(
   // eslint-disable-next-line max-len
   "M466 91C466 141.258 361.682 182 233 182C104.318 182 0 141.258 0 91C0 40.7421 104.318 0 233 0C361.682 0 466 40.7421 466 91Z"
@@ -33,9 +32,7 @@ const path = Skia.Path.MakeFromSVGString(
 const vWidth = 466;
 const vHeight = 182;
 const vOrigin = { x: vWidth / 2, y: vHeight / 2 };
-const scale = (SIZE - 64) / vWidth;
-const origin = { x: (vWidth * scale) / 2, y: (vHeight * scale) / 2 };
-const center = { x: SIZE / 2, y: SIZE / 2 };
+
 const basePaint = Skia.Paint();
 basePaint.setAntiAlias(true);
 basePaint.setColor(Skia.Color("#61DAFB"));
@@ -50,7 +47,11 @@ transparentPaint.setStyle(PaintStyle.Stroke);
 transparentPaint.setStrokeWidth(15);
 transparentPaint.setAlphaf(0.2);
 
-const Logo = () => {
+const Logo: React.FC<{ center: Vector; origin: Vector; scale: number }> = ({
+  center,
+  origin,
+  scale,
+}) => {
   return (
     <>
       <Circle c={center} r={30} style="fill" />
@@ -82,7 +83,11 @@ const Logo = () => {
 };
 
 const rect1 = rect(0, 0, vWidth, vHeight);
-const SquaredLogo = () => {
+const SquaredLogo: React.FC<{
+  center: Vector;
+  origin: Vector;
+  scale: number;
+}> = ({ center, origin, scale }) => {
   return (
     <>
       <Circle c={center} r={30} style="fill" />
@@ -114,37 +119,45 @@ const SquaredLogo = () => {
 };
 
 export const PathEffectDemo = () => {
+  const { width } = useWindowDimensions();
+  const SIZE = width;
+  const scale = (SIZE - 64) / vWidth;
+  const origin = { x: (vWidth * scale) / 2, y: (vHeight * scale) / 2 };
+  const center = { x: SIZE / 2, y: SIZE / 2 };
+
+  const styles = useMemo(() => ({ width, height: width }), [width]);
+
   return (
     <ScrollView>
       <Title>Discrete</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={styles}>
         <Group color="#61DAFB" style="stroke" strokeWidth={15}>
           <DiscretePathEffect length={10} deviation={4} />
-          <Logo />
+          <Logo center={center} origin={origin} scale={scale} />
         </Group>
       </Canvas>
 
       <Title>Dash</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={styles}>
         <Group color="#61DAFB" style="stroke" strokeWidth={15}>
           <DashPathEffect intervals={[10, 10]} />
-          <Logo />
+          <Logo center={center} origin={origin} scale={scale} />
         </Group>
       </Canvas>
 
       <Title>Corner</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={styles}>
         <Group color="#61DAFB" style="stroke" strokeWidth={15} opacity={0.5}>
-          <SquaredLogo />
+          <SquaredLogo center={center} origin={origin} scale={scale} />
         </Group>
         <Group color="#61DAFB" style="stroke" strokeWidth={15}>
           <CornerPathEffect r={200} />
-          <SquaredLogo />
+          <SquaredLogo center={center} origin={origin} scale={scale} />
         </Group>
       </Canvas>
 
       <Title>Path1D</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={styles}>
         <Group color="#61DAFB" style="stroke" strokeWidth={15}>
           <Path1DPathEffect
             path="M -10 0 L 0 -10, 10 0, 0 10 Z"
@@ -152,48 +165,41 @@ export const PathEffectDemo = () => {
             phase={0}
             style="rotate"
           />
-          <Logo />
+          <Logo center={center} origin={origin} scale={scale} />
         </Group>
       </Canvas>
 
       <Title>Path2D</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={styles}>
         <Group color="#61DAFB" style="stroke" strokeWidth={15}>
           <Path2DPathEffect
             path="M -10 0 L 0 -10, 10 0, 0 10 Z"
             matrix={processTransform2d([{ scale: 40 }])}
           />
-          <Logo />
+          <Logo center={center} origin={origin} scale={scale} />
         </Group>
       </Canvas>
 
       <Title>Line2D</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={styles}>
         <Group color="#61DAFB" style="stroke" strokeWidth={15}>
           <Line2DPathEffect
             width={0}
             matrix={processTransform2d([{ scale: 8 }])}
           />
-          <Logo />
+          <Logo center={center} origin={origin} scale={scale} />
         </Group>
       </Canvas>
 
       <Title>Compose</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={styles}>
         <Group color="#61DAFB" style="stroke" strokeWidth={15}>
           <DashPathEffect intervals={[10, 10]}>
             <DiscretePathEffect length={10} deviation={10} />
           </DashPathEffect>
-          <Logo />
+          <Logo center={center} origin={origin} scale={scale} />
         </Group>
       </Canvas>
     </ScrollView>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    width: SIZE,
-    height: SIZE,
-  },
-});

--- a/example/src/Examples/API/SVG.tsx
+++ b/example/src/Examples/API/SVG.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-import { Dimensions } from "react-native";
+import { useWindowDimensions } from "react-native";
 import { Canvas, ImageSVG, useSVG } from "@shopify/react-native-skia";
 
-const { width, height } = Dimensions.get("window");
-
 export const SVG = () => {
+  const { width, height } = useWindowDimensions();
   const svg = useSVG(require("./tiger.svg"));
   return (
     <Canvas style={{ flex: 1 }}>

--- a/example/src/Examples/API/Shapes.tsx
+++ b/example/src/Examples/API/Shapes.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { StyleSheet, Dimensions, ScrollView, PixelRatio } from "react-native";
+import React, { useMemo } from "react";
+import { ScrollView, PixelRatio, useWindowDimensions } from "react-native";
 import {
   Skia,
   PaintStyle,
@@ -22,8 +22,6 @@ import {
 
 import { Title } from "./components/Title";
 
-const { width } = Dimensions.get("window");
-const SIZE = width / 4;
 const paint = Skia.Paint();
 paint.setAntiAlias(true);
 paint.setColor(Skia.Color("#61DAFB"));
@@ -32,44 +30,84 @@ const strokePaint = paint.copy();
 strokePaint.setStyle(PaintStyle.Stroke);
 strokePaint.setStrokeWidth(2);
 
-const c = { x: width / 2, y: SIZE / 2 + 16 };
-const S = 25;
-const c1 = [
-  vec(c.x - 2 * S, c.y - S),
-  vec(c.x - S, c.y - 2 * S),
-  vec(c.x - S, c.y - S),
-];
-
-const c2 = [vec(c.x, c.y - 2 * S), vec(c.x + S, c.y), vec(c.x + S, c.y - S)];
-
-const c3 = [vec(c.x - 10, c.y + 10), vec(c.x + S, c.y), vec(c.x + S, c.y + S)];
-
-const c4 = [
-  vec(c.x - 2 * S, c.y + S),
-  vec(c.x - S, c.y + 2 * S),
-  vec(c.x - S, c.y + S),
-];
-
-const cubics = [...c1, ...c2, ...c3, ...c4];
-
 const PADDING = 16;
-const outer = rrect(rect(2 * SIZE + 3 * 16, PADDING, SIZE, SIZE), 25, 25);
-const inner = rrect(
-  rect(2 * SIZE + 4 * PADDING, 2 * PADDING, SIZE - 32, SIZE - 32),
-  0,
-  0
-);
-
-const topLeft = { pos: vec(16, 0), c1: vec(0, 15), c2: vec(15, 0) };
-const topRight = { pos: vec(100, 0), c1: vec(80, 15), c2: vec(85, 0) };
-const bottomRight = { pos: vec(100, 100), c1: vec(100, 85), c2: vec(85, 100) };
-const bottomLeft = { pos: vec(16, 100), c1: vec(0, 85), c2: vec(15, 100) };
 
 export const Shapes = () => {
+  const { width } = useWindowDimensions();
+  const SIZE = width / 4;
+  const c = useMemo(() => ({ x: width / 2, y: SIZE / 2 + 16 }), [SIZE, width]);
+  const S = 25;
+  const c1 = useMemo(
+    () => [
+      vec(c.x - 2 * S, c.y - S),
+      vec(c.x - S, c.y - 2 * S),
+      vec(c.x - S, c.y - S),
+    ],
+    [c.x, c.y]
+  );
+
+  const c2 = useMemo(
+    () => [vec(c.x, c.y - 2 * S), vec(c.x + S, c.y), vec(c.x + S, c.y - S)],
+    [c.x, c.y]
+  );
+
+  const c3 = useMemo(
+    () => [vec(c.x - 10, c.y + 10), vec(c.x + S, c.y), vec(c.x + S, c.y + S)],
+    [c.x, c.y]
+  );
+
+  const c4 = useMemo(
+    () => [
+      vec(c.x - 2 * S, c.y + S),
+      vec(c.x - S, c.y + 2 * S),
+      vec(c.x - S, c.y + S),
+    ],
+    [c.x, c.y]
+  );
+
+  const cubics = useMemo(() => [...c1, ...c2, ...c3, ...c4], [c1, c2, c3, c4]);
+
+  const outer = useMemo(
+    () => rrect(rect(2 * SIZE + 3 * 16, PADDING, SIZE, SIZE), 25, 25),
+    [SIZE]
+  );
+  const inner = useMemo(
+    () =>
+      rrect(
+        rect(2 * SIZE + 4 * PADDING, 2 * PADDING, SIZE - 32, SIZE - 32),
+        0,
+        0
+      ),
+    [SIZE]
+  );
+
+  const topLeft = useMemo(
+    () => ({ pos: vec(16, 0), c1: vec(0, 15), c2: vec(15, 0) }),
+    []
+  );
+  const topRight = useMemo(
+    () => ({ pos: vec(100, 0), c1: vec(80, 15), c2: vec(85, 0) }),
+    []
+  );
+  const bottomRight = useMemo(
+    () => ({
+      pos: vec(100, 100),
+      c1: vec(100, 85),
+      c2: vec(85, 100),
+    }),
+    []
+  );
+  const bottomLeft = useMemo(
+    () => ({ pos: vec(16, 100), c1: vec(0, 85), c2: vec(15, 100) }),
+    []
+  );
+
+  const style = useMemo(() => ({ width, height: SIZE + 32 }), [SIZE, width]);
+
   return (
     <ScrollView>
       <Title>Rectangles</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={style}>
         <Group color="#61DAFB">
           <Rect rect={{ x: PADDING, y: PADDING, width: 100, height: 100 }} />
           <RoundedRect
@@ -83,7 +121,7 @@ export const Shapes = () => {
         </Group>
       </Canvas>
       <Title>Ovals & Circles</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={style}>
         <Group color="#61DAFB">
           <Oval x={PADDING} y={PADDING} width={2 * SIZE} height={SIZE}>
             <Paint
@@ -101,7 +139,7 @@ export const Shapes = () => {
         </Group>
       </Canvas>
       <Title>Points & Lines</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={style}>
         <Group color="#61DAFB" style="stroke" strokeWidth={PixelRatio.get()}>
           <Points mode="polygon" points={cubics} />
           <Line p1={c} p2={vec(SIZE, 0)} />
@@ -109,14 +147,14 @@ export const Shapes = () => {
         </Group>
       </Canvas>
       <Title>Coon Patch</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={style}>
         <Patch
           colors={["#61DAFB", "#fb61da", "#61fbcf", "#dafb61"]}
           patch={[topLeft, topRight, bottomRight, bottomLeft]}
         />
       </Canvas>
       <Title>Vertices</Title>
-      <Canvas style={styles.container}>
+      <Canvas style={style}>
         <Vertices
           mode="triangleFan"
           vertices={[
@@ -131,10 +169,3 @@ export const Shapes = () => {
     </ScrollView>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    width,
-    height: SIZE + 32,
-  },
-});

--- a/example/src/Examples/API/Transform.tsx
+++ b/example/src/Examples/API/Transform.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { StyleSheet, Dimensions, ScrollView } from "react-native";
+import React, { useMemo } from "react";
+import { ScrollView, useWindowDimensions } from "react-native";
 import {
   Skia,
   useDrawCallback,
@@ -11,13 +11,6 @@ import {
 import { Title } from "./components/Title";
 
 const card = require("../../assets/card.png");
-
-const { width } = Dimensions.get("window");
-const SIZE = width;
-const center = { x: SIZE / 2, y: SIZE / 2 };
-const aspectRatio = 836 / 1324;
-const CARD_WIDTH = width - 64;
-const CARD_HEIGHT = CARD_WIDTH * aspectRatio;
 
 const paint = Skia.Paint();
 paint.setAntiAlias(true);
@@ -31,6 +24,13 @@ strokePaint.setStrokeWidth(2);
 // Once the Path API is available.
 export const Transform = () => {
   const image = useImage(card);
+
+  const { width } = useWindowDimensions();
+  const SIZE = width;
+  const center = useMemo(() => ({ x: SIZE / 2, y: SIZE / 2 }), [SIZE]);
+  const aspectRatio = 836 / 1324;
+  const CARD_WIDTH = width - 64;
+  const CARD_HEIGHT = CARD_WIDTH * aspectRatio;
 
   const onRotateDraw = useDrawCallback(
     (canvas) => {
@@ -54,7 +54,7 @@ export const Transform = () => {
         canvas.restore();
       }
     },
-    [image]
+    [CARD_HEIGHT, CARD_WIDTH, center.x, center.y, image]
   );
 
   const onSkewDraw = useDrawCallback(
@@ -78,7 +78,7 @@ export const Transform = () => {
         canvas.restore();
       }
     },
-    [image]
+    [CARD_HEIGHT, CARD_WIDTH, center.x, center.y, image]
   );
 
   const onMatrixDraw = useDrawCallback(
@@ -102,24 +102,19 @@ export const Transform = () => {
         canvas.restore();
       }
     },
-    [image]
+    [CARD_HEIGHT, CARD_WIDTH, center.x, center.y, image]
   );
+
+  const style = useMemo(() => ({ width: SIZE, height: SIZE }), [SIZE]);
 
   return (
     <ScrollView>
       <Title>Rotate & Scale</Title>
-      <SkiaView style={styles.container} onDraw={onRotateDraw} />
+      <SkiaView style={style} onDraw={onRotateDraw} />
       <Title>Skew</Title>
-      <SkiaView style={styles.container} onDraw={onSkewDraw} />
+      <SkiaView style={style} onDraw={onSkewDraw} />
       <Title>Matrix</Title>
-      <SkiaView style={styles.container} onDraw={onMatrixDraw} />
+      <SkiaView style={style} onDraw={onMatrixDraw} />
     </ScrollView>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    width: SIZE,
-    height: SIZE,
-  },
-});

--- a/example/src/Examples/API/components/drawings/backface.tsx
+++ b/example/src/Examples/API/components/drawings/backface.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Dimensions } from "react-native";
 import {
   Skia,
   PaintStyle,
@@ -9,11 +8,9 @@ import {
   translate,
 } from "@shopify/react-native-skia";
 
-const { width } = Dimensions.get("window");
-
 const aspectRatio = 757 / 492;
 const center = { x: 492 / 2, y: 757 / 2 };
-export const CARD_WIDTH = width * 0.75;
+export const CARD_WIDTH = 300;
 export const CARD_HEIGHT = CARD_WIDTH * aspectRatio;
 const scale = 0.6;
 const strokeWidth = 10;

--- a/example/src/Examples/Animation/AnimationWithTouchHandler2.tsx
+++ b/example/src/Examples/Animation/AnimationWithTouchHandler2.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, Dimensions } from "react-native";
+import { StyleSheet, useWindowDimensions } from "react-native";
 import type {
   AnimationState,
   SkiaMutableValue,
@@ -15,18 +15,15 @@ import {
 
 import { AnimationDemo, Size, Padding } from "./Components";
 
-const { width } = Dimensions.get("window");
-
-const leftBoundary = Size;
-const rightBoundary = width - Size - Padding;
-
 interface PhysicsAnimationState extends AnimationState {
   velocity: number;
 }
 
 const runBouncing = (
   translate: SkiaMutableValue<number>,
-  initialVelocity: number
+  initialVelocity: number,
+  leftBoundary: number,
+  rightBoundary: number
 ) => {
   translate.animation = ValueApi.createAnimation<PhysicsAnimationState>(
     (now, state) => {
@@ -68,6 +65,11 @@ const runBouncing = (
 };
 
 export const AnimationWithTouchHandler = () => {
+  const { width } = useWindowDimensions();
+
+  const leftBoundary = Size;
+  const rightBoundary = width - Size - Padding;
+
   // Translate X value for the circle
   const translateX = useValue((width - Size - Padding) / 2);
   // Offset to let us pick up the circle from anywhere
@@ -84,7 +86,7 @@ export const AnimationWithTouchHandler = () => {
       );
     },
     onEnd: ({ velocityX }) => {
-      runBouncing(translateX, velocityX);
+      runBouncing(translateX, velocityX, leftBoundary, rightBoundary);
     },
   });
 

--- a/example/src/Examples/Aurora/components/CoonsPatchMeshGradient.tsx
+++ b/example/src/Examples/Aurora/components/CoonsPatchMeshGradient.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import type { CubicBezierHandle, SkiaValue } from "@shopify/react-native-skia";
 import {
   Skia,
@@ -14,16 +14,13 @@ import {
   useImage,
   useDerivedValue,
 } from "@shopify/react-native-skia";
-import { Dimensions } from "react-native";
+import { useWindowDimensions } from "react-native";
 import SimplexNoise from "simplex-noise";
 
 import { symmetric } from "./Math";
 import { Cubic } from "./Cubic";
 import { Curves } from "./Curves";
 import { useHandles } from "./useHandles";
-
-const { width, height } = Dimensions.get("window");
-const window = Skia.XYWHRect(0, 0, width, height);
 
 const rectToTexture = (
   vertices: CubicBezierHandle[],
@@ -96,6 +93,12 @@ export const CoonsPatchMeshGradient = ({
   handles,
   play,
 }: CoonsPatchMeshGradientProps) => {
+  const { width, height } = useWindowDimensions();
+  const window = useMemo(
+    () => Skia.XYWHRect(0, 0, width, height),
+    [height, width]
+  );
+
   const clock = useClockValue();
   const image = useImage(require("../../../assets/debug.png"));
   const dx = width / cols;

--- a/example/src/Examples/Breathe/Breathe.tsx
+++ b/example/src/Examples/Breathe/Breathe.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Dimensions, StyleSheet } from "react-native";
+import React, { useMemo } from "react";
+import { StyleSheet, useWindowDimensions } from "react-native";
 import type { SkiaValue } from "@shopify/react-native-skia";
 import {
   useDerivedValue,
@@ -15,11 +15,8 @@ import {
   mix,
 } from "@shopify/react-native-skia";
 
-const { width, height } = Dimensions.get("window");
 const c1 = "#61bea2";
 const c2 = "#529ca0";
-const R = width / 4;
-const center = vec(width / 2, height / 2 - 64);
 
 interface RingProps {
   index: number;
@@ -27,6 +24,13 @@ interface RingProps {
 }
 
 const Ring = ({ index, progress }: RingProps) => {
+  const { width, height } = useWindowDimensions();
+  const R = width / 4;
+  const center = useMemo(
+    () => vec(width / 2, height / 2 - 64),
+    [height, width]
+  );
+
   const theta = (index * (2 * Math.PI)) / 6;
   const transform = useDerivedValue(() => {
     const { x, y } = polar2Canvas(
@@ -45,6 +49,12 @@ const Ring = ({ index, progress }: RingProps) => {
 };
 
 export const Breathe = () => {
+  const { width, height } = useWindowDimensions();
+  const center = useMemo(
+    () => vec(width / 2, height / 2 - 64),
+    [height, width]
+  );
+
   const progress = useLoop({
     duration: 3000,
     easing: Easing.inOut(Easing.ease),

--- a/example/src/Examples/Filters/Filters.tsx
+++ b/example/src/Examples/Filters/Filters.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions } from "react-native";
+import { useWindowDimensions } from "react-native";
 import {
   useImage,
   Canvas,
@@ -12,8 +12,6 @@ import {
   useLoop,
 } from "@shopify/react-native-skia";
 
-const { width, height } = Dimensions.get("window");
-
 const source = Skia.RuntimeEffect.Make(`
 uniform shader image;
 uniform float r;
@@ -24,6 +22,7 @@ half4 main(float2 xy) {
 }`)!;
 
 export const Filters = () => {
+  const { width, height } = useWindowDimensions();
   const progress = useLoop({ duration: 1500 });
 
   const uniforms = useDerivedValue(

--- a/example/src/Examples/Glassmorphism/Card.tsx
+++ b/example/src/Examples/Glassmorphism/Card.tsx
@@ -13,18 +13,21 @@ import {
   useDerivedValue,
   runDecay,
 } from "@shopify/react-native-skia";
-import React from "react";
-import { Dimensions } from "react-native";
+import React, { useMemo } from "react";
+import { useWindowDimensions } from "react-native";
 
 import { Background } from "./components/Background";
 import { Ball } from "./components/Ball";
 
-const { width, height } = Dimensions.get("window");
-const CARD_WIDTH = width - 64;
-const CARD_HEIGHT = CARD_WIDTH * 0.61;
-const clip = rrect(rect(0, 0, CARD_WIDTH, CARD_HEIGHT), 20, 20);
-
 export const Glassmorphism = () => {
+  const { width, height } = useWindowDimensions();
+  const CARD_WIDTH = width - 64;
+  const CARD_HEIGHT = CARD_WIDTH * 0.61;
+  const clip = useMemo(
+    () => rrect(rect(0, 0, CARD_WIDTH, CARD_HEIGHT), 20, 20),
+    [CARD_HEIGHT, CARD_WIDTH]
+  );
+
   const x = useValue((width - CARD_WIDTH) / 2);
   const y = useValue((height - CARD_HEIGHT) / 2);
   const offsetX = useValue(0);

--- a/example/src/Examples/Glassmorphism/Glassmorphism.tsx
+++ b/example/src/Examples/Glassmorphism/Glassmorphism.tsx
@@ -12,15 +12,18 @@ import {
   Blur,
   useDerivedValue,
 } from "@shopify/react-native-skia";
-import React from "react";
-import { Dimensions } from "react-native";
-
-const { width, height } = Dimensions.get("window");
-const c = vec(width / 2, height / 2);
-const r = c.x - 32;
-const rect = { x: 0, y: c.y, width, height: c.y };
+import React, { useMemo } from "react";
+import { useWindowDimensions } from "react-native";
 
 export const Glassmorphism = () => {
+  const { width, height } = useWindowDimensions();
+  const c = vec(width / 2, height / 2);
+  const r = c.x - 32;
+  const rect = useMemo(
+    () => ({ x: 0, y: c.y, width, height: c.y }),
+    [c.y, width]
+  );
+
   const progress = useLoop({ duration: 2000 });
   const start = useDerivedValue(
     () => sub(c, vec(0, mix(progress.current, r, r / 2))),

--- a/example/src/Examples/Glassmorphism/components/Background.tsx
+++ b/example/src/Examples/Glassmorphism/components/Background.tsx
@@ -1,12 +1,11 @@
 import { Fill, Group, Paint, rect } from "@shopify/react-native-skia";
 import React from "react";
-import { Dimensions } from "react-native";
+import { useWindowDimensions } from "react-native";
 
 import { BilinearGradient } from "../../Aurora/components/BilinearGradient";
 
-const { width, height } = Dimensions.get("window");
-
 export const Background = () => {
+  const { width, height } = useWindowDimensions();
   return (
     <Group>
       <Paint>

--- a/example/src/Examples/Gooey/Gooey.tsx
+++ b/example/src/Examples/Gooey/Gooey.tsx
@@ -20,14 +20,11 @@ import {
   Spring,
   createDerivedValue,
 } from "@shopify/react-native-skia";
-import { Dimensions } from "react-native";
+import { useWindowDimensions } from "react-native";
 
 import { Icon, R } from "./components/Icon";
 import { Hamburger } from "./components/Hamburger";
 import { BG, FG } from "./components/Theme";
-
-const { width, height } = Dimensions.get("window");
-const c = vec(width / 2, height / 2 - 64);
 
 const p1 = Skia.Path.MakeFromSVGString(
   "M 22.54 6.42 A 2.78 2.78 0 0 0 20.6 4.42 C 18.88 4 12 4 12 4 C 12 4 5.12 4 3.4 4.46 A 2.78 2.78 0 0 0 1.46 6.46 A 29 29 0 0 0 1 11.75 A 29 29 0 0 0 1.46 17.08 A 2.78 2.78 0 0 0 3.4 19 C 5.12 19.46 12 19.46 12 19.46 C 12 19.46 18.88 19.46 20.6 19 A 2.78 2.78 0 0 0 22.54 17 A 29 29 0 0 0 23 11.75 A 29 29 0 0 0 22.54 6.42 Z"
@@ -35,28 +32,40 @@ const p1 = Skia.Path.MakeFromSVGString(
 const p2 = Skia.Path.MakeFromSVGString(
   "M 9.75 15.02 L 15.5 11.75 L 9.75 8.48 L 9.75 15.02 Z"
 )!;
+
 const youtube = Skia.Path.MakeFromOp(p1, p2, PathOp.Difference)!;
 
-const icons = [
-  {
-    path: Skia.Path.MakeFromSVGString(
-      "M 23 3 A 10.9 10.9 0 0 1 19.86 4.53 A 4.48 4.48 0 0 0 12 7.53 L 12 8.53 A 10.66 10.66 0 0 1 3 4 C 3 4 -1 13 8 17 A 11.64 11.64 0 0 1 1 19 C 10 24 21 19 21 7.5 A 4.5 4.5 0 0 0 20.92 6.67 A 7.72 7.72 0 0 0 23 3 Z"
-    )!,
-    dst: rotate(vec(c.x + 150, c.y), c, Math.PI / 4),
-  },
-  {
-    path: Skia.Path.MakeFromSVGString(
-      "M 18 2 L 15 2 A 5 5 0 0 0 10 7 L 10 10 H 7 V 14 H 10 V 22 H 14 V 14 H 17 L 18 10 H 14 V 7 A 1 1 0 0 1 15 6 H 18 Z"
-    )!,
-    dst: rotate(vec(c.x + 150, c.y), c, Math.PI / 2),
-  },
-  {
-    path: youtube,
-    dst: rotate(vec(c.x + 150, c.y), c, 0.75 * Math.PI),
-  },
-];
+const icon1 = Skia.Path.MakeFromSVGString(
+  "M 23 3 A 10.9 10.9 0 0 1 19.86 4.53 A 4.48 4.48 0 0 0 12 7.53 L 12 8.53 A 10.66 10.66 0 0 1 3 4 C 3 4 -1 13 8 17 A 11.64 11.64 0 0 1 1 19 C 10 24 21 19 21 7.5 A 4.5 4.5 0 0 0 20.92 6.67 A 7.72 7.72 0 0 0 23 3 Z"
+)!;
+
+const icon2 = Skia.Path.MakeFromSVGString(
+  "M 18 2 L 15 2 A 5 5 0 0 0 10 7 L 10 10 H 7 V 14 H 10 V 22 H 14 V 14 H 17 L 18 10 H 14 V 7 A 1 1 0 0 1 15 6 H 18 Z"
+)!;
 
 export const Gooey = () => {
+  const { width, height } = useWindowDimensions();
+
+  const c = useMemo(() => vec(width / 2, height / 2 - 64), [height, width]);
+
+  const icons = useMemo(
+    () => [
+      {
+        path: icon1,
+        dst: rotate(vec(c.x + 150, c.y), c, Math.PI / 4),
+      },
+      {
+        path: icon2,
+        dst: rotate(vec(c.x + 150, c.y), c, Math.PI / 2),
+      },
+      {
+        path: youtube,
+        dst: rotate(vec(c.x + 150, c.y), c, 0.75 * Math.PI),
+      },
+    ],
+    [c]
+  );
+
   const paint = usePaintRef();
   const [toggled, setToggled] = useState(false);
   const onTouch = useTouchHandler({ onEnd: () => setToggled((t) => !t) });
@@ -70,7 +79,7 @@ export const Gooey = () => {
           [progress]
         )
       ),
-    [progress]
+    [c, icons, progress]
   );
 
   return (

--- a/example/src/Examples/Hue/Hue.tsx
+++ b/example/src/Examples/Hue/Hue.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import type { Color } from "@shopify/react-native-skia";
 import {
   Canvas,
@@ -14,13 +14,10 @@ import {
   polar2Canvas,
   Shader,
 } from "@shopify/react-native-skia";
-import { Dimensions } from "react-native";
+import { useWindowDimensions } from "react-native";
 
 import { polar2Color } from "./Helpers";
 
-const { width, height } = Dimensions.get("window");
-const c = vec(width / 2, height / 2);
-const center = vec(width / 2, height / 2);
 const source = Skia.RuntimeEffect.Make(`
 uniform float2 c;
 uniform float r;
@@ -39,6 +36,10 @@ half4 main(vec2 uv) {
 }`)!;
 
 export const Hue = () => {
+  const { width, height } = useWindowDimensions();
+  const c = vec(width / 2, height / 2);
+  const center = useMemo(() => vec(width / 2, height / 2), [height, width]);
+
   const r = (width - 32) / 2;
   const translateX = useValue(c.x);
   const translateY = useValue(c.y);

--- a/example/src/Examples/Matrix/Matrix.tsx
+++ b/example/src/Examples/Matrix/Matrix.tsx
@@ -7,8 +7,9 @@ import {
   useFont,
 } from "@shopify/react-native-skia";
 import React from "react";
+import { useWindowDimensions } from "react-native";
 
-import { COLS, ROWS, Symbol, SYMBOL } from "./Symbol";
+import { COLS, ROWS, Symbol } from "./Symbol";
 
 const cols = new Array(COLS).fill(0).map((_, i) => i);
 const rows = new Array(ROWS).fill(0).map((_, i) => i);
@@ -32,7 +33,9 @@ const streams = cols.map(() =>
 
 export const Matrix = () => {
   const clock = useClockValue();
-  const font = useFont(require("./matrix-code-nfi.otf"), SYMBOL.height);
+  const { width, height } = useWindowDimensions();
+  const symbol = { width: width / COLS, height: height / ROWS };
+  const font = useFont(require("./matrix-code-nfi.otf"), symbol.height);
   if (font === null) {
     return null;
   }
@@ -52,6 +55,7 @@ export const Matrix = () => {
               i={i}
               j={j}
               stream={streams[i]}
+              symbol={symbol}
             />
           ))
         )}

--- a/example/src/Examples/Matrix/Symbol.tsx
+++ b/example/src/Examples/Matrix/Symbol.tsx
@@ -6,12 +6,9 @@ import {
   vec,
   Glyphs,
 } from "@shopify/react-native-skia";
-import { Dimensions } from "react-native";
 
-const { width, height } = Dimensions.get("window");
 export const COLS = 5;
 export const ROWS = 10;
-export const SYMBOL = { width: width / COLS, height: height / ROWS };
 const pos = vec(0, 0);
 
 interface SymbolProps {
@@ -21,6 +18,7 @@ interface SymbolProps {
   stream: number[];
   font: SkFont;
   symbols: number[];
+  symbol: { width: number; height: number };
 }
 
 export const Symbol = ({
@@ -30,11 +28,12 @@ export const Symbol = ({
   stream,
   font,
   symbols,
+  symbol,
 }: SymbolProps) => {
   const offset = useRef(Math.round(Math.random() * (symbols.length - 1)));
   const range = useRef(100 + Math.random() * 900);
-  const x = i * SYMBOL.width;
-  const y = j * SYMBOL.height;
+  const x = i * symbol.width;
+  const y = j * symbol.height;
 
   const glyphs = useDerivedValue(() => {
     const idx = offset.current + Math.floor(timestamp.current / range.current);
@@ -58,8 +57,8 @@ export const Symbol = ({
 
   return (
     <Glyphs
-      x={x + SYMBOL.width / 4}
-      y={y + SYMBOL.height}
+      x={x + symbol.width / 4}
+      y={y + symbol.height}
       font={font}
       glyphs={glyphs}
       opacity={opacity}

--- a/example/src/Examples/Neumorphism/BoxShadow.tsx
+++ b/example/src/Examples/Neumorphism/BoxShadow.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   FitBox,
   Path,
@@ -12,15 +12,17 @@ import {
   Shadow,
   BoxShadow,
 } from "@shopify/react-native-skia";
-import { Dimensions } from "react-native";
-
-const { width } = Dimensions.get("window");
-const r = 150;
-const c = vec(width / 2, r);
-
-const rct = rrect(rect(c.x - r, c.y - r, 2 * r, 2 * r), r, r);
+import { useWindowDimensions } from "react-native";
 
 export const Neumorphism = () => {
+  const { width } = useWindowDimensions();
+  const r = 150;
+
+  const rct = useMemo(() => {
+    const c = vec(width / 2, r);
+    return rrect(rect(c.x - r, c.y - r, 2 * r, 2 * r), r, r);
+  }, [width]);
+
   const dx = 10;
   const dy = 10;
   return (

--- a/example/src/Examples/Neumorphism/Dashboard/Dashboard.tsx
+++ b/example/src/Examples/Neumorphism/Dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions } from "react-native";
+import { useWindowDimensions } from "react-native";
 import {
   runSpring,
   mix,
@@ -31,15 +31,15 @@ import { Mode } from "./components/Mode";
 import { Control } from "./components/Control";
 import { Snow } from "./components/icons/Snow";
 
-const window = Dimensions.get("window");
 const width = 390;
 const height = 844;
 const src = rect(0, 0, width, height);
-const dst = rect(0, 0, window.width, window.height);
-const rects = fitRects("cover", src, dst);
-const transform = rect2rect(rects.src, rects.dst);
 
 export const Neumorphism = () => {
+  const window = useWindowDimensions();
+  const dst = rect(0, 0, window.width, window.height);
+  const rects = fitRects("cover", src, dst);
+  const transform = rect2rect(rects.src, rects.dst);
   const translateY = useValue(0);
   const offsetY = useValue(0);
   const t = useLoop({ duration: 3000 });

--- a/example/src/Examples/Neumorphism/Elements/Elements.tsx
+++ b/example/src/Examples/Neumorphism/Elements/Elements.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions } from "react-native";
+import { useWindowDimensions } from "react-native";
 import {
   Canvas,
   Fill,
@@ -10,13 +10,13 @@ import {
 
 import { Switch } from "./components/Switch";
 
-const { width } = Dimensions.get("window");
 const PADDING = 32;
-const size = width - PADDING * 2;
 const x = PADDING;
 const y = 75;
 
 export const Neumorphism = () => {
+  const { width } = useWindowDimensions();
+  const size = width - PADDING * 2;
   const pressed = useValue(0);
   const onTouch = useTouchHandler({
     onStart: () => {

--- a/example/src/Examples/Severance/Severance.tsx
+++ b/example/src/Examples/Severance/Severance.tsx
@@ -8,19 +8,19 @@ import {
   useValue,
 } from "@shopify/react-native-skia";
 import React from "react";
-import { Dimensions } from "react-native";
+import { useWindowDimensions } from "react-native";
 
 import { CRT } from "./CRT";
-import { COLS, ROWS, SIZE, Symbol } from "./Symbol";
+import { COLS, ROWS, Symbol } from "./Symbol";
 import { BG } from "./Theme";
 
-const { width, height } = Dimensions.get("window");
-const rows = new Array(Math.round(COLS)).fill(0).map((_, i) => i);
-const cols = new Array(Math.round(ROWS)).fill(0).map((_, i) => i);
+const rows = new Array(COLS).fill(0).map((_, i) => i);
+const cols = new Array(ROWS).fill(0).map((_, i) => i);
 
 export const Severance = () => {
+  const { width, height } = useWindowDimensions();
   const clock = useClockValue();
-  const font = useFont(require("./SF-Mono-Medium.otf"), SIZE.height);
+  const font = useFont(require("./SF-Mono-Medium.otf"), height / ROWS);
   const pointer = useValue({ x: width / 2, y: height / 2 });
   const onTouch = useTouchHandler({
     onActive: (pt) => {

--- a/example/src/Examples/Severance/Symbol.tsx
+++ b/example/src/Examples/Severance/Symbol.tsx
@@ -13,15 +13,13 @@ import {
   Text,
 } from "@shopify/react-native-skia";
 import React from "react";
-import { Dimensions } from "react-native";
 import SimplexNoise from "simplex-noise";
+import { useWindowDimensions } from "react-native";
 
 import { FG } from "./Theme";
 
-const { width, height } = Dimensions.get("window");
 export const COLS = 5;
 export const ROWS = 10;
-export const SIZE = { width: width / COLS, height: height / ROWS };
 const DIGITS = new Array(10).fill(0).map((_, i) => `${i}`);
 const F = 0.0008;
 const R = 125;
@@ -36,6 +34,8 @@ interface SymbolProps {
 }
 
 export const Symbol = ({ i, j, font, pointer, clock }: SymbolProps) => {
+  const { width, height } = useWindowDimensions();
+  const SIZE = { width: width / COLS, height: height / ROWS };
   const x = i * SIZE.width;
   const y = j * SIZE.height;
   const noise = new SimplexNoise(`${i}-${j}`);

--- a/example/src/Examples/Wallet/Model.ts
+++ b/example/src/Examples/Wallet/Model.ts
@@ -1,14 +1,12 @@
 /* eslint-disable camelcase */
+import type { SkPath } from "@shopify/react-native-skia";
 import { Skia } from "@shopify/react-native-skia";
-import { Dimensions } from "react-native";
 
 import data from "./data.json";
 import { curveLines } from "./Math";
 
-export const WIDTH = Dimensions.get("window").width;
-export const HEIGHT = WIDTH / 2;
 export const PADDING = 16;
-export const AJUSTED_SIZE = HEIGHT - PADDING * 2;
+
 export const COLORS = ["#F69D69", "#FFC37D", "#61E0A1", "#31CBD1"].map(
   Skia.Color
 );
@@ -54,7 +52,13 @@ interface Prices {
 const values = data.data.prices as Prices;
 const POINTS = 20;
 
-const buildGraph = (datapoints: DataPoints, label: string) => {
+const buildGraph = (
+  datapoints: DataPoints,
+  label: string,
+  WIDTH: number,
+  HEIGHT: number
+) => {
+  const AJUSTED_SIZE = HEIGHT - PADDING * 2;
   const priceList = datapoints.prices.slice(0, POINTS);
   const formattedValues = priceList
     .map((price) => [parseFloat(price[0]), price[1]] as [number, number])
@@ -81,32 +85,46 @@ const buildGraph = (datapoints: DataPoints, label: string) => {
   };
 };
 
-export const graphs = [
+export interface Graph {
+  label: string;
+  value: number;
+  data: {
+    label: string;
+    minPrice: number;
+    maxPrice: number;
+    percentChange: number;
+    path: SkPath;
+  };
+}
+
+export type Graphs = Graph[];
+
+export const getGraph = (width: number, height: number) => [
   {
     label: "1H",
     value: 0,
-    data: buildGraph(values.hour, "Last Hour"),
+    data: buildGraph(values.hour, "Last Hour", width, height),
   },
   {
     label: "1D",
     value: 1,
-    data: buildGraph(values.day, "Today"),
+    data: buildGraph(values.day, "Today", width, height),
   },
   {
     label: "1M",
     value: 2,
-    data: buildGraph(values.month, "Last Month"),
+    data: buildGraph(values.month, "Last Month", width, height),
   },
   {
     label: "1Y",
     value: 3,
-    data: buildGraph(values.year, "This Year"),
+    data: buildGraph(values.year, "This Year", width, height),
   },
   {
     label: "All",
     value: 4,
-    data: buildGraph(values.all, "All time"),
+    data: buildGraph(values.all, "All time", width, height),
   },
-] as const;
+];
 
 export type GraphIndex = 0 | 1 | 2 | 3 | 4;

--- a/example/src/Examples/Wallet/components/Cursor.tsx
+++ b/example/src/Examples/Wallet/components/Cursor.tsx
@@ -8,18 +8,19 @@ import {
 } from "@shopify/react-native-skia";
 import React from "react";
 
-import { COLORS, WIDTH } from "../Model";
+import { COLORS } from "../Model";
 
 interface CursorProps {
   x: SkiaValue<number>;
   y: SkiaValue<number>;
+  width: number;
 }
 
-export const Cursor = ({ x, y }: CursorProps) => {
+export const Cursor = ({ x, y, width }: CursorProps) => {
   const color = useDerivedValue(
     () =>
       interpolateColors(
-        x.current / WIDTH,
+        x.current / width,
         COLORS.map((_, i) => i / COLORS.length),
         COLORS
       ),

--- a/example/src/Examples/Wallet/components/Label.tsx
+++ b/example/src/Examples/Wallet/components/Label.tsx
@@ -7,10 +7,12 @@ import {
 } from "@shopify/react-native-skia";
 import React from "react";
 
-import { graphs, AJUSTED_SIZE, WIDTH, HEIGHT, PADDING } from "../Model";
+import type { Graphs } from "../Model";
+import { PADDING } from "../Model";
 
 import type { GraphState } from "./Selection";
 
+const sfMono = require("../../Severance/SF-Mono-Medium.otf");
 const format = (value: number) =>
   "$ " +
   Math.round(value)
@@ -20,12 +22,17 @@ const format = (value: number) =>
 interface LabelProps {
   y: SkiaValue<number>;
   state: SkiaValue<GraphState>;
+  graphs: Graphs;
+  width: number;
+  height: number;
 }
 
-export const Label = ({ state, y }: LabelProps) => {
-  const titleFont = useFont("helvetica", 64)!;
-  const subtitleFont = useFont("helvetica", 24)!;
-  const translateY = HEIGHT + PADDING;
+export const Label = ({ state, y, graphs, width, height }: LabelProps) => {
+  const titleFont = useFont(sfMono, 64);
+  const subtitleFont = useFont(sfMono, 24);
+  console.log({ titleFont });
+  const translateY = height + PADDING;
+  const AJUSTED_SIZE = height - PADDING * 2;
   const text = useDerivedValue(() => {
     const graph = graphs[state.current.current];
     return format(
@@ -38,11 +45,17 @@ export const Label = ({ state, y }: LabelProps) => {
   }, [y, state]);
   const subtitle = "+ $314,15";
   const titleX = useDerivedValue(() => {
+    if (!titleFont) {
+      return 0;
+    }
     const graph = graphs[state.current.current];
     return (
-      WIDTH / 2 - titleFont.measureText(format(graph.data.maxPrice)).width / 2
+      width / 2 - titleFont.measureText(format(graph.data.maxPrice)).width / 2
     );
-  }, [state]);
+  }, [state, titleFont]);
+  if (!titleFont || !subtitleFont) {
+    return null;
+  }
   const subtitlePos = subtitleFont.measureText(subtitle);
   return (
     <>
@@ -54,7 +67,7 @@ export const Label = ({ state, y }: LabelProps) => {
         color="white"
       />
       <Text
-        x={WIDTH / 2 - subtitlePos.width / 2}
+        x={width / 2 - subtitlePos.width / 2}
         y={translateY - 60}
         text={subtitle}
         font={subtitleFont}

--- a/example/src/Examples/Wallet/components/Selection.tsx
+++ b/example/src/Examples/Wallet/components/Selection.tsx
@@ -13,9 +13,9 @@ import {
   mix,
 } from "@shopify/react-native-skia";
 
-import { graphs, WIDTH } from "../Model";
+import type { Graphs } from "../Model";
 
-const buttonWidth = (WIDTH - 32) / graphs.length;
+const buttonWidth = 50;
 const styles = StyleSheet.create({
   root: {
     paddingHorizontal: 16,
@@ -49,9 +49,10 @@ export interface GraphState {
 interface SelectionProps {
   state: SkiaMutableValue<GraphState>;
   transition: SkiaMutableValue<number>;
+  graphs: Graphs;
 }
 
-export const Selection = ({ state, transition }: SelectionProps) => {
+export const Selection = ({ state, transition, graphs }: SelectionProps) => {
   const transform = useDerivedValue(() => {
     const { current, next } = state.current;
     return [

--- a/example/src/Examples/Wallet/components/useGraphTouchHandler.ts
+++ b/example/src/Examples/Wallet/components/useGraphTouchHandler.ts
@@ -9,14 +9,15 @@ import {
   useTouchHandler,
 } from "@shopify/react-native-skia";
 
-import { HEIGHT, PADDING, WIDTH } from "../Model";
-
-const translateY = HEIGHT + PADDING;
+import { PADDING } from "../Model";
 
 export const useGraphTouchHandler = (
   x: SkiaMutableValue<number>,
-  y: SkiaValue<number>
+  y: SkiaValue<number>,
+  width: number,
+  height: number
 ) => {
+  const translateY = height + PADDING;
   const gestureActive = useValue(false);
   const offsetX = useValue(0);
   const onTouch = useTouchHandler({
@@ -32,13 +33,13 @@ export const useGraphTouchHandler = (
     },
     onActive: (pos) => {
       if (gestureActive.current) {
-        x.current = clamp(offsetX.current + pos.x, 0, WIDTH);
+        x.current = clamp(offsetX.current + pos.x, 0, width);
       }
     },
     onEnd: ({ velocityX }) => {
       if (gestureActive.current) {
         gestureActive.current = false;
-        runDecay(x, { velocity: velocityX, clamp: [0, WIDTH] });
+        runDecay(x, { velocity: velocityX, clamp: [0, width] });
       }
     },
   });

--- a/example/src/Examples/Wallpaper/Wallpaper.tsx
+++ b/example/src/Examples/Wallpaper/Wallpaper.tsx
@@ -11,15 +11,15 @@ import {
   Turbulence,
 } from "@shopify/react-native-skia";
 import React from "react";
-import { Dimensions } from "react-native";
+import { useWindowDimensions } from "react-native";
 
-const { height, width: wWidth } = Dimensions.get("window");
 const length = 9;
 const STRIPES = new Array(length).fill(0).map((_, i) => i);
-const width = wWidth / length;
-const origin = vec(width / 2, height / 2);
 
 export const Wallpaper = () => {
+  const { height, width: wWidth } = useWindowDimensions();
+  const width = wWidth / length;
+  const origin = vec(width / 2, height / 2);
   return (
     <Canvas style={{ flex: 1 }}>
       <Fill>


### PR DESCRIPTION
In React Native Web the screen is resized more often than on mobile, and instead of statically saving the window width/height on module import (as we currently do in most of our examples) we should depend on the useWindowDimensions() hook.

This will help making the examples on Web (and when rotating the screen on mobile) look correct even after the browser window is resized.

This PR is still a draft since there are some examples that haven't yet been fixed due to either complexity or other constants that haven't been resolved:

- [ ] Backface.tsx
- [ ] Symbol.tsx
- [ ] Dashboard.tsx
- [ ] CRT.tsx
- [ ] Severance.tsx
- [ ] Symbol.tsx
- [ ] Model.tsx