### PR TITLE
Return isPencil prop on touch

### DIFF
--- a/package/cpp/rnskia/RNSkInfoParameter.h
+++ b/package/cpp/rnskia/RNSkInfoParameter.h
@@ -25,6 +25,7 @@ using RNSkTouchPoint = struct {
   RNSkTouchType type;
   size_t id;
   long timestamp;
+  bool isPencil;
 };
 
 class RNSkInfoObject : public JsiHostObject {
@@ -47,6 +48,7 @@ public:
         touchObj.setProperty(runtime, "type", (double)t.type);
         touchObj.setProperty(runtime, "timestamp", (double)t.timestamp / 1000.0);
         touchObj.setProperty(runtime, "id", (double)t.id);
+        touchObj.setProperty(runtime, "isPencil", t.isPencil);
         touches.setValueAtIndex(runtime, n, touchObj);
       }
       ops.setValueAtIndex(runtime, i, touches);

--- a/package/ios/RNSkia-iOS/SkiaDrawView.mm
+++ b/package/ios/RNSkia-iOS/SkiaDrawView.mm
@@ -139,6 +139,7 @@
       nextTouch.y = position.y;
       nextTouch.force = [touch force];    
       nextTouch.id = [touch hash];
+      nextTouch.isPencil = touch.type == 2 ? true : false; // Pencil vs Touch
       auto phase = [touch phase];
       switch(phase) {
         case UITouchPhaseBegan:

--- a/package/src/views/types.ts
+++ b/package/src/views/types.ts
@@ -24,6 +24,7 @@ export interface TouchInfo {
   type: TouchType;
   id: number;
   timestamp: number;
+  isPencil: boolean;
 }
 
 export interface DrawingInfo {


### PR DESCRIPTION
**Issues**
- #460
- #735

**To Do**
- [x] RN Updates to add isPencil to touch props to satisfy TypeScript
- [ ] Android Support
- [ ] Web Support

**Using**
With a simple setup like the one found with the [Touch Events](https://shopify.github.io/react-native-skia/docs/animations/touch-events/#usetouchhandler) example, it can be used like:

```
  const touchHandler = useTouchHandler({
    onActive: ({ x, y, isPencil }) => {
      ...
    },
  });
```

_P.S., This is my first ever open source PR so I appreciate y'alls patience._