### PR TITLE
Add faster matrix to <Group />

### DIFF
--- a/package/cpp/api/JsiSkMatrix.h
+++ b/package/cpp/api/JsiSkMatrix.h
@@ -79,8 +79,8 @@ public:
     return jsi::Value::undefined();
   }
   
-  JSI_HOST_FUNCTION(reset) {
-    getObject()->reset();
+  JSI_HOST_FUNCTION(identity) {
+    getObject()->setIdentity();
     return jsi::Value::undefined();
   }
 
@@ -89,8 +89,8 @@ public:
     JSI_EXPORT_FUNC(JsiSkMatrix, translate),
     JSI_EXPORT_FUNC(JsiSkMatrix, scale),
     JSI_EXPORT_FUNC(JsiSkMatrix, skew),
-    JSI_EXPORT_FUNC(JsiSkMatrix, reset),
     JSI_EXPORT_FUNC(JsiSkMatrix, rotate),
+    JSI_EXPORT_FUNC(JsiSkMatrix, identity),
   )
 
   /**

--- a/package/cpp/api/JsiSkMatrix.h
+++ b/package/cpp/api/JsiSkMatrix.h
@@ -78,12 +78,18 @@ public:
     getObject()->preRotate(SkRadiansToDegrees(a));
     return jsi::Value::undefined();
   }
+  
+  JSI_HOST_FUNCTION(reset) {
+    getObject()->reset();
+    return jsi::Value::undefined();
+  }
 
   JSI_EXPORT_FUNCTIONS(
     JSI_EXPORT_FUNC(JsiSkMatrix, concat),
     JSI_EXPORT_FUNC(JsiSkMatrix, translate),
     JSI_EXPORT_FUNC(JsiSkMatrix, scale),
     JSI_EXPORT_FUNC(JsiSkMatrix, skew),
+    JSI_EXPORT_FUNC(JsiSkMatrix, reset),
     JSI_EXPORT_FUNC(JsiSkMatrix, rotate),
   )
 

--- a/package/src/renderer/components/Group.tsx
+++ b/package/src/renderer/components/Group.tsx
@@ -58,7 +58,7 @@ const onDraw = createDrawing<GroupProps>(
       } else {
         canvas.save();
       }
-      processCanvasTransform(ctx, groupProps);
+      processCanvasTransform(canvas, groupProps);
       if (clip) {
         const op = invertClip ? ClipOp.Difference : ClipOp.Intersect;
         processClip(Skia, canvas, clip, op);

--- a/package/src/renderer/processors/Transform.ts
+++ b/package/src/renderer/processors/Transform.ts
@@ -1,6 +1,7 @@
-import type { DrawingContext } from "../DrawingContext";
 import type { SkMatrix, Vector, Transforms2d } from "../../skia/types";
 import { processTransform } from "../../skia/types";
+import type { SkCanvas } from "../../skia/types/Canvas";
+import { concatTransform } from "../../skia/types/Matrix";
 
 export interface TransformProps {
   transform?: Transforms2d;
@@ -9,25 +10,22 @@ export interface TransformProps {
 }
 
 export const processCanvasTransform = (
-  { canvas, Skia }: DrawingContext,
+  canvas: SkCanvas,
   { transform, origin, matrix }: TransformProps
 ) => {
   if (matrix) {
     if (origin) {
-      const m3 = Skia.Matrix();
-      m3.translate(origin.x, origin.y);
-      m3.concat(matrix);
-      m3.translate(-origin.x, -origin.y);
-      canvas.concat(m3);
+      canvas.translate(origin.x, origin.y);
+      canvas.concat(matrix);
+      canvas.translate(-origin.x, -origin.y);
     } else {
       canvas.concat(matrix);
     }
   } else if (transform) {
-    const m3 = processTransform(
-      Skia.Matrix(),
+    concatTransform(
+      canvas,
       origin ? transformOrigin(origin, transform) : transform
     );
-    canvas.concat(m3);
   }
 };
 

--- a/package/src/skia/types/Matrix.ts
+++ b/package/src/skia/types/Matrix.ts
@@ -17,6 +17,7 @@ export interface SkMatrix extends SkJSIInstance<"Matrix"> {
   scale: (x: number, y?: number) => void;
   skew: (x: number, y: number) => void;
   rotate: (theta: number) => void;
+  reset: () => void;
 }
 
 type Transform2dName =

--- a/package/src/skia/types/Matrix.ts
+++ b/package/src/skia/types/Matrix.ts
@@ -17,7 +17,7 @@ export interface SkMatrix extends SkJSIInstance<"Matrix"> {
   scale: (x: number, y?: number) => void;
   skew: (x: number, y: number) => void;
   rotate: (theta: number) => void;
-  reset: () => void;
+  identity: () => void;
 }
 
 type Transform2dName =

--- a/package/src/skia/types/Matrix.ts
+++ b/package/src/skia/types/Matrix.ts
@@ -1,4 +1,5 @@
 import type { SkJSIInstance } from "./JsiInstance";
+import type { SkCanvas } from "./Canvas";
 export enum MatrixIndex {
   ScaleX = 0,
   SkewX = 1,
@@ -91,6 +92,51 @@ export const processTransform = (m: SkMatrix, transforms: Transforms2d) => {
   return m;
 };
 
+export const concatTransform = (m: SkCanvas, transforms: Transforms2d) => {
+  for (const transform of transforms) {
+    const key = Object.keys(transform)[0] as Transform2dName;
+    const value = (transform as Pick<Transformations, typeof key>)[key];
+    if (key === "translateX") {
+      m.translate(value, 0);
+      continue;
+    }
+    if (key === "translateY") {
+      m.translate(0, value);
+      continue;
+    }
+    if (key === "scale") {
+      m.scale(value, value);
+      continue;
+    }
+    if (key === "scaleX") {
+      m.scale(value, 1);
+      continue;
+    }
+    if (key === "scaleY") {
+      m.scale(1, value);
+      continue;
+    }
+    if (key === "skewX") {
+      m.skew(value, 0);
+      continue;
+    }
+    if (key === "skewY") {
+      m.skew(0, value);
+      continue;
+    }
+    if (key === "rotate" || key === "rotateZ") {
+      m.rotate(toDegrees(value), 0, 0);
+      continue;
+    }
+    exhaustiveCheck(key);
+  }
+  return m;
+};
+
 const exhaustiveCheck = (a: never): never => {
   throw new Error(`Unknown transformation: ${a}`);
+};
+
+export const toDegrees = (rad: number) => {
+  return (rad * 180) / Math.PI;
 };

--- a/package/src/skia/web/JsiSkMatrix.ts
+++ b/package/src/skia/web/JsiSkMatrix.ts
@@ -51,4 +51,8 @@ export class JsiSkMatrix
       )
     );
   }
+
+  reset() {
+    this.ref.set(this.CanvasKit.Matrix.identity());
+  }
 }

--- a/package/src/skia/web/JsiSkMatrix.ts
+++ b/package/src/skia/web/JsiSkMatrix.ts
@@ -52,7 +52,7 @@ export class JsiSkMatrix
     );
   }
 
-  reset() {
+  identity() {
     this.ref.set(this.CanvasKit.Matrix.identity());
   }
 }


### PR DESCRIPTION
So originally we wanted the SkMatrix and SkCanvas but we've made a bit of a mess there regarding rotations:
* canvas.rotate is in deg
* canvas.rotate as a mandatory pivot param

After looking at the implementation of these, it looks like we may want to unify these with a single interface that supports degrees, radians, and pivot axis. But here to avoid breaking backward compatibility, I've made a single function to process the transform. 

And update the group component to use that function