### PR TITLE
[RFC] feat: wrapped text

### DIFF
--- a/example/src/Examples/API/ImageFilters.tsx
+++ b/example/src/Examples/API/ImageFilters.tsx
@@ -12,6 +12,7 @@ import {
   Circle,
   Skia,
   useFont,
+  WrappedText,
 } from "@shopify/react-native-skia";
 import React from "react";
 
@@ -70,6 +71,7 @@ const MorphologyDemo = () => {
         <Morphology radius={0.3} operator="erode" />
         <Text text="Hello World" x={32} y={96} font={font} />
       </Group>
+      <WrappedText text="Hello World" x={32} y={128} font={font} />
     </Group>
   );
 };

--- a/package/src/renderer/components/text/WrappedText.tsx
+++ b/package/src/renderer/components/text/WrappedText.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+import type {
+  CustomPaintProps,
+  AnimatedProps,
+  FontDef,
+} from "../../processors";
+import { createDrawing } from "../../nodes/Drawing";
+import { processFont } from "../../processors";
+
+type TextProps = CustomPaintProps &
+  FontDef & {
+    text: string;
+    x: number;
+    y: number;
+  };
+
+const onDraw = createDrawing<TextProps>(
+  ({ canvas, paint, fontMgr, Skia }, { text, x, y, ...fontDef }) => {
+    const font = processFont(Skia, fontMgr, fontDef);
+    const padding = 16
+    const measured = font.measureText(text)
+    const paint2 = Skia.Paint();
+    paint2.setColor(Skia.Color("#61DAFB"));
+    canvas.drawRect({x:x-padding,y:y-measured.height-padding, width:measured.width+padding+padding, height:measured.height+padding+padding}, paint2)
+    canvas.drawText(text, x, y, paint, font);
+  }
+);
+
+export const WrappedText = (props: AnimatedProps<TextProps>) => {
+  return <skDrawing onDraw={onDraw} {...props} />;
+};
+
+WrappedText.defaultProps = {
+  x: 0,
+  y: 0,
+};

--- a/package/src/renderer/components/text/index.ts
+++ b/package/src/renderer/components/text/index.ts
@@ -2,3 +2,4 @@ export * from "./Text";
 export * from "./Glyphs";
 export * from "./TextBlob";
 export * from "./TextPath";
+export * from "./WrappedText";


### PR DESCRIPTION
Hello Shopify Team ! 👋 

Thank you for a great library. I am not very advanced in creating elements on canvas, hence I would like to ask you, if my way is correct. So I would like to create a button, which will always wrap a container into text. Ofc lots of work is needed here (eg expose the props like padding etc), but I would like to ask, if my way of doing that is correct ? 

Below you can find expected effect: 
![Simulator Screen Shot - iPhone 13 - 2022-07-19 at 17 12 56](https://user-images.githubusercontent.com/12766071/179785708-210d4397-0675-430e-acb2-1cd141ca1f40.png)

![Simulator Screen Shot - iPhone 13 - 2022-07-19 at 17 13 07](https://user-images.githubusercontent.com/12766071/179785736-fd419108-4b81-4c63-8f69-0393ae488b96.png)

