### PR TITLE
Added identity method to Matrix to avoid recreating Matrix objects

### DIFF
--- a/package/cpp/api/JsiSkMatrix.h
+++ b/package/cpp/api/JsiSkMatrix.h
@@ -79,8 +79,8 @@ public:
     return jsi::Value::undefined();
   }
   
-  JSI_HOST_FUNCTION(reset) {
-    getObject()->reset();
+  JSI_HOST_FUNCTION(identity) {
+    getObject()->setIdentity();
     return jsi::Value::undefined();
   }
 
@@ -89,8 +89,8 @@ public:
     JSI_EXPORT_FUNC(JsiSkMatrix, translate),
     JSI_EXPORT_FUNC(JsiSkMatrix, scale),
     JSI_EXPORT_FUNC(JsiSkMatrix, skew),
-    JSI_EXPORT_FUNC(JsiSkMatrix, reset),
     JSI_EXPORT_FUNC(JsiSkMatrix, rotate),
+    JSI_EXPORT_FUNC(JsiSkMatrix, identity),
   )
 
   /**

--- a/package/cpp/api/JsiSkMatrix.h
+++ b/package/cpp/api/JsiSkMatrix.h
@@ -78,12 +78,18 @@ public:
     getObject()->preRotate(SkRadiansToDegrees(a));
     return jsi::Value::undefined();
   }
+  
+  JSI_HOST_FUNCTION(reset) {
+    getObject()->reset();
+    return jsi::Value::undefined();
+  }
 
   JSI_EXPORT_FUNCTIONS(
     JSI_EXPORT_FUNC(JsiSkMatrix, concat),
     JSI_EXPORT_FUNC(JsiSkMatrix, translate),
     JSI_EXPORT_FUNC(JsiSkMatrix, scale),
     JSI_EXPORT_FUNC(JsiSkMatrix, skew),
+    JSI_EXPORT_FUNC(JsiSkMatrix, reset),
     JSI_EXPORT_FUNC(JsiSkMatrix, rotate),
   )
 

--- a/package/src/skia/types/Matrix.ts
+++ b/package/src/skia/types/Matrix.ts
@@ -17,6 +17,7 @@ export interface SkMatrix extends SkJSIInstance<"Matrix"> {
   scale: (x: number, y?: number) => void;
   skew: (x: number, y: number) => void;
   rotate: (theta: number) => void;
+  reset: () => void;
 }
 
 type Transform2dName =

--- a/package/src/skia/types/Matrix.ts
+++ b/package/src/skia/types/Matrix.ts
@@ -17,7 +17,7 @@ export interface SkMatrix extends SkJSIInstance<"Matrix"> {
   scale: (x: number, y?: number) => void;
   skew: (x: number, y: number) => void;
   rotate: (theta: number) => void;
-  reset: () => void;
+  identity: () => void;
 }
 
 type Transform2dName =

--- a/package/src/skia/web/JsiSkMatrix.ts
+++ b/package/src/skia/web/JsiSkMatrix.ts
@@ -51,4 +51,8 @@ export class JsiSkMatrix
       )
     );
   }
+
+  reset() {
+    this.ref.set(this.CanvasKit.Matrix.identity());
+  }
 }

--- a/package/src/skia/web/JsiSkMatrix.ts
+++ b/package/src/skia/web/JsiSkMatrix.ts
@@ -52,7 +52,7 @@ export class JsiSkMatrix
     );
   }
 
-  reset() {
+  identity() {
     this.ref.set(this.CanvasKit.Matrix.identity());
   }
 }


### PR DESCRIPTION
When performance is an issue recreating a lot of JsiSkXXX objects when rendering each frame can bring the performance down.

This is caused by the translation layer between C++/JSI and Javascript where new objects needs to look up functions from names the first time a function or property is called on the object.

This PR adds a `identity` method to the Matrix object (both Web/Native) that resets the Matrix object to its zero state. This makes it possible to reuse Matrix objects when creating performance heavy renderings. This lets us use Matrices directly in Group tags without having to parse / read the transform on each render - and without having to create new objects on each render.