### PR TITLE
Fix list of unsupported on React Native Web

### DIFF
--- a/docs/docs/getting-started/web.mdx
+++ b/docs/docs/getting-started/web.mdx
@@ -169,7 +169,6 @@ Some of these features are a work in progress, and some others will come later.
 **Coming soon**
 
 * `Font::GetPath`
-* `ImageFilter::MakeShader`
 * `ShaderFilter`
 
 **Unplanned**


### PR DESCRIPTION
`ImageFilter::MakeShader` was implemented in the latest PR