### PR TITLE
#584 Deprecate JsiSkTypeface bold italic props

### DIFF
--- a/package/cpp/api/JsiSkTypeface.h
+++ b/package/cpp/api/JsiSkTypeface.h
@@ -6,6 +6,7 @@
 #include <jsi/jsi.h>
 
 #include "JsiSkHostObjects.h"
+#include <RNSkLog.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
@@ -21,8 +22,16 @@ using namespace facebook;
 
 class JsiSkTypeface : public JsiSkWrappingSkPtrHostObject<SkTypeface> {
 public:
-  JSI_PROPERTY_GET(bold) { return jsi::Value(getObject()->isBold()); }
-  JSI_PROPERTY_GET(italic) { return jsi::Value(getObject()->isItalic()); }
+  JSI_PROPERTY_GET(bold) {
+    RNSkLogger::warnToJavascriptConsole(runtime, "Typeface.bold is deprecated and will be removed in a future release.");
+    return jsi::Value(getObject()->isBold());
+  }
+  
+  JSI_PROPERTY_GET(italic) {
+    RNSkLogger::warnToJavascriptConsole(runtime, "Typeface.italic is deprecated and will be removed in a future release.");
+    return jsi::Value(getObject()->isItalic());
+  }
+  
   // TODO: declare in JsiSkWrappingSkPtrHostObject via extra template parameter?
   JSI_PROPERTY_GET(__typename__) {
     return jsi::String::createFromUtf8(runtime, "Typeface");

--- a/package/cpp/utils/RNSkLog.h
+++ b/package/cpp/utils/RNSkLog.h
@@ -49,5 +49,27 @@ public:
 #endif
     va_end(args);
   }
+  
+  static void logToJavascriptConsole(jsi::Runtime& runtime, const std::string& message) {
+    auto console = RNSkLogger::getJavascriptConsole(runtime).asObject(runtime);
+    auto log = console.getPropertyAsFunction(runtime, "log");
+    log.call(runtime, jsi::String::createFromUtf8(runtime, message));
+  }
+  
+  static void warnToJavascriptConsole(jsi::Runtime& runtime, const std::string& message) {
+    auto console = RNSkLogger::getJavascriptConsole(runtime).asObject(runtime);
+    auto warn = console.getPropertyAsFunction(runtime, "warn");
+    warn.call(runtime, jsi::String::createFromUtf8(runtime, message));
+  }
+  
+private:
+  static jsi::Value getJavascriptConsole(jsi::Runtime& runtime) {
+    auto console = runtime.global().getProperty(runtime, "console");
+    if(console.isUndefined() || console.isNull()) {
+      jsi::detail::throwJSError(runtime, "Could not find console object.");
+      return jsi::Value::undefined();
+    }
+    return console;
+  }
 };
 } // namespace RNSkia

--- a/package/src/skia/web/JsiSkTypeface.ts
+++ b/package/src/skia/web/JsiSkTypeface.ts
@@ -13,8 +13,6 @@ export class JsiSkTypeface
   }
 
   get bold(): boolean {
-    // Do not remove the comment below. We use it to track missing APIs in CanvasKit
-    // throw new NotImplementedOnRNWeb();
     console.warn(
       "Typeface.bold is deprecated and will be removed in a future release. The property will return false."
     );
@@ -22,8 +20,6 @@ export class JsiSkTypeface
   }
 
   get italic(): boolean {
-    // Do not remove the comment below. We use it to track missing APIs in CanvasKit
-    // throw new NotImplementedOnRNWeb();
     console.warn(
       "Typeface.italic is deprecated and will be removed in a future release. The property will return false."
     );

--- a/package/src/skia/web/JsiSkTypeface.ts
+++ b/package/src/skia/web/JsiSkTypeface.ts
@@ -2,7 +2,7 @@ import type { CanvasKit, Typeface } from "canvaskit-wasm";
 
 import type { SkTypeface } from "../types";
 
-import { HostObject, NotImplementedOnRNWeb } from "./Host";
+import { HostObject } from "./Host";
 
 export class JsiSkTypeface
   extends HostObject<Typeface, "Typeface">
@@ -13,10 +13,20 @@ export class JsiSkTypeface
   }
 
   get bold(): boolean {
-    throw new NotImplementedOnRNWeb();
+    // Do not remove the comment below. We use it to track missing APIs in CanvasKit
+    // throw new NotImplementedOnRNWeb();
+    console.warn(
+      "Typeface.bold is deprecated and will be removed in a future release. The property will return false."
+    );
+    return false;
   }
 
   get italic(): boolean {
-    throw new NotImplementedOnRNWeb();
+    // Do not remove the comment below. We use it to track missing APIs in CanvasKit
+    // throw new NotImplementedOnRNWeb();
+    console.warn(
+      "Typeface.italic is deprecated and will be removed in a future release. The property will return false."
+    );
+    return false;
   }
 }


### PR DESCRIPTION
To align APIs with CanvasKit we're removing the `bold`/`italic` props from the `JsiSkTypeface` class. 

This PR adds deprecation warnings, the issue #584 is still open and should be implemented and merged in a later release.

Related to #584 