### PR TITLE
Fixed regression on Android in RNSkLog

### DIFF
--- a/package/cpp/utils/RNSkLog.h
+++ b/package/cpp/utils/RNSkLog.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <string>
+#include <jsi/jsi.h>
+
 #ifdef ANDROID
 #include <android/log.h>
 #endif
@@ -14,6 +16,9 @@
 #endif
 
 namespace RNSkia {
+
+using namespace facebook;
+
 class RNSkLogger {
 public:
   /**


### PR DESCRIPTION
After adding logging and warning to JS console in RNSkLog.h we found a regression that made Android fail to build.

This is a fix that includes the necessary includes and namespace imports to fix it.