### PR TITLE
CanvasKit Adjustments

### DIFF
--- a/package/patches/canvaskit-wasm+0.34.0.patch
+++ b/package/patches/canvaskit-wasm+0.34.0.patch
@@ -1,54 +1,14 @@
-diff --git a/node_modules/canvaskit-wasm/package.json b/node_modules/canvaskit-wasm/package.json
-index cc970b8..aac112d 100644
---- a/node_modules/canvaskit-wasm/package.json
-+++ b/node_modules/canvaskit-wasm/package.json
-@@ -2,7 +2,7 @@
-   "name": "canvaskit-wasm",
-   "version": "0.34.0",
-   "description": "A WASM version of Skia's Canvas API",
--  "main": "bin/canvaskit.js",
-+  "main": "bin/full/canvaskit.js",
-   "homepage": "https://github.com/google/skia/tree/main/modules/canvaskit",
-   "bugs": {
-     "url": "https://bugs.chromium.org/p/skia/issues/entry"
 diff --git a/node_modules/canvaskit-wasm/types/index.d.ts b/node_modules/canvaskit-wasm/types/index.d.ts
-index 3abbcc3..30dc4e3 100644
+index 3abbcc3..88fcb2b 100644
 --- a/node_modules/canvaskit-wasm/types/index.d.ts
 +++ b/node_modules/canvaskit-wasm/types/index.d.ts
 @@ -1,5 +1,5 @@
  // Minimum TypeScript Version: 3.7
 -export function CanvasKitInit(opts: CanvasKitInitOptions): Promise<CanvasKit>;
-+export default function CanvasKitInit(opts?: CanvasKitInitOptions): Promise<CanvasKit>;
++export default function CanvasKitInit(opts: CanvasKitInitOptions): Promise<CanvasKit>;
  
  export interface CanvasKitInitOptions {
      /**
-@@ -366,7 +366,7 @@ export interface CanvasKit {
-      */
-     MakeVertices(mode: VertexMode, positions: InputFlattenedPointArray,
-                  textureCoordinates?: InputFlattenedPointArray | null,
--                 colors?: Float32Array | ColorIntArray | null, indices?: number[] | null,
-+                 colors?: Float32Array[] | ColorIntArray[] | null, indices?: number[] | null,
-                  isVolatile?: boolean): Vertices;
- 
-     /**
-@@ -847,7 +847,7 @@ export interface Paragraph extends EmbindObject<Paragraph> {
-     getMaxIntrinsicWidth(): number;
-     getMaxWidth(): number;
-     getMinIntrinsicWidth(): number;
--    getRectsForPlaceholders(): FlattenedRectangleArray;
-+    getRectsForPlaceholders(): FlattenedRectangleArray[];
- 
-     /**
-      * Returns bounding boxes that enclose all text in the range of glpyh indexes [start, end).
-@@ -857,7 +857,7 @@ export interface Paragraph extends EmbindObject<Paragraph> {
-      * @param wStyle
-      */
-     getRectsForRange(start: number, end: number, hStyle: RectHeightStyle,
--                     wStyle: RectWidthStyle): FlattenedRectangleArray;
-+                     wStyle: RectWidthStyle): FlattenedRectangleArray[];
- 
-     /**
-      * Finds the first and last glyphs that define a word containing the glyph at index offset.
 @@ -1983,7 +1983,7 @@ export interface Paint extends EmbindObject<Paint> {
       * Sets the current color filter, replacing the existing one if there was one.
       * @param filter
@@ -88,12 +48,3 @@ index 3abbcc3..30dc4e3 100644
  
      /**
       * Sets the geometry drawn at the beginning and end of strokes.
-@@ -3440,7 +3440,7 @@ export interface ShaderFactory {
-      * @param color
-      * @param space
-      */
--    MakeColor(color: InputColor, space: ColorSpace): Shader;
-+    MakeColor(color: InputColor, space?: ColorSpace): Shader;
- 
-     /**
-      * Returns a shader with Perlin Fractal Noise.

--- a/package/src/renderer/__tests__/setup.tsx
+++ b/package/src/renderer/__tests__/setup.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import CanvasKitInit from "canvaskit-wasm";
 import type { ReactNode } from "react";
 import ReactReconciler from "react-reconciler";
 
@@ -10,12 +9,13 @@ import { Container } from "../nodes";
 import type { DrawingContext } from "../DrawingContext";
 import { CanvasProvider } from "../useCanvas";
 import { ValueApi } from "../../values/web";
+import { LoadSkia } from "../../web";
 
 export let Skia: ReturnType<typeof JsiSkApi>;
 
 beforeAll(async () => {
-  const CanvasKit = await CanvasKitInit();
-  Skia = JsiSkApi(CanvasKit);
+  await LoadSkia();
+  Skia = JsiSkApi(global.CanvasKit);
 });
 
 export const width = 256;

--- a/package/src/skia/__tests__/setup.ts
+++ b/package/src/skia/__tests__/setup.ts
@@ -1,13 +1,12 @@
-import CanvasKitInit from "canvaskit-wasm";
-
+import { LoadSkia } from "../../web";
 import { Skia } from "../types";
 import { JsiSkApi } from "../web";
 
 let Skia: ReturnType<typeof JsiSkApi>;
 
 beforeAll(async () => {
-  const CanvasKit = await CanvasKitInit();
-  Skia = JsiSkApi(CanvasKit);
+  await LoadSkia();
+  Skia = JsiSkApi(global.CanvasKit);
 });
 
 export const setupSkia = () => {

--- a/package/src/skia/web/JsiSkFontMgr.ts
+++ b/package/src/skia/web/JsiSkFontMgr.ts
@@ -9,10 +9,6 @@ export class JsiSkFontMgr
   implements SkFontMgr
 {
   constructor(CanvasKit: CanvasKit) {
-    console.warn(
-      // eslint-disable-next-line max-len
-      "Using system fonts is deprecated. Please use the font property instead: https://shopify.github.io/react-native-skia/docs/text/fonts"
-    );
     super(CanvasKit, null, "FontMgr");
   }
 

--- a/package/src/skia/web/JsiSkShaderFactory.ts
+++ b/package/src/skia/web/JsiSkShaderFactory.ts
@@ -172,7 +172,10 @@ export class JsiSkShaderFactory extends Host implements ShaderFactory {
   MakeColor(color: SkColor) {
     return new JsiSkShader(
       this.CanvasKit,
-      this.CanvasKit.Shader.MakeColor(toValue(color))
+      this.CanvasKit.Shader.MakeColor(
+        toValue(color),
+        this.CanvasKit.ColorSpace.SRGB
+      )
     );
   }
 }

--- a/package/src/skia/web/JsiSkVerticesFactory.ts
+++ b/package/src/skia/web/JsiSkVerticesFactory.ts
@@ -5,6 +5,20 @@ import type { SkColor, SkPoint, VertexMode } from "../types";
 import { ckEnum } from "./Host";
 import { JsiSkVertices } from "./JsiSkVertices";
 
+const concat = (...arrays: Float32Array[]) => {
+  let totalLength = 0;
+  for (const arr of arrays) {
+    totalLength += arr.length;
+  }
+  const result = new Float32Array(totalLength);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+};
+
 export const MakeVertices = (
   CanvasKit: CanvasKit,
   mode: VertexMode,
@@ -20,7 +34,7 @@ export const MakeVertices = (
       ckEnum(mode),
       positions.map(({ x, y }) => [x, y]).flat(),
       (textureCoordinates || []).map(({ x, y }) => [x, y]).flat(),
-      colors,
+      !colors ? null : colors.reduce((a, c) => concat(a, c)),
       indices,
       isVolatile
     )

--- a/package/src/web/index.ts
+++ b/package/src/web/index.ts
@@ -1,4 +1,6 @@
-import CanvasKitInit from "canvaskit-wasm";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+import CanvasKitInit from "canvaskit-wasm/bin/full/canvaskit";
 import type { CanvasKit as CanvasKitType } from "canvaskit-wasm";
 
 declare global {


### PR DESCRIPTION
The goal of this PR is to substantially improve the setup process for an RN Web project by removing the need to patch CanvasKit at the client level. We additionally remove a bogus warning on RN Web. 

We do this the following by:
* Factorizing the CanvasKit loading in a single place, directly loading the full version without a patch. We could eventually offer a loader for the version without SKGL, but the size difference is somewhat "small."
* Only using the CanvasKit type declaration patch that will likely be available in v0.35. We received great insights there.
* Remove a bogus warning that would be triggered by the renderer, which is still using the FontMgr.

The last thing missing on my list is an issue related to the canvas reference; I will make a separate PR for it.