### PR TITLE
Added correct namespace qualifier to .mm file

### DIFF
--- a/package/ios/RNSkia-iOS/SkiaManager.mm
+++ b/package/ios/RNSkia-iOS/SkiaManager.mm
@@ -34,7 +34,7 @@
     if (cxxBridge.runtime) {
       
       auto callInvoker = bridge.jsCallInvoker;
-      jsi::Runtime* jsRuntime = (jsi::Runtime*)cxxBridge.runtime;
+      facebook::jsi::Runtime* jsRuntime = (facebook::jsi::Runtime*)cxxBridge.runtime;
       
       // Create platform context
       _platformContext = std::make_shared<RNSkia::PlatformContext>(jsRuntime, callInvoker);


### PR DESCRIPTION
When adding this library to a React-Native 0.69 project the iOS build fails with an error in Xcode. This PR fixes this by qualifying the namespace in the SKManager.mm file.

Closes #624  