### PR TITLE
Remove Node dependency from DepMgr

### DIFF
--- a/package/src/renderer/DependencyManager.tsx
+++ b/package/src/renderer/DependencyManager.tsx
@@ -28,7 +28,7 @@ export class DependencyManager {
    * properties have changed.
    * @param node Node to unsubscribe value listeners from
    */
-  unsubscribeNode(node: Props) {
+  unsubscribeProps(node: Props) {
     const subscriptions = Array.from(this.subscriptions.values()).filter((p) =>
       p.nodes.has(node)
     );
@@ -72,7 +72,7 @@ export class DependencyManager {
    * @param props Node's properties
    * @param onResolveProp Callback when a property value changes
    */
-  subscribeNode<P>(props: AnimatedProps<P>) {
+  subscribeProps<P>(props: AnimatedProps<P>) {
     // Get mutators from node's properties
     const propSubscriptions = initializePropertySubscriptions(props);
     if (propSubscriptions.length === 0) {
@@ -138,7 +138,9 @@ export class DependencyManager {
 
     // 2) Unregister nodes
     Array.from(this.subscriptions.values()).forEach((si) => {
-      Array.from(si.nodes.keys()).forEach((node) => this.unsubscribeNode(node));
+      Array.from(si.nodes.keys()).forEach((node) =>
+        this.unsubscribeProps(node)
+      );
     });
 
     // 3) Clear the rest of the subscriptions

--- a/package/src/renderer/HostConfig.ts
+++ b/package/src/renderer/HostConfig.ts
@@ -265,7 +265,17 @@ export const skHostConfig: SkiaHostConfig = {
       return;
     }
     bustBranchMemoization(instance);
-    instance.props = nextProps;
+    if (instance instanceof DrawingNode) {
+      const { onDraw, skipProcessing, ...props } = nextProps;
+      instance.props = props;
+    } else if (instance instanceof DeclarationNode) {
+      const { onDeclare, ...props } = nextProps;
+      instance.props = props;
+    } else {
+      throw new Error(
+        "Unsupported instance commitUpdate " + instance.constructor.name
+      );
+    }
   },
 
   commitTextUpdate: (

--- a/package/src/renderer/HostConfig.ts
+++ b/package/src/renderer/HostConfig.ts
@@ -101,7 +101,7 @@ const removeNode = (parent: Node, child: Node) => {
   bustBranchMemoization(parent);
   const index = parent.children.indexOf(child);
   parent.children.splice(index, 1);
-  child.depMgr.unsubscribeNode(child.props);
+  child.depMgr.unsubscribeProps(child.props);
   // unsubscribe to all children as well
   for (const c of child.children) {
     removeNode(child, c);

--- a/package/src/renderer/HostConfig.ts
+++ b/package/src/renderer/HostConfig.ts
@@ -101,7 +101,7 @@ const removeNode = (parent: Node, child: Node) => {
   bustBranchMemoization(parent);
   const index = parent.children.indexOf(child);
   parent.children.splice(index, 1);
-  child.depMgr.unsubscribeNode(child);
+  child.depMgr.unsubscribeNode(child.props);
   // unsubscribe to all children as well
   for (const c of child.children) {
     removeNode(child, c);

--- a/package/src/renderer/__tests__/DependencyManager.spec.tsx
+++ b/package/src/renderer/__tests__/DependencyManager.spec.tsx
@@ -74,7 +74,7 @@ describe("DependencyManager", () => {
     const value = new RNSkValue(100);
     const node = new TestNode(mgr, { a: value });
     expect(mgr.subscriptions.has(value)).toBe(true);
-    expect(mgr.subscriptions.get(value)!.nodes.has(node)).toBe(true);
+    expect(mgr.subscriptions.get(value)!.nodes.has(node.props)).toBe(true);
     mgr.unsubscribeProps(node.props);
     expect(mgr.subscriptions.has(value)).toBe(false);
   });
@@ -86,8 +86,8 @@ describe("DependencyManager", () => {
     expect(mgr.subscriptions.has(value)).toBe(true);
     mgr.unsubscribeProps(node1.props);
     expect(mgr.subscriptions.has(value)).toBe(true);
-    expect(mgr.subscriptions.get(value)?.nodes.has(node1)).toBe(false);
-    expect(mgr.subscriptions.get(value)?.nodes.has(node2)).toBe(true);
+    expect(mgr.subscriptions.get(value)?.nodes.has(node1.props)).toBe(false);
+    expect(mgr.subscriptions.get(value)?.nodes.has(node2.props)).toBe(true);
     mgr.unsubscribeProps(node2.props);
     expect(mgr.subscriptions.has(value)).toBe(false);
   });

--- a/package/src/renderer/__tests__/DependencyManager.spec.tsx
+++ b/package/src/renderer/__tests__/DependencyManager.spec.tsx
@@ -31,7 +31,7 @@ describe("DependencyManager", () => {
     const value = new RNSkValue(100);
     const node = new TestNode(mgr, { a: value });
     expect(node.props.a).toBe(100);
-    mgr.unsubscribeNode(node);
+    mgr.unsubscribeProps(node.props);
     value.current = 200;
     expect(node.props.a).toBe(100);
   });
@@ -53,7 +53,7 @@ describe("DependencyManager", () => {
     expect(nodeA.props.a).toBe(100);
     const nodeB = new TestNode(mgr, { b: value });
     expect(nodeB.props.b).toBe(100);
-    mgr.unsubscribeNode(nodeA);
+    mgr.unsubscribeProps(nodeA.props);
     value.current = 200;
     expect(nodeA.props.a).toBe(100);
     expect(nodeB.props.b).toBe(200);
@@ -75,7 +75,7 @@ describe("DependencyManager", () => {
     const node = new TestNode(mgr, { a: value });
     expect(mgr.subscriptions.has(value)).toBe(true);
     expect(mgr.subscriptions.get(value)!.nodes.has(node)).toBe(true);
-    mgr.unsubscribeNode(node);
+    mgr.unsubscribeProps(node.props);
     expect(mgr.subscriptions.has(value)).toBe(false);
   });
   it("should remove listeners for removed node only", () => {
@@ -84,11 +84,11 @@ describe("DependencyManager", () => {
     const node1 = new TestNode(mgr, { a: value });
     const node2 = new TestNode(mgr, { a: value });
     expect(mgr.subscriptions.has(value)).toBe(true);
-    mgr.unsubscribeNode(node1);
+    mgr.unsubscribeProps(node1.props);
     expect(mgr.subscriptions.has(value)).toBe(true);
     expect(mgr.subscriptions.get(value)?.nodes.has(node1)).toBe(false);
     expect(mgr.subscriptions.get(value)?.nodes.has(node2)).toBe(true);
-    mgr.unsubscribeNode(node2);
+    mgr.unsubscribeProps(node2.props);
     expect(mgr.subscriptions.has(value)).toBe(false);
   });
   it("should remove value when last node is removed", () => {
@@ -96,7 +96,7 @@ describe("DependencyManager", () => {
     const value = new RNSkValue(100);
     const node = new TestNode(mgr, { a: value });
     expect(mgr.subscriptions.has(value)).toBe(true);
-    mgr.unsubscribeNode(node);
+    mgr.unsubscribeProps(node.props);
     expect(mgr.subscriptions.has(value)).toBe(false);
   });
   it("should resolve a value property to the value's current", () => {
@@ -148,7 +148,7 @@ describe("DependencyManager", () => {
     const mgr = new DependencyManager(mockRegister);
     const node = new TestNode(mgr, { a: value });
     expect(node.props.a).toBe(100);
-    mgr.unsubscribeNode(node);
+    mgr.unsubscribeProps(node.props);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     expect(value._listeners.length).toBe(0);

--- a/package/src/renderer/nodes/Node.ts
+++ b/package/src/renderer/nodes/Node.ts
@@ -29,11 +29,11 @@ export abstract class Node<P = unknown> {
   private updateSubscriptionNode(props: AnimatedProps<P>) {
     // This cast is ok because we understand that the dependency manager will setup the initial props
     this.resolvedProps = props as P;
-    this.depMgr.subscribeNode(props);
+    this.depMgr.subscribeProps(props);
   }
 
   set props(props: AnimatedProps<P>) {
-    this.depMgr.unsubscribeNode(this.props);
+    this.depMgr.unsubscribeProps(this.props);
     this.updateSubscriptionNode(props);
   }
 

--- a/package/src/renderer/nodes/Node.ts
+++ b/package/src/renderer/nodes/Node.ts
@@ -21,18 +21,20 @@ export abstract class Node<P = unknown> {
 
   constructor(depMgr: DependencyManager, props: AnimatedProps<P>) {
     this.depMgr = depMgr;
-    this.updatePropSubscriptions(props);
+    this.updateSubscriptionNode(props);
   }
 
   abstract draw(ctx: DrawingContext): void | DeclarationResult;
 
-  updatePropSubscriptions(props: AnimatedProps<P>) {
-    this.depMgr.subscribeNode(this, props);
+  private updateSubscriptionNode(props: AnimatedProps<P>) {
+    // This cast is ok because we understand that the dependency manager will setup the initial props
+    this.resolvedProps = props as P;
+    this.depMgr.subscribeNode(props);
   }
 
   set props(props: AnimatedProps<P>) {
-    this.depMgr.unsubscribeNode(this);
-    this.updatePropSubscriptions(props);
+    this.depMgr.unsubscribeNode(this.props);
+    this.updateSubscriptionNode(props);
   }
 
   get props(): P {


### PR DESCRIPTION
This is a minor simplification of the depMgr API since the `props` identity doesn't change, we don't need the `node` parameter.