### PR TITLE
Fix handling of high pixel density on RN Web

### DIFF
--- a/package/src/views/SkiaView.web.tsx
+++ b/package/src/views/SkiaView.web.tsx
@@ -23,7 +23,7 @@ export class SkiaView extends React.Component<SkiaViewProps> {
   private _unsubscriptions: Array<() => void> = [];
   private _touches: Array<TouchInfo> = [];
   private _canvas: SkCanvas | null = null;
-  private _canvasRef: React.RefObject<HTMLCanvasElement> = React.createRef();
+  private _canvasRef = React.createRef<HTMLCanvasElement>();
   private _mode: DrawMode;
   private _redrawRequests = 0;
   private _unmounted = false;


### PR DESCRIPTION
The recipe is taken from https://www.khronos.org/webgl/wiki/HandlingHighDPI
This allow us to remove the need to have a state in `Canvas` that feels more elegant now.
The difference can be seen on the example app, most notably the gooey and filter example.

<img width="414" alt="Screenshot 2022-08-10 at 06 52 52" src="https://user-images.githubusercontent.com/306134/183818811-42835508-c98d-4add-bb8a-07bb5a3abb33.png"> <img width="384" alt="Screenshot 2022-08-10 at 06 53 48" src="https://user-images.githubusercontent.com/306134/183818755-245dd6c1-93dd-4d17-8bfb-7f5c5d62c812.png">



fixes #750
