### PR TITLE
Removed hard version requirement of CMake

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -133,8 +133,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            path file('CMakeLists.txt')
-            version '3.10.2'
+            path file('CMakeLists.txt')            
         }
     }
 


### PR DESCRIPTION
In our gradle file we provide a hardcoded version number for CMake. This has led to some issues with some CI systems.

From the [docs](https://developer.android.com/studio/projects/install-ndk#vanilla_cmake) it shouldn't be necessary, since the default version (if not provided) will be 3.10.2

Fixes #739
Fixes #627