### PR TITLE
Removed unused code path from useFont

### DIFF
--- a/package/src/skia/core/Font.ts
+++ b/package/src/skia/core/Font.ts
@@ -23,7 +23,7 @@ export const useFont = (
     } else if (typeface && !size) {
       return Skia.Font(typeface);
     } else {
-      return Skia.Font();
+      return null;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [typeface]);


### PR DESCRIPTION
After landing #585 we ended up with an invalid code path.

This commit fixes this by returning null instead of a default font.