### PR TITLE
Fix Example web navigation

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -23,18 +23,45 @@ import {
 } from "./Examples";
 import { HomeScreen } from "./Home";
 
+const linking = {
+  config: {
+    screens: {
+      Home: "",
+      Vertices: "vertices",
+      API: "api",
+      Breathe: "breathe",
+      Filters: "filters",
+      Gooey: "gooey",
+      Hue: "hue",
+      Matrix: "matrix",
+      Severance: "severance",
+      Aurora: "aurora",
+      Glassmorphism: "glassmorphism",
+      Neumorphism: "neumorphism",
+      Wallpaper: "wallpaper",
+      Wallet: "wallet",
+      Graphs: "graphs",
+      Animation: "animation",
+      Performance: "performance",
+    },
+  },
+  prefixes: ["rnskia://"],
+};
+
 const App = () => {
   const Stack = createNativeStackNavigator();
+
   return (
     <>
       <StatusBar hidden />
-      <NavigationContainer>
+      <NavigationContainer linking={linking}>
         <Stack.Navigator>
           <Stack.Screen
             name="Home"
             component={HomeScreen}
             options={{
               title: "🎨 Skia",
+              headerTitleAlign: "center",
             }}
           />
           <Stack.Screen

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -8,9 +8,9 @@ const CopyPlugin = require("copy-webpack-plugin");
 const appDirectory = path.resolve(__dirname);
 const { presets, plugins } = require(`${appDirectory}/babel.config.js`);
 // This is only needed in the development repo to transpile the TypeScript files
-const compileNodeModules = [
-  "../../package",
-].map((moduleName) => path.resolve(appDirectory, `node_modules/${moduleName}`));
+const compileNodeModules = ["../../package"].map((moduleName) =>
+  path.resolve(appDirectory, `node_modules/${moduleName}`)
+);
 
 const babelLoaderConfiguration = {
   test: /\.(ts|tsx)$/,
@@ -66,6 +66,9 @@ module.exports = {
     path: path.resolve(appDirectory, "dist"),
     publicPath: "/",
     filename: "rn-skia-example.bundle.js",
+  },
+  devServer: {
+    historyApiFallback: true,
   },
   resolve: {
     // FIXME: To fix missing modules in browser when using webassembly


### PR DESCRIPTION
This PR slightly improves the web navigation of the Example project

### Before

✅  It was possible to go back from an example with the react navigation header
🔴  It was not possible to go back from an example without the header
🔴  It was not possible to open a specific example e.g. `http://localhost:8080/breathe`

https://user-images.githubusercontent.com/11232797/178853656-92202419-8025-4404-84dd-10a71551d293.mov

### This PR

✅  It is possible to go back from an example with the header
✅  It is not possible to go back from an example without the header using the browser back button
✅  Direct links to examples are now working e.g. `http://localhost:8080/breathe`
➕  The header title is centered


https://user-images.githubusercontent.com/11232797/178854177-8d1359a9-d47d-4922-b170-5f89f193e1c5.mov