### PR TITLE
Fix Image loading on RN Web

### DIFF
--- a/package/src/skia/__tests__/Drawings.spec.ts
+++ b/package/src/skia/__tests__/Drawings.spec.ts
@@ -85,4 +85,12 @@ describe("Drawings", () => {
     canvas.drawColor(Skia.Color("purple"));
     processResult(surface, "snapshots/drawings/purple.png");
   });
+
+  it("Should accept object implementation of SkRect", () => {
+    const { surface, canvas, Skia } = setupSkia();
+    const paint = Skia.Paint();
+    paint.setColor(Skia.Color("lightblue"));
+    canvas.drawRect({ x: 64, y: 64, width: 128, height: 128 }, paint);
+    processResult(surface, "snapshots/drawings/lightblue-rect.png");
+  });
 });

--- a/package/src/skia/core/Data.ts
+++ b/package/src/skia/core/Data.ts
@@ -1,9 +1,15 @@
 import type { DependencyList } from "react";
 import { useRef, useEffect, useState } from "react";
-import { Image } from "react-native";
+import { Image, Platform } from "react-native";
 
 import { Skia } from "../Skia";
 import type { SkData, DataSource } from "../types";
+
+const resolveAsset = (source: ReturnType<typeof require>) => {
+  return Platform.OS === "web"
+    ? source.default
+    : Image.resolveAssetSource(source).uri;
+};
 
 export const useDataCollection = <T>(
   sources: DataSource[],
@@ -16,9 +22,7 @@ export const useDataCollection = <T>(
       if (source instanceof Uint8Array) {
         return source;
       }
-      return typeof source === "string"
-        ? source
-        : Image.resolveAssetSource(source).uri;
+      return typeof source === "string" ? source : resolveAsset(source);
     });
     Promise.all(
       bytesOrURIs.map((bytesOrURI) =>
@@ -57,9 +61,7 @@ export const useRawData = <T>(
           factoryWrapper(Skia.Data.fromBytes(source));
         } else {
           const uri =
-            typeof source === "string"
-              ? source
-              : Image.resolveAssetSource(source).uri;
+            typeof source === "string" ? source : resolveAsset(source);
           Skia.Data.fromURI(uri).then((d) => factoryWrapper(d));
         }
       } else {

--- a/package/src/skia/web/JsiSkCanvas.ts
+++ b/package/src/skia/web/JsiSkCanvas.ts
@@ -1,4 +1,4 @@
-import type { CanvasKit, Canvas, Image, Paint, Rect } from "canvaskit-wasm";
+import type { Canvas, Image, Paint, CanvasKit } from "canvaskit-wasm";
 
 import type {
   BlendMode,
@@ -31,6 +31,7 @@ import {
   toUndefinedableValue,
   toOptionalValue,
 } from "./Host";
+import { JsiSkRect } from "./JsiSkRect";
 
 export class JsiSkCanvas
   extends HostObject<Canvas, "Canvas">
@@ -41,7 +42,10 @@ export class JsiSkCanvas
   }
 
   drawRect(rect: SkRect, paint: SkPaint) {
-    this.ref.drawRect(toValue<Rect>(rect), toValue<Paint>(paint));
+    this.ref.drawRect(
+      JsiSkRect.fromValue(this.CanvasKit, rect).ref,
+      toValue<Paint>(paint)
+    );
   }
 
   drawImage(image: SkImage, x: number, y: number, paint?: SkPaint) {
@@ -57,8 +61,8 @@ export class JsiSkCanvas
   ) {
     this.ref.drawImageRect(
       toValue<Image>(img),
-      toValue<Rect>(src),
-      toValue<Rect>(dest),
+      JsiSkRect.fromValue(this.CanvasKit, src).ref,
+      JsiSkRect.fromValue(this.CanvasKit, dest).ref,
       toValue<Paint>(paint),
       fastSample
     );
@@ -126,8 +130,8 @@ export class JsiSkCanvas
   ) {
     this.ref.drawImageRectCubic(
       toValue<Image>(img),
-      toValue<Rect>(src),
-      toValue<Rect>(dest),
+      JsiSkRect.fromValue(this.CanvasKit, src).ref,
+      JsiSkRect.fromValue(this.CanvasKit, dest).ref,
       B,
       C,
       toOptionalValue(paint)
@@ -144,8 +148,8 @@ export class JsiSkCanvas
   ) {
     this.ref.drawImageRectOptions(
       toValue<Image>(img),
-      toValue<Rect>(src),
-      toValue<Rect>(dest),
+      JsiSkRect.fromValue(this.CanvasKit, src).ref,
+      JsiSkRect.fromValue(this.CanvasKit, dest).ref,
       ckEnum(fm),
       ckEnum(mm),
       toOptionalValue(paint)

--- a/package/src/skia/web/JsiSkRect.ts
+++ b/package/src/skia/web/JsiSkRect.ts
@@ -5,6 +5,16 @@ import type { SkRect } from "../types";
 import { HostObject } from "./Host";
 
 export class JsiSkRect extends HostObject<Rect, "Rect"> implements SkRect {
+  static fromValue(CanvasKit: CanvasKit, rect: SkRect) {
+    if (rect instanceof JsiSkRect) {
+      return rect;
+    }
+    return new JsiSkRect(
+      CanvasKit,
+      CanvasKit.XYWHRect(rect.x, rect.y, rect.width, rect.height)
+    );
+  }
+
   constructor(CanvasKit: CanvasKit, ref: Rect) {
     super(CanvasKit, ref, "Rect");
   }


### PR DESCRIPTION
This PR fixes image loading on web:
* By using Image.resolveAsset only on React Native
* Fix a bug in JsiSkCanvas where objects implementing SkRect wouldn't be transformed to a JsiSkRect