### PR TITLE
Keep the RN Web Canvas mounted

### DIFF
--- a/package/src/views/SkiaView.web.tsx
+++ b/package/src/views/SkiaView.web.tsx
@@ -175,17 +175,15 @@ export class SkiaView extends React.Component<
     const { mode, debug = false, ...viewProps } = this.props;
     return (
       <View {...viewProps} onLayout={this.onLayout.bind(this)}>
-        {this.state.width > -1 ? (
-          <canvas
-            ref={this._canvasRef}
-            width={`${this.state.width}px`}
-            height={`${this.state.height}px`}
-            onPointerDown={this.handleTouchStart.bind(this)}
-            onPointerMove={this.handleTouchMove.bind(this)}
-            onPointerUp={this.handleTouchEnd.bind(this)}
-            onPointerCancel={this.handleTouchCancel.bind(this)}
-          />
-        ) : null}
+        <canvas
+          ref={this._canvasRef}
+          width={this.state.width}
+          height={this.state.height}
+          onPointerDown={this.handleTouchStart.bind(this)}
+          onPointerMove={this.handleTouchMove.bind(this)}
+          onPointerUp={this.handleTouchEnd.bind(this)}
+          onPointerCancel={this.handleTouchCancel.bind(this)}
+        />
       </View>
     );
   }


### PR DESCRIPTION
The goal of this PR is to keep the canvas mounted to make sure we have a reference to it when the onLayoutEvent is called. 
I could confirm that this fixes the package usage with Remotion. I am not sure yet why I cannot reproduce the issue on the example project.