### PR TITLE
Fix issue with version number

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "title": "React Native Skia",
-  "version": "0.0.1-development",
+  "version": "0.1.0-development",
   "description": "High-performance React Native Graphics using Skia",
   "main": "index.ts",
   "files": [


### PR DESCRIPTION
The latest version number we published was `0.0.135` but `0.1.135` was expected.