### PR TITLE
Unmount composide components in the renderer

### DIFF
--- a/package/src/renderer/Canvas.tsx
+++ b/package/src/renderer/Canvas.tsx
@@ -111,9 +111,11 @@ export const Canvas = forwardRef<SkiaView, CanvasProps>(
 
     useEffect(() => {
       return () => {
-        container.depMgr.unsubscribe();
+        skiaReconciler.updateContainer(null, root, null, () => {
+          container.depMgr.unsubscribe();
+        });
       };
-    }, [container]);
+    }, [container, root]);
 
     return (
       <SkiaView


### PR DESCRIPTION
fixes #765 

Recipe was taken from unmountComponentAtNode: https://github.com/facebook/react/blob/2e0d86d22192ff0b13b71b4ad68fea46bf523ef6/packages/react-native-renderer/src/ReactFabric.js#L233