### PR TITLE
Remove unnecessary configuration directive

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -60,7 +60,6 @@ const fontLoaderConfiguration = {
 };
 
 module.exports = {
-  experiments: { asyncWebAssembly: true },
   entry: {
     app: path.join(__dirname, "index.web.js"),
   },


### PR DESCRIPTION
Since we are not loading canvaskit-wasm ourselves, this configuration clause doesn't seem to be needed. The idea behind removing it is not confuse user that this might be needed as an installation/configuration step for React Native Web