### PR TITLE
Add skia web setup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "## Getting started",
   "main": "index.js",
+  "bin": {
+    "setup-skia-web": "./scripts/copy-canvaskit-wasm.js"
+  },
   "directories": {
     "example": "example"
   },

--- a/package/package.json
+++ b/package/package.json
@@ -3,6 +3,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "bin": {
+    "setup-skia-web": "./scripts/setup-canvaskit.js"
+  },
   "title": "React Native Skia",
   "version": "0.1.0-development",
   "description": "High-performance React Native Graphics using Skia",
@@ -29,6 +32,7 @@
     "libs/ios/libsvg.xcframework",
     "react-native-skia.podspec",
     "scripts/install-npm.js",
+    "scripts/setup-canvaskit.js",
     "dist/**"
   ],
   "scripts": {

--- a/package/scripts/setup-canvaskit.js
+++ b/package/scripts/setup-canvaskit.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+/**
+ * A script to automate the setup of `@shopify/react-native-skia` for web.
+ * This script is aimed at being agnostic to web frameworks and tools,
+ * the only requirement is that your project supports a 'static' folder (often named '/public').
+ * In `@expo/webpack-config` this is `./web`.
+ *
+ * This script does the following:
+ * 1. Resolve the public path relative to wherever the script is being run.
+ * 2. Log out some useful info about the web setup, just in case anything goes wrong.
+ * 3. Resolve the installed wasm file `canvaskit-wasm/bin/full/canvaskit.wasm` from `@shopify/react-native-skia -> canvaskit`.
+ * 4. Recursively ensure the path exists and copy the file into the desired location.
+ *
+ *
+ * Usage:
+ * $ `npx <script>`
+ *
+ * -> Copies the file to `<project>/public/static/js/canvaskit.wasm`
+ *
+ * Expo Webpack:
+ * $ `npx <script> web`
+ *
+ * -> Copies the file to `<project>/web/static/js/canvaskit.wasm`
+ */
+const fs = require("fs");
+const path = require("path");
+
+const args = process.argv.slice(2);
+
+const gray = (text) => `\x1b[90m${text}\x1b[0m`;
+const lime = (text) => `\x1b[32m${text}\x1b[0m`;
+
+function getWasmFilePath() {
+  try {
+    return require.resolve("canvaskit-wasm/bin/full/canvaskit.wasm");
+  } catch (error) {
+    // No idea how this could happen.
+    console.error(
+      `Could not find 'canvaskit-wasm'. Please install '@shopify/react-native-skia' and ensure it can be resolved from your project: ${process.cwd()}`
+    );
+    process.exit(1);
+  }
+}
+
+function getOutputFilePath() {
+  // Most tools use `public` but Expo Webpack uses `web`.
+  const publicFolder = path.resolve(args[0] || "public");
+  const publicLocation = "./static/js/canvaskit.wasm";
+  const output = path.join(publicFolder, publicLocation);
+
+  console.log(
+    `› Copying 'canvaskit.wasm' file to static folder:\n  ${gray(output)}\n`
+  );
+  // A doc explaining what a public folder is -- React Native developers may not be familiar with the concept.
+  console.log(gray(`› Learn more: [TODO: Link to RNSkia docs]`));
+
+  return output;
+}
+
+function copyFile(from, to) {
+  const data = fs.readFileSync(from);
+  fs.mkdirSync(path.dirname(to), { recursive: true });
+  fs.writeFileSync(to, data);
+}
+
+// Copy the WASM file to `<public>/static/js/canvaskit.wasm`
+(() => {
+  copyFile(getWasmFilePath(), getOutputFilePath());
+
+  console.log(lime(`› Success! You may need to restart your dev server`));
+})();


### PR DESCRIPTION
Added a script to automate the setup of `@shopify/react-native-skia` for web.
This script is aimed at being agnostic to web frameworks and tools, the only requirement is that your project supports a 'static' folder (often `/public`).
In `@expo/webpack-config` this is `./web`.

This script does the following:
1. Resolve the public path relative to wherever the script is being run.
2. Log out some useful info about the web setup, just in case anything goes wrong.
3. Resolve the installed wasm file `canvaskit-wasm/bin/full/canvaskit.wasm` from @shopify/react-native-skia -> canvaskit`.
4. Recursively ensure the path exists and copy the file into the desired location.

```
Usage:
$ `yarn setup-skia-web`

-> Copies the file to `<project>/public/static/js/canvaskit.wasm`

Expo Webpack:
$ `yarn setup-skia-web web`

-> Copies the file to `<project>/web/static/js/canvaskit.wasm`
```

I have the `bin` named `setup-skia-web` but I'm not tied to it, feel free to rename. 

## Test plan: 
1. Run `npm pack`
2. `yarn add /path/to/pkg.tgz`
3. Run `yarn setup-skia-web web`
4. Everything should be setup and ready. [Example](https://github.com/EvanBacon/expo-skia-demo)


