### PR TITLE
Added jestSetup.js to tsconfig excludes

### DIFF
--- a/package/tsconfig.json
+++ b/package/tsconfig.json
@@ -33,6 +33,7 @@
     "babel.config.js",
     "metro.config.js",
     "jest.config.js",
+    "jestSetup.js",
     "lib",
     "scripts"
   ]


### PR DESCRIPTION
To avoid warning / problem in package about not being able to overwrite jestSetup.js, the file was added to the exclude section since it is already a JS file.