### PR TITLE
Fixed wrong font used in AnimatedTextOnPath

### DIFF
--- a/example/src/Examples/Animation/AnimateTextOnPath.tsx
+++ b/example/src/Examples/Animation/AnimateTextOnPath.tsx
@@ -14,11 +14,12 @@ import {
 import { AnimationDemo, Padding } from "./Components";
 
 const ExampleHeight = 60;
+const Font = require("../../assets/SF-Mono-Semibold.otf");
 
 export const AnimateTextOnPath = () => {
   const { width } = useWindowDimensions();
 
-  const font = useFont("helvetica", 14);
+  const font = useFont(Font, 12);
 
   // Create a progress going from 0..1 and back
   const progress = useLoop({


### PR DESCRIPTION
The example `AnimatedTextOnPath.tsx` used a wrong typeface for the `useFont` hook. Previously doing this resulted in a default font, but after #585 was landed it results in a null font and no rendering of the text.

This PR fixes this issue.