### PR TITLE
Bugfix: useRawData internal cache purge

### DIFF
--- a/example/src/Examples/API/Images.tsx
+++ b/example/src/Examples/API/Images.tsx
@@ -36,6 +36,7 @@ export const Images = () => {
   useImage(undefined);
 
   const oslo = useImage(require("../../assets/oslo.jpg"));
+  const coffee = useImage("https://picsum.photos/id/1060/640/360");
 
   const { width: wWidth } = useWindowDimensions();
   const SIZE = wWidth / 3;
@@ -84,6 +85,25 @@ export const Images = () => {
           </Canvas>
         </React.Fragment>
       ))}
+      {coffee ? (
+        <Canvas
+          style={{
+            alignSelf: "center",
+            width: 320,
+            height: 180,
+            marginVertical: PAD,
+          }}
+        >
+          <Image
+            image={coffee}
+            x={0}
+            y={0}
+            width={320}
+            height={180}
+            fit="contain"
+          />
+        </Canvas>
+      ) : null}
     </ScrollView>
   );
 };

--- a/package/src/skia/core/Data.ts
+++ b/package/src/skia/core/Data.ts
@@ -62,9 +62,10 @@ export const useRawData = <T>(
               : Image.resolveAssetSource(source).uri;
           Skia.Data.fromURI(uri).then((d) => factoryWrapper(d));
         }
+      } else {
+        // new source is null or undefined -> remove cached data
+        setData(null);
       }
-    } else {
-      setData(null);
     }
   }, [factory, onError, source]);
   return data;


### PR DESCRIPTION
- fix(use-raw-data): correct useRawData internal data purge
  - only reset data if new source is null or undefined, not if it is same as previous one

Fixes #571