### PR TITLE
MakeFreeTypeFaceFromData should return null when inner typeface object is null

### DIFF
--- a/package/cpp/api/JsiSkTypefaceFactory.h
+++ b/package/cpp/api/JsiSkTypefaceFactory.h
@@ -17,8 +17,12 @@ namespace RNSkia {
     public:
         JSI_HOST_FUNCTION(MakeFreeTypeFaceFromData) {
             auto data = JsiSkData::fromValue(runtime, arguments[0]);
+            auto typeface = SkFontMgr::RefDefault()->makeFromData(std::move(data));
+            if(typeface == nullptr) {
+              return jsi::Value::null();
+            }
             return jsi::Object::createFromHostObject(
-                runtime, std::make_shared<JsiSkTypeface>(getContext(), SkFontMgr::RefDefault()->makeFromData(std::move(data))));
+                runtime, std::make_shared<JsiSkTypeface>(getContext(), typeface));
         }
 
         JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkTypefaceFactory, MakeFreeTypeFaceFromData))


### PR DESCRIPTION
When calling `JsiSkTypefaceFactory.MakeFreeTypeFaceFromData` the current implementation may return a `JsiSkTypeface` object wrapping a nullptr for the SkTypeface inner object.

This PR fixes this so that `JsiSkTypefaceFactory.MakeFreeTypeFaceFromData` correctly returns null when there is no SkTypeface object returned from `SkFontMgr::RefDefault()->makeFromData`.

Fixes #313