### PR TITLE
Fix regression on main

### DIFF
--- a/example/src/Examples/Performance/PerformanceCanvases.tsx
+++ b/example/src/Examples/Performance/PerformanceCanvases.tsx
@@ -29,10 +29,9 @@ export const PerformanceDrawingTest: React.FC = () => {
     return () => clearTimeout(to);
   }, []);
 
-  if (image === null) {
+  if (!image) {
     return null;
   }
-
   return (
     <View style={styles.container}>
       <View style={styles.mode}>

--- a/example/src/Examples/Performance/PerformanceCanvases.tsx
+++ b/example/src/Examples/Performance/PerformanceCanvases.tsx
@@ -29,7 +29,7 @@ export const PerformanceDrawingTest: React.FC = () => {
     return () => clearTimeout(to);
   }, []);
 
-  if (!image) {
+  if (image === null) {
     return null;
   }
   return (

--- a/package/src/renderer/__tests__/Data.spec.tsx
+++ b/package/src/renderer/__tests__/Data.spec.tsx
@@ -36,6 +36,19 @@ const CheckFont = ({}: EmptyProps) => {
   return <Fill color="green" />;
 };
 
+const CheckImage = ({}: EmptyProps) => {
+  const { useImage } = require("../../skia/core/Image");
+  const image = useImage(
+    nodeRequire(
+      path.resolve(__dirname, "../../skia/__tests__/assets/zurich.jpg")
+    )
+  );
+  if (!image) {
+    return <Fill color="red" />;
+  }
+  return <Fill color="green" />;
+};
+
 const CheckDataCollection = ({}: EmptyProps) => {
   const { useDataCollection } = require("../../skia/core/Data");
   const font = useDataCollection(
@@ -67,8 +80,18 @@ describe("Data Loading", () => {
     draw();
     processResult(surface, "snapshots/font/green.png");
   });
+
   it("Should load a font file", async () => {
     const { surface, draw } = mountCanvas(<CheckFont />);
+    draw();
+    processResult(surface, "snapshots/font/red.png");
+    await wait(500);
+    draw();
+    processResult(surface, "snapshots/font/green.png");
+  });
+
+  it("Should load an image", async () => {
+    const { surface, draw } = mountCanvas(<CheckImage />);
     draw();
     processResult(surface, "snapshots/font/red.png");
     await wait(500);

--- a/package/src/skia/core/Data.ts
+++ b/package/src/skia/core/Data.ts
@@ -32,19 +32,22 @@ const loadDataCollection = <T>(
 ): Promise<(T | null)[]> =>
   Promise.all(sources.map((source) => loadData(source, factory, onError)));
 
-const loadData = async <T>(
+const loadData = <T>(
   source: DataSource,
   factory: (data: SkData) => T,
   onError?: (err: Error) => void
 ): Promise<T | null> => {
   if (source === null) {
-    return null;
+    return new Promise((resolve) => resolve(null));
   } else if (source instanceof Uint8Array) {
-    return factoryWrapper(Skia.Data.fromBytes(source), factory, onError);
+    return new Promise((resolve) =>
+      resolve(factoryWrapper(Skia.Data.fromBytes(source), factory, onError))
+    );
   } else {
     const uri = typeof source === "string" ? source : resolveAsset(source);
-    const d = await Skia.Data.fromURI(uri);
-    return factoryWrapper(d, factory, onError);
+    return Skia.Data.fromURI(uri).then((d) =>
+      factoryWrapper(d, factory, onError)
+    );
   }
 };
 

--- a/package/src/skia/core/Image.ts
+++ b/package/src/skia/core/Image.ts
@@ -3,10 +3,12 @@ import type { DataSource } from "../types";
 
 import { useRawData } from "./Data";
 
+const imgFactory = Skia.Image.MakeImageFromEncoded.bind(Skia.Image);
+
 /**
  * Returns a Skia Image object
  * */
 export const useImage = (
   source: DataSource | null | undefined,
   onError?: (err: Error) => void
-) => useRawData(source, Skia.Image.MakeImageFromEncoded, onError);
+) => useRawData(source, imgFactory, onError);

--- a/package/src/skia/core/SVG.ts
+++ b/package/src/skia/core/SVG.ts
@@ -3,7 +3,9 @@ import type { DataSource } from "../types";
 
 import { useRawData } from "./Data";
 
+const svgFactory = Skia.SVG.MakeFromData.bind(Skia.SVG);
+
 export const useSVG = (
   source: DataSource | null | undefined,
   onError?: (err: Error) => void
-) => useRawData(source, Skia.SVG.MakeFromData, onError);
+) => useRawData(source, svgFactory, onError);

--- a/package/src/skia/core/Typeface.ts
+++ b/package/src/skia/core/Typeface.ts
@@ -2,15 +2,13 @@ import { Skia } from "../Skia";
 import type { DataSource } from "../types";
 
 import { useRawData } from "./Data";
+
+const tfFactory = Skia.Typeface.MakeFreeTypeFaceFromData.bind(Skia.Typeface);
+
 /**
  * Returns a Skia Typeface object
  * */
 export const useTypeface = (
   source: DataSource | null | undefined,
   onError?: (err: Error) => void
-) =>
-  useRawData(
-    source,
-    Skia.Typeface.MakeFreeTypeFaceFromData.bind(Skia.Typeface),
-    onError
-  );
+) => useRawData(source, tfFactory, onError);


### PR DESCRIPTION
This fixes a regression on main where we assumed that direct and awaited returns are treated homogeneously in an `async` function. It looks like the issue wasn't caught by typescript due to the wait the `Awaited` type is written.