### PR TITLE
Fix minor documentation typo

### DIFF
--- a/docs/docs/getting-started/web.mdx
+++ b/docs/docs/getting-started/web.mdx
@@ -170,7 +170,7 @@ If you are interested to use one of these features, please make [a feature reque
 
 * `PathEffectFactory.MakeSum()`
 * `PathEffectFactory.MakeCompose()`
-* `Font.GetPath()`
+* `PathFactory.MakeFromText()`
 * `ShaderFilter`
 
 **Unplanned**


### PR DESCRIPTION
I realized that we don't expose Font.getPath but we have `PathFactory.MakeFromText`. I greped in src/ to make sure I didn't forget any non implemented methods