### PR TITLE
Fix fast refresh for features backed by useLoading

### DIFF
--- a/package/src/skia/core/Data.ts
+++ b/package/src/skia/core/Data.ts
@@ -62,7 +62,7 @@ const useLoading = <T>(
     if (prevSourceRef.current !== source) {
       prevSourceRef.current = source;
       loader().then(setData);
-    } else {
+    } else if (!source) {
       setData(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Not tested with anything except with `useFont()` on my own project.
Need your assessment whether this is a good idea.

**Bug flow:**

- Call `useFont()` with any font
- Loader gets executed because font has changed from undefined -> font
- Component gets fast refreshed
- Effect triggers again, but since `prevSourceRef.current === source`, it gets set to null even though font is still there

Bugfix is to only set it to null if there is no `source` anymore

Fixes #677 