### PR TITLE
iOS: Fixed compile warning in JsiSkShaderBuilder.h

### DIFF
--- a/package/cpp/api/JsiSkRuntimeShaderBuilder.h
+++ b/package/cpp/api/JsiSkRuntimeShaderBuilder.h
@@ -39,7 +39,7 @@ namespace RNSkia {
                 auto e = jsiValue.getValueAtIndex(runtime, i).asNumber();
                 value.push_back(e);
             }
-            getObject()->uniform(name.c_str()).set(value.data(), (int)size);
+            getObject()->uniform(name.c_str()).set(value.data(), static_cast<int>(size));
             return jsi::Value::undefined();
         }
 

--- a/package/cpp/api/JsiSkRuntimeShaderBuilder.h
+++ b/package/cpp/api/JsiSkRuntimeShaderBuilder.h
@@ -39,7 +39,7 @@ namespace RNSkia {
                 auto e = jsiValue.getValueAtIndex(runtime, i).asNumber();
                 value.push_back(e);
             }
-            getObject()->uniform(name.c_str()).set(value.data(), size);
+            getObject()->uniform(name.c_str()).set(value.data(), (int)size);
             return jsi::Value::undefined();
         }
 


### PR DESCRIPTION
After adding uniforms in Runtime shaders (#561) a small regression resulted in a warning when casting from size_t to int when setting uniforms. 

This PR fixes this by casting from long (size_t) -> int.