### PR TITLE
undefined velocities are passed to onTouch's onEnd event

### DIFF
--- a/package/src/views/useTouchHandler.ts
+++ b/package/src/views/useTouchHandler.ts
@@ -51,13 +51,15 @@ const useInternalTouchHandler = (
               x: distX / timeDiffseconds / PixelRatio.get(),
               y: distY / timeDiffseconds / PixelRatio.get(),
             };
+          } else {
+            prevVelocityRef.current[touch.id] = { x: 0, y: 0 };
           }
         }
 
         const extendedTouchInfo: ExtendedTouchInfo = {
           ...touch,
-          velocityX: prevVelocityRef.current[touch.id]?.x,
-          velocityY: prevVelocityRef.current[touch.id]?.y,
+          velocityX: prevVelocityRef.current[touch.id].x,
+          velocityY: prevVelocityRef.current[touch.id].y,
         };
 
         // Save previous touch


### PR DESCRIPTION
SpringBackTouch example freezes if you release your finger immediately after tapping without dragging. It seems to be caused by `undefined` velocity values being passed to `runSpring` in `onEnd.`


~I fixed the example to return if the values are undefined.~
I fixed `useTouchHandler`.

fixes #788


| Example |
|:-----------:|
|<img width="200" src="https://user-images.githubusercontent.com/4277693/184083974-9ae28567-6164-4812-8a8f-f57b44ce9ce5.png" />|


