### PR TITLE
Fix wrong undefined value check

### DIFF
--- a/package/cpp/api/JsiSkCanvas.h
+++ b/package/cpp/api/JsiSkCanvas.h
@@ -414,7 +414,7 @@ public:
   JSI_HOST_FUNCTION(saveLayer) {
     SkPaint *paint = (count >= 1 && !arguments[0].isUndefined()) ?
                          JsiSkPaint::fromValue(runtime, arguments[0]).get() : nullptr;
-    SkRect *bounds = count >= 2 && !arguments[1].isNull() && arguments[1].isUndefined() ? JsiSkRect::fromValue(runtime, arguments[1]).get() : nullptr;
+    SkRect *bounds = count >= 2 && !arguments[1].isNull() && !arguments[1].isUndefined() ? JsiSkRect::fromValue(runtime, arguments[1]).get() : nullptr;
     SkImageFilter *backdrop = count >= 3 && !arguments[2].isNull() && !arguments[2].isUndefined() ? JsiSkImageFilter::fromValue(runtime, arguments[2]).get() : nullptr;
     SkCanvas::SaveLayerFlags flags = count >= 4 ? arguments[3].asNumber() : 0;
     return jsi::Value(_canvas->saveLayer(


### PR DESCRIPTION
Hello! This PR fixes wrong `undefined` check by missing `!` operator in `Canvas.saveLayer`