### PR TITLE
Create Metal device lazily

### DIFF
--- a/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
+++ b/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
@@ -21,7 +21,6 @@ RNSkMetalCanvasProvider::RNSkMetalCanvasProvider(std::function<void()> requestRe
                         std::shared_ptr<RNSkia::RNSkPlatformContext> context):
 RNSkCanvasProvider(requestRedraw),
   _context(context) {
-  assert([[NSThread currentThread] isMainThread]);
   if (!_device) {
     _device = MTLCreateSystemDefaultDevice();
   }

--- a/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
+++ b/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
@@ -13,15 +13,22 @@
 #pragma clang diagnostic pop
 
 // These static class members are used by all Skia Views
-id<MTLDevice> RNSkMetalCanvasProvider::_device = MTLCreateSystemDefaultDevice();
-id<MTLCommandQueue> RNSkMetalCanvasProvider::_commandQueue = id<MTLCommandQueue>(CFRetain((GrMTLHandle)[_device newCommandQueue]));
-
+id<MTLDevice> RNSkMetalCanvasProvider::_device = nullptr;
+id<MTLCommandQueue> RNSkMetalCanvasProvider::_commandQueue = nullptr;
 sk_sp<GrDirectContext> RNSkMetalCanvasProvider::_skContext = nullptr;
 
 RNSkMetalCanvasProvider::RNSkMetalCanvasProvider(std::function<void()> requestRedraw,
                         std::shared_ptr<RNSkia::RNSkPlatformContext> context):
 RNSkCanvasProvider(requestRedraw),
   _context(context) {
+  assert([[NSThread currentThread] isMainThread]);
+  if (!_device) {
+    _device = MTLCreateSystemDefaultDevice();
+  }
+  if (!_commandQueue) {
+    _commandQueue = id<MTLCommandQueue>(CFRetain((GrMTLHandle)[_device newCommandQueue]));
+  }
+
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wunguarded-availability-new"
   _layer = [CAMetalLayer layer];


### PR DESCRIPTION
# Why

GitHub Actions macOS runners [do not support hardware acceleration](https://github.com/rnmapbox/maps/issues/2139). Even though the code paths don't create a skia view, apps still crash because `MTLCreateSystemDefaultDevice` is initialized when startup.

The crash stackstace with detox:
```
2022-09-24 01:12:41.729 Db BareExpoDetox[77472:31cad] [com.apple.defaults:User Defaults] setting new value 0 for key METAL_DEVICE_WRAPPER_TYPE in CFPrefsSource<0x600003fcd500> (Domain: Volatile, User: , ByHost: No, Container: , Contents Need Refresh: No)
2022-09-24 01:12:41.731 Db BareExpoDetox[77472:31cad] [com.apple.defaults:User Defaults] CFPrefsManagedSource<0x6000004cc480> (Domain: dev.expo.Payments, User: kCFPreferencesCurrentUser, ByHost: Yes, Container: (null), Contents Need Refresh: No) loaded: an empty base plist and no additional changes from the base plist
2022-09-24 01:12:41.731 Db BareExpoDetox[77472:31cad] [com.apple.defaults:User Defaults] CFPrefsManagedSource<0x6000004cc500> (Domain: dev.expo.Payments, User: kCFPreferencesAnyUser, ByHost: Yes, Container: (null), Contents Need Refresh: No) loaded: an empty base plist and no additional changes from the base plist
2022-09-24 01:12:41.731 Db BareExpoDetox[77472:31cad] [com.apple.defaults:User Defaults] looked up value 0 for key METAL_DEVICE_WRAPPER_TYPE in CFPrefsSource<0x600003fcd500> (Domain: Volatile, User: , ByHost: No, Container: , Contents Need Refresh: No) via CFPrefsSearchListSource<0x6000004cc380> (Domain: dev.expo.Payments, Container: (null
2022-09-24 01:12:41.731 Db BareExpoDetox[77472:31cad] [com.apple.CFBundle:resources] Resource lookup at CFBundle 0x7f91c7005320 </Users/runner/Library/Developer/CoreSimulator/Devices/09FD5476-16BF-4B36-B741-13FC3A63656E/data/Containers/Bundle/Application/41353671-09A8-4825-9EB3-378084AEA00E/BareExpoDetox.app> (executable, loaded)
        Request       : InfoPlist type: strings
        Result        : None
2022-09-24 01:12:41.731 Db BareExpoDetox[77472:31cad] [com.apple.defaults:User Defaults] found no value for key MetalForceCaptureEnabled in CFPrefsSearchListSource<0x6000004cc380> (Domain: dev.expo.Payments, Container: (null))
2022-09-24 01:12:41.733 Db BareExpoDetox[77472:31cad] [com.apple.defaults:User Defaults] CFPrefsManagedSource<0x6000004d4280> (Domain: com.apple.metal, User: kCFPreferencesCurrentUser, ByHost: Yes, Container: (null), Contents Need Refresh: No) loaded: an empty base plist and no additional changes from the base plist
2022-09-24 01:12:41.733 Db BareExpoDetox[77472:31cad] [com.apple.defaults:User Defaults] CFPrefsManagedSource<0x6000004d4300> (Domain: com.apple.metal, User: kCFPreferencesAnyUser, ByHost: Yes, Container: (null), Contents Need Refresh: No) loaded: an empty base plist and no additional changes from the base plist
2022-09-24 01:12:41.733 Db BareExpoDetox[77472:31cad] [com.apple.defaults:User Defaults] CFPrefsPlistSource<0x6000004d4180> (Domain: com.apple.metal, User: kCFPreferencesCurrentUser, ByHost: No, Container: (null), Contents Need Refresh: No) loaded: an empty base plist and no additional changes from the base plist
2022-09-24 01:12:41.734 Db BareExpoDetox[77472:31cad] [com.apple.defaults:User Defaults] CFPrefsPlistSource<0x6000004d4480> (Domain: com.apple.metal, User: kCFPreferencesCurrentUser, ByHost: No, Container: /Users/runner/Library/Developer/CoreSimulator/Devices/09FD5476-16BF-4B36-B741-13FC3A63656E/data, Contents Need Refresh: No) loaded: an
2022-09-24 01:12:41.734 Db BareExpoDetox[77472:31cad] [com.apple.defaults:User Defaults] CFPrefsPlistSource<0x6000004d4580> (Domain: com.apple.metal, User: kCFPreferencesCurrentUser, ByHost: Yes, Container: (null), Contents Need Refresh: No) loaded: an empty base plist and no additional changes from the base plist
2022-09-24 01:12:41.734 Db BareExpoDetox[77472:31cad] [com.apple.defaults:User Defaults] found no value for key MetalSimulatorEnabled in CFPrefsSearchListSource<0x6000004d4200> (Domain: com.apple.metal, Container: (null))
2022-09-24 01:12:41.779 E  BareExpoDetox[77472:31cad] [com.wix.Detox:DetoxManager] App crashed: Signal 4 was raised
(
        0   Detox                               0x000000010d966915 +[NSThread(DetoxUtils) dtx_demangledCallStackSymbols] + 37
        1   Detox                               0x000000010d969370 __DTXHandleCrash + 464
        2   Detox                               0x000000010d969ab1 __DTXHandleSignal + 59
        3   libsystem_platform.dylib            0x00007fff6da1dd7d _sigtramp + 29
        4   ???                                 0x000000010d635000 0x0 + 4519579648
        5   BareExpoDetox                       0x000000010a362b8b _GLOBAL__sub_I_RNSkDrawViewImpl.mm + 54
        6   dyld                                0x000000010d4a98b5 invocation function for block in dyld4::Loader::findAndRunAllInitializers(dyld4::RuntimeState&) const + 182
        7   dyld                                0x000000010d4c5d05 invocation function for block in dyld3::MachOAnalyzer::forEachInitializer(Diagnostics&, dyld3::MachOAnalyzer::VMAddrConverter const&, void (unsigned int) block_pointer, void const*) const + 129
        8   dyld     <…>
```

# How

The ideal solution is to support software renderer path, i.e. supporting skia software renderer backend. I think it would take more time to support this feature. This pr is somehow a workaround to create Metal stuffs lazily until someone creates a skia canvas. As long as the app doesn't hit the skia canvas, the app should not just crash on Github Actions runners.