### PR TITLE
Add support for computed array values

### DIFF
--- a/example/src/Examples/Performance/index.ts
+++ b/example/src/Examples/Performance/index.ts
@@ -1,2 +1,2 @@
-//export { PerformanceDrawingTest } from "./PerformanceRects";
-export { PerformanceDrawingTest } from "./PerformanceCanvases";
+export { PerformanceDrawingTest } from "./PerformanceRects";
+//export { PerformanceDrawingTest } from "./PerformanceCanvases";

--- a/package/src/renderer/processors/Animations/Animations.ts
+++ b/package/src/renderer/processors/Animations/Animations.ts
@@ -17,6 +17,21 @@ export const isValue = (value: unknown): value is SkiaValue<unknown> => {
   return false;
 };
 
+export const isIndexedAccess = (
+  value: unknown
+): value is { index: number; value: SkiaValue<Array<unknown>> } => {
+  if (value) {
+    return (
+      typeof value === "object" &&
+      "index" in value &&
+      "value" in value &&
+      (value as Record<string, unknown>).index !== undefined &&
+      (value as Record<string, unknown>).value !== undefined
+    );
+  }
+  return false;
+};
+
 export const isAnimated = <T>(props: AnimatedProps<T>) => {
   for (const value of Object.values(props)) {
     if (isValue(value)) {
@@ -32,11 +47,16 @@ export const materialize = <T>(props: AnimatedProps<T>) => {
     const value = props[key];
     if (isValue(value)) {
       result[key] = (value as SkiaValue<T[typeof key]>).current;
+    } else if (isIndexedAccess(value)) {
+      result[key] = value.value.current[value.index] as T[typeof key];
     }
   });
   return result as T;
 };
 
 export type AnimatedProps<T> = {
-  [K in keyof T]: T[K] | SkiaValue<T[K]>;
+  [K in keyof T]:
+    | T[K]
+    | SkiaValue<T[K]>
+    | { index: number; value: SkiaValue<Array<T[K]>> };
 };

--- a/package/src/values/hooks/useComputedValue.ts
+++ b/package/src/values/hooks/useComputedValue.ts
@@ -17,6 +17,27 @@ export const useComputedValue = <R>(cb: () => R, values: unknown[]) =>
     values
   );
 
+/**
+ * Creates a new computed value that returns an array that can be indexed into.
+ * The syntax for using it is like this:
+ * ```ts
+ * const colors = useComputedArrayValue(() => ["red", "green", "blue""], [input]);
+ * return () => <Canvas>
+ *   {arr.map((_, i) => <Rectangle fill={colors(i)} />)}
+ * </Canvas>;
+ * ```
+ * @param cb Callback to calculate new value
+ * @param values Dependant values
+ * @returns A factory function that returns a description of the value and the index to access
+ */
+export const useComputedArrayValue = <R>(cb: () => R, values: unknown[]) => {
+  const value = useComputedValue(cb, values);
+  return (index: number) => ({
+    index,
+    value,
+  });
+};
+
 export const useDerivedValue = <R>(cb: () => R, values: unknown[]) => {
   console.warn("useDerivedValue is deprecated. Use useComputedValue instead.");
   return useComputedValue(cb, values);


### PR DESCRIPTION
A problem with computed values is that we often would like to return an array of values corresponding to an array of components that is rendered on the Canvas like this:

```ts
const values = useComputedValue(() => return arr(...), [arr]);
return <Canvas>
  {arr.map((_, i) => <Rect x={values.current[i]} y={0} />}
</Canvas>
```

The problem with this approach is that when accessing individual elements in the array the reconciler won't be able to see that the property value is coming from a computed value and thus will not be able to infer automatic update when the value change in "Skia land". 

Previously we had to create arrays of computed values - but this is a bit of an overkill to accomplish the above:

```ts
const values = useMemo(() => arr.map(() => ValuesApi.createComputedValue(...), [arr]);
return <Canvas>
  {arr.map((_, i) => <Rect x={values.current[i]} y={0} />}
</Canvas>
```

This PR fixes this issue by adding a specialised computed value hook that knows how to handle this by returning a specific descriptor that the reconciler can use to evaluate the value:

```ts
const values = useComputedArrayValue(() => return arr(...), [arr]);
return <Canvas>
  {arr.map((_, i) => <Rect x={values(i)} y={0} />}
</Canvas>
```
