### PR TITLE
Fixed issue with Skia Views not sharing the same native id counter

### DIFF
--- a/package/src/views/SkiaPictureView.tsx
+++ b/package/src/views/SkiaPictureView.tsx
@@ -5,9 +5,8 @@ import type { SkRect } from "../skia/types";
 import type { SkiaValue } from "../values";
 
 import { SkiaViewApi } from "./api";
+import { SkiaViewNativeId } from "./SkiaView";
 import type { NativeSkiaViewProps, SkiaPictureViewProps } from "./types";
-
-let SkiaViewNativeId = 1000;
 
 const NativeSkiaPictureView =
   requireNativeComponent<NativeSkiaViewProps>("SkiaPictureView");
@@ -15,7 +14,7 @@ const NativeSkiaPictureView =
 export class SkiaPictureView extends React.Component<SkiaPictureViewProps> {
   constructor(props: SkiaPictureViewProps) {
     super(props);
-    this._nativeId = SkiaViewNativeId++;
+    this._nativeId = SkiaViewNativeId.current++;
     const { picture } = props;
     if (picture) {
       assertSkiaViewApi();

--- a/package/src/views/SkiaView.tsx
+++ b/package/src/views/SkiaView.tsx
@@ -7,7 +7,7 @@ import type { SkiaValue } from "../values";
 import { SkiaViewApi } from "./api";
 import type { NativeSkiaViewProps, SkiaDrawViewProps } from "./types";
 
-let SkiaViewNativeId = 1000;
+export const SkiaViewNativeId = { current: 1000 };
 
 const NativeSkiaView =
   requireNativeComponent<NativeSkiaViewProps>("SkiaDrawView");
@@ -15,7 +15,7 @@ const NativeSkiaView =
 export class SkiaView extends React.Component<SkiaDrawViewProps> {
   constructor(props: SkiaDrawViewProps) {
     super(props);
-    this._nativeId = SkiaViewNativeId++;
+    this._nativeId = SkiaViewNativeId.current++;
     const { onDraw } = props;
     if (onDraw) {
       assertSkiaViewApi();


### PR DESCRIPTION
When using different types of Skia Views we need to make sure that the native Id counter is shared between the views, otherwise there will be crashes when accessing them on the native side.

This is a bug that hasn't a lot since we basically only have the Skia View used. (PictureView is not documented and not official yet?)