### PR TITLE
Use bridge instance as singleton

### DIFF
--- a/package/ios/RNSkiaModule.h
+++ b/package/ios/RNSkiaModule.h
@@ -7,5 +7,6 @@
 @interface RNSkiaModule : NSObject <RCTBridgeModule>
 
 - (SkiaManager *)manager;
+- (RCTBridge *)appBridge;
 
 @end

--- a/package/ios/RNSkiaModule.mm
+++ b/package/ios/RNSkiaModule.mm
@@ -4,6 +4,7 @@
 
 @implementation RNSkiaModule {
   SkiaManager* skiaManager;
+  RCTBridge* appBridge;
 }
 
 RCT_EXPORT_MODULE(RNSkia)
@@ -34,8 +35,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install)
     // Already initialized, ignore call.
     return @true;
   }
-  RCTBridge* bridge = [RCTBridge currentBridge];
-  skiaManager = [[SkiaManager alloc] initWithBridge:bridge];
+  if (appBridge == nil) {
+    appBridge = [RCTBridge currentBridge];
+  }
+  skiaManager = [[SkiaManager alloc] initWithBridge:appBridge];
   return @true;
 }
 


### PR DESCRIPTION
fixes #106 

The goal of this PR is to provide a patch symmetric to https://github.com/expo/expo/pull/17780, the assumption being that on an Expo dev client at the moment, the install method is invoked more than once and with a different instance of the bridge every time, causing the crash.