### PR TITLE
Fixed example pod install error

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -288,32 +288,32 @@ PODS:
     - RCTTypeSafety
     - React
     - ReactCommon/turbomodule/core
-  - react-native-skia (0.1.100):
+  - react-native-skia (0.0.1-development):
     - React
     - React-callinvoker
     - React-Core
-    - react-native-skia/Api (= 0.1.100)
-    - react-native-skia/Jsi (= 0.1.100)
-    - react-native-skia/RNSkia (= 0.1.100)
-    - react-native-skia/SkiaHeaders (= 0.1.100)
-    - react-native-skia/Utils (= 0.1.100)
-  - react-native-skia/Api (0.1.100):
+    - react-native-skia/Api (= 0.0.1-development)
+    - react-native-skia/Jsi (= 0.0.1-development)
+    - react-native-skia/RNSkia (= 0.0.1-development)
+    - react-native-skia/SkiaHeaders (= 0.0.1-development)
+    - react-native-skia/Utils (= 0.0.1-development)
+  - react-native-skia/Api (0.0.1-development):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/Jsi (0.1.100):
+  - react-native-skia/Jsi (0.0.1-development):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/RNSkia (0.1.100):
+  - react-native-skia/RNSkia (0.0.1-development):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/SkiaHeaders (0.1.100):
+  - react-native-skia/SkiaHeaders (0.0.1-development):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/Utils (0.1.100):
+  - react-native-skia/Utils (0.0.1-development):
     - React
     - React-callinvoker
     - React-Core
@@ -601,7 +601,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 90f0bfd5d04e0b066c29216a110ffb9a6c34f23f
   React-logger: 8474fefa09d05f573a13c044cb0dfd751d4e52e3
   react-native-safe-area-context: f98b0b16d1546d208fc293b4661e3f81a895afd9
-  react-native-skia: 57f0f077c9acde81e26caa35d7d8958439762d14
+  react-native-skia: f9ccb4d45e3f6111683ad480db812169d28c05de
   React-perflogger: 15cb741d6c2379f4d3fc8f9e4d4e1110ef3020cb
   React-RCTActionSheet: ea9099db0597bd769430db1e2d011fd5fdb7fc5e
   React-RCTAnimation: 252df4749866f2654f37612f839522cac91c1165

--- a/package/package.json
+++ b/package/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "title": "React Native Skia",
-  "version": "0.0.0-development",
+  "version": "0.0.1-development",
   "description": "High-performance React Native Graphics using Skia",
   "main": "index.ts",
   "files": [


### PR DESCRIPTION
This PR fixes and error in iOS that occurs when running pod install in example after setting version in package.json to "0.0.0-development":

```
Couldn't install Pods. Updating the Pods project and trying again...
Command `pod install` failed.
└─ Cause: CocoaPods could not find compatible versions for pod "react-native-skia":
  In snapshot (Podfile.lock):
    react-native-skia (from `../../package`)

  In Podfile:
    react-native-skia (from `../../package`)

None of your spec sources contain a spec satisfying the dependency: `react-native-skia (from `../../package`)`.

You have either:
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.

pod exited with non-zero code: 31
```

The fix sets the package version to "0.0.1-development" - since "0.0.0-development" exhibits the error above.