### PR TITLE
docs: add Android proguard rules in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ And then the _SDK Location_ section. It will show you the NDK path, or the optio
 
 And them the _Modules_ section. click on `shopify_react-native-skia` and select _NDK version_ with dropdown, and click on apply.
 
+#### Proguard
+
+If you're using Proguard, make sure to add the following rule:
+
+```
+-keep class com.shopify.reactnative.skia.** { *; }
+```
+
 #### TroubleShooting
 
 For error **_CMake 'X.X.X' was not found in SDK, PATH, or by cmake.dir property._**

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -35,6 +35,14 @@ If the NDK is not installed, you can install it via Android Studio by going to t
 
 And then the _SDK Location_ section. It will show you the NDK path, or the option to download it if you don't have it installed.
 
+### Proguard
+
+If you're using Proguard, make sure to add the following rule:
+
+```
+-keep class com.shopify.reactnative.skia.** { *; }
+```
+
 ## Playground
 
 We have an example project you can play with [here](https://github.com/Shopify/react-native-skia/tree/main/example).

--- a/package/README.md
+++ b/package/README.md
@@ -31,6 +31,14 @@ If the NDK is not installed, you can install it via Android Studio by going to t
 
 And then the _SDK Location_ section. It will show you the NDK path, or the option to download it if you don't have it installed.
 
+### Proguard
+
+If you're using Proguard, make sure to add the following rule:
+
+```
+-keep class com.shopify.reactnative.skia.** { *; }
+```
+
 ## Playground
 
 We have an example project you can play with [here](https://github.com/Shopify/react-native-skia/tree/main/example).


### PR DESCRIPTION
When proguard is enabled on release builds, some classes were throwing exceptions and we should prevent them from being obfuscated.

This PR adds a small note in the installation guides to add a rule in `proguard-rules.pro`:

```
-keep class com.shopify.reactnative.skia.** { *; }
```