### PR TITLE
Rename <Text /> to <SimpleText />

### DIFF
--- a/docs/docs/image-filters/morphology.md
+++ b/docs/docs/image-filters/morphology.md
@@ -18,7 +18,7 @@ Its usefulness lies primarily in fattening or thinning effects.
 ## Example
 
 ```tsx twoslash
-import {Canvas, Text, Morphology, useFont} from "@shopify/react-native-skia";
+import {Canvas, SimpleText, Morphology, useFont} from "@shopify/react-native-skia";
 
 export const MorphologyDemo = () => {
   const font = useFont(require("./SF-Pro.ttf"), 24);
@@ -27,28 +27,28 @@ export const MorphologyDemo = () => {
   }
   return (
     <Canvas style={{ width: 256, height: 256 }}>
-      <Text
+      <SimpleText
         text="Hello World"
         x={32}
         y={32}
         font={font}
       />
-      <Text
+      <SimpleText
         text="Hello World"
         x={32}
         y={64}
         font={font}
       >
         <Morphology radius={1} />
-      </Text>
-      <Text
+      </SimpleText>
+      <SimpleText
         text="Hello World"
         x={32}
         y={96}
         font={font}
       >
         <Morphology radius={0.3} operator="erode" />
-      </Text>
+      </SimpleText>
     </Canvas>
   );
 };

--- a/docs/docs/text/text.md
+++ b/docs/docs/text/text.md
@@ -1,7 +1,7 @@
 ---
 id: text
-title: Text
-sidebar_label: Text
+title: Simple Text
+sidebar_label: Simple Text
 slug: /text/text
 ---
 
@@ -18,7 +18,7 @@ Please note that the y origin of the Text is the bottom of the text, not the top
 ### Simple Text
 
 ```tsx twoslash
-import {Canvas, Text, useFont, Fill} from "@shopify/react-native-skia";
+import {Canvas, SimpleText, useFont, Fill} from "@shopify/react-native-skia";
 
 export const HelloWorld = () => {
   const fontSize = 32;
@@ -29,7 +29,7 @@ export const HelloWorld = () => {
   return (
     <Canvas style={{ flex: 1 }}>
       <Fill color="white" />
-      <Text
+      <SimpleText
         x={0}
         y={fontSize}
         text="Hello World"
@@ -46,7 +46,7 @@ export const HelloWorld = () => {
 ### Emojis
 
 ```tsx twoslash
-import {Canvas, Text, useFont, Fill} from "@shopify/react-native-skia";
+import {Canvas, SimpleText, useFont, Fill} from "@shopify/react-native-skia";
 
 export const HelloWorld = () => {
   const fontSize = 32;
@@ -57,7 +57,7 @@ export const HelloWorld = () => {
   return (
     <Canvas style={{ flex: 1 }}>
       <Fill color="white" />
-      <Text text="🙋🌎" font={font} y={fontSize} x={0} />
+      <SimpleText text="🙋🌎" font={font} y={fontSize} x={0} />
     </Canvas>
   );
 };

--- a/example/src/Examples/API/BlendModes.tsx
+++ b/example/src/Examples/API/BlendModes.tsx
@@ -7,7 +7,7 @@ import {
   Group,
   Path,
   Skia,
-  Text,
+  SimpleText,
   useFont,
   enumKey,
 } from "@shopify/react-native-skia";
@@ -97,7 +97,7 @@ export const BlendModes = () => {
               <Group layer={paint}>
                 <Path path={src} color="lightblue" />
               </Group>
-              <Text text={blendMode} x={0} y={0} font={font} />
+              <SimpleText text={blendMode} x={0} y={0} font={font} />
             </Group>
           );
         })}

--- a/example/src/Examples/API/Freeze.tsx
+++ b/example/src/Examples/API/Freeze.tsx
@@ -4,7 +4,7 @@ import {
   Canvas,
   Group,
   Rect,
-  Text,
+  SimpleText,
   useClockValue,
   useComputedValue,
 } from "@shopify/react-native-skia";
@@ -28,7 +28,9 @@ export const FreezeExample = () => {
       <Group origin={{ x: size / 2, y: size / 2 }} transform={transform}>
         <Checkerboard color="black" />
       </Group>
-      {font && <Text x={20} y={size + 100} text={`n = ${n * n}`} font={font} />}
+      {font && (
+        <SimpleText x={20} y={size + 100} text={`n = ${n * n}`} font={font} />
+      )}
     </Canvas>
   );
 };

--- a/example/src/Examples/API/ImageFilters.tsx
+++ b/example/src/Examples/API/ImageFilters.tsx
@@ -2,7 +2,7 @@ import {
   Fill,
   Image,
   Offset,
-  Text,
+  SimpleText,
   useImage,
   Morphology,
   Group,
@@ -61,14 +61,14 @@ const MorphologyDemo = () => {
   }
   return (
     <Group>
-      <Text text="Hello World" x={32} y={32} font={font} />
+      <SimpleText text="Hello World" x={32} y={32} font={font} />
       <Group>
         <Morphology radius={1} />
-        <Text text="Hello World" x={32} y={64} font={font} />
+        <SimpleText text="Hello World" x={32} y={64} font={font} />
       </Group>
       <Group>
         <Morphology radius={0.3} operator="erode" />
-        <Text text="Hello World" x={32} y={96} font={font} />
+        <SimpleText text="Hello World" x={32} y={96} font={font} />
       </Group>
     </Group>
   );

--- a/example/src/Examples/Glassmorphism/Card.tsx
+++ b/example/src/Examples/Glassmorphism/Card.tsx
@@ -9,7 +9,7 @@ import {
   Rect,
   LinearGradient,
   Paint,
-  Text,
+  SimpleText,
   useComputedValue,
   runDecay,
   useFont,
@@ -81,11 +81,22 @@ export const Glassmorphism = () => {
           />
         </Paint>
         <Rect x={0} y={CARD_HEIGHT - 70} width={CARD_WIDTH} height={70} />
-        <Text text="SUPERBANK" x={20} y={40} font={titleFont} />
-        <Text x={20} y={110} text="1234 5678 1234 5678" font={titleFont} />
-        <Text text="VALID THRU" x={20} y={145} color="white" font={font} />
-        <Text text="12/29" x={20} y={160} color="white" font={font} />
-        <Text
+        <SimpleText text="SUPERBANK" x={20} y={40} font={titleFont} />
+        <SimpleText
+          x={20}
+          y={110}
+          text="1234 5678 1234 5678"
+          font={titleFont}
+        />
+        <SimpleText
+          text="VALID THRU"
+          x={20}
+          y={145}
+          color="white"
+          font={font}
+        />
+        <SimpleText text="12/29" x={20} y={160} color="white" font={font} />
+        <SimpleText
           text="JOHN DOE"
           x={20}
           y={185}

--- a/example/src/Examples/Graphs/Slider.tsx
+++ b/example/src/Examples/Graphs/Slider.tsx
@@ -11,7 +11,7 @@ import {
   LinearGradient,
   Path,
   useTouchHandler,
-  Text as SkiaText,
+  SimpleText as SkiaText,
   vec,
 } from "@shopify/react-native-skia";
 import React, { useMemo } from "react";

--- a/example/src/Examples/Neumorphism/Dashboard/components/Control.tsx
+++ b/example/src/Examples/Neumorphism/Dashboard/components/Control.tsx
@@ -3,7 +3,7 @@ import {
   vec,
   Group,
   translate,
-  Text,
+  SimpleText,
   Circle,
   LinearGradient,
 } from "@shopify/react-native-skia";
@@ -37,7 +37,7 @@ export const Control = ({
   const labelWidth = font.getTextWidth(label);
   return (
     <Group transform={translate({ x: x + 30, y: y + 30 })}>
-      <Text
+      <SimpleText
         x={2 * r - labelWidth - 16}
         y={r + font.getSize() / 2}
         font={font}

--- a/example/src/Examples/Neumorphism/Dashboard/components/ProgressBar.tsx
+++ b/example/src/Examples/Neumorphism/Dashboard/components/ProgressBar.tsx
@@ -12,7 +12,7 @@ import {
   Path,
   SweepGradient,
   useFont,
-  Text,
+  SimpleText,
   useComputedValue,
   Box,
 } from "@shopify/react-native-skia";
@@ -71,7 +71,7 @@ export const ProgressBar = ({ progress }: ProgressBarProps) => {
           inner
         />
       </Box>
-      <Text
+      <SimpleText
         x={c.x - textWidth / 2}
         y={c.y + font.getSize() / 2}
         font={font}

--- a/example/src/Examples/Neumorphism/Dashboard/components/Title.tsx
+++ b/example/src/Examples/Neumorphism/Dashboard/components/Title.tsx
@@ -1,4 +1,4 @@
-import { Group, Text, useFont } from "@shopify/react-native-skia";
+import { Group, SimpleText, useFont } from "@shopify/react-native-skia";
 import React from "react";
 
 import { Button, BUTTON_SIZE } from "./Button";
@@ -22,7 +22,7 @@ export const Title = ({ title }: Title) => {
       <Button x={30} y={0}>
         <ChervronLeft />
       </Button>
-      <Text
+      <SimpleText
         text={title}
         x={offsetX + (space - titleWidth) / 2}
         y={BUTTON_SIZE - font.getSize()}

--- a/example/src/Examples/Severance/Symbol.tsx
+++ b/example/src/Examples/Severance/Symbol.tsx
@@ -10,7 +10,7 @@ import {
   useComputedValue,
   vec,
   Group,
-  Text,
+  SimpleText,
 } from "@shopify/react-native-skia";
 import React from "react";
 import SimplexNoise from "simplex-noise";
@@ -68,7 +68,7 @@ export const Symbol = ({ i, j, font, pointer, clock }: SymbolProps) => {
   }, [clock]);
   return (
     <Group transform={transform} origin={origin}>
-      <Text text={text} x={dx} y={dy} font={font} color={FG} />
+      <SimpleText text={text} x={dx} y={dy} font={font} color={FG} />
     </Group>
   );
 };

--- a/example/src/Examples/Wallet/components/Label.tsx
+++ b/example/src/Examples/Wallet/components/Label.tsx
@@ -2,7 +2,7 @@ import type { SkiaValue } from "@shopify/react-native-skia";
 import {
   useFont,
   interpolate,
-  Text,
+  SimpleText,
   useComputedValue,
 } from "@shopify/react-native-skia";
 import React from "react";
@@ -58,14 +58,14 @@ export const Label = ({ state, y, graphs, width, height }: LabelProps) => {
   const subtitleWidth = subtitleFont.getTextWidth(subtitle);
   return (
     <>
-      <Text
+      <SimpleText
         x={titleX}
         y={translateY - 120}
         text={text}
         font={titleFont}
         color="white"
       />
-      <Text
+      <SimpleText
         x={width / 2 - subtitleWidth / 2}
         y={translateY - 60}
         text={subtitle}

--- a/package/src/dom/nodes/JsiSkDOM.ts
+++ b/package/src/dom/nodes/JsiSkDOM.ts
@@ -19,7 +19,7 @@ import type {
   RectProps,
   RoundedRectProps,
   VerticesProps,
-  TextProps,
+  SimpleTextProps,
   DiffRectProps,
   OffsetImageFilterProps,
   BlendColorFilterProps,
@@ -68,7 +68,7 @@ import {
   RectNode,
   RRectNode,
   VerticesNode,
-  TextNode,
+  SimpleTextNode,
   OvalNode,
   CustomDrawingNode,
   TextPathNode,
@@ -187,8 +187,8 @@ export class JsiSkDOM implements SkDOM {
     return new VerticesNode(this.ctx, props);
   }
 
-  Text(props: TextProps) {
-    return new TextNode(this.ctx, props);
+  SimpleText(props: SimpleTextProps) {
+    return new SimpleTextNode(this.ctx, props);
   }
 
   TextPath(props: TextPathProps) {

--- a/package/src/dom/nodes/drawings/Text.ts
+++ b/package/src/dom/nodes/drawings/Text.ts
@@ -3,7 +3,7 @@ import type {
   DrawingContext,
   TextBlobProps,
   TextPathProps,
-  TextProps,
+  SimpleTextProps,
 } from "../../types";
 import { NodeType } from "../../types";
 import { processPath } from "../datatypes";
@@ -11,9 +11,9 @@ import type { GlyphsProps } from "../../types/Drawings";
 import { JsiDrawingNode } from "../DrawingNode";
 import type { NodeContext } from "../Node";
 
-export class TextNode extends JsiDrawingNode<TextProps, null> {
-  constructor(ctx: NodeContext, props: TextProps) {
-    super(ctx, NodeType.Text, props);
+export class SimpleTextNode extends JsiDrawingNode<SimpleTextProps, null> {
+  constructor(ctx: NodeContext, props: SimpleTextProps) {
+    super(ctx, NodeType.SimpleText, props);
   }
 
   protected deriveProps() {

--- a/package/src/dom/types/Drawings.ts
+++ b/package/src/dom/types/Drawings.ts
@@ -111,7 +111,7 @@ export interface DiffRectProps extends DrawingNodeProps {
   outer: SkRRect;
 }
 
-export interface TextProps extends DrawingNodeProps {
+export interface SimpleTextProps extends DrawingNodeProps {
   font: SkFont;
   text: string;
   x: number;

--- a/package/src/dom/types/NodeType.ts
+++ b/package/src/dom/types/NodeType.ts
@@ -62,7 +62,7 @@ export const enum NodeType {
   Patch = "skPatch",
   Vertices = "skVertices",
   DiffRect = "skDiffRect",
-  Text = "skText",
+  SimpleText = "skSimpleText",
   TextPath = "skTextPath",
   TextBlob = "skTextBlob",
   Glyphs = "skGlyphs",

--- a/package/src/dom/types/SkDOM.ts
+++ b/package/src/dom/types/SkDOM.ts
@@ -36,7 +36,7 @@ import type {
   RectProps,
   RoundedRectProps,
   VerticesProps,
-  TextProps,
+  SimpleTextProps,
   DiffRectProps,
   TextPathProps,
   TextBlobProps,
@@ -95,7 +95,7 @@ export interface SkDOM {
   Rect(props: RectProps): DrawingNode<RectProps>;
   RRect(props: RoundedRectProps): DrawingNode<RoundedRectProps>;
   Vertices(props: VerticesProps): DrawingNode<VerticesProps>;
-  Text(props: TextProps): DrawingNode<TextProps>;
+  SimpleText(props: SimpleTextProps): DrawingNode<SimpleTextProps>;
   TextPath(props: TextPathProps): DrawingNode<TextPathProps>;
   TextBlob(props: TextBlobProps): DrawingNode<TextBlobProps>;
   Glyphs(props: GlyphsProps): DrawingNode<GlyphsProps>;

--- a/package/src/renderer/HostComponents.ts
+++ b/package/src/renderer/HostComponents.ts
@@ -14,7 +14,7 @@ import type {
   PointsProps,
   RectProps,
   RoundedRectProps,
-  TextProps,
+  SimpleTextProps,
   VerticesProps,
   BlurMaskFilterProps,
   BlendImageFilterProps,
@@ -82,7 +82,7 @@ declare global {
       skRect: SkiaProps<RectProps>;
       skRRect: SkiaProps<RoundedRectProps>;
       skVertices: SkiaProps<VerticesProps>;
-      skText: SkiaProps<TextProps>;
+      skSimpleText: SkiaProps<SimpleTextProps>;
       skTextPath: SkiaProps<TextPathProps>;
       skTextBlob: SkiaProps<TextBlobProps>;
       skGlyphs: SkiaProps<GlyphsProps>;
@@ -178,8 +178,8 @@ export const createNode = (
       return Sk.RRect(props);
     case NodeType.Vertices:
       return Sk.Vertices(props);
-    case NodeType.Text:
-      return Sk.Text(props);
+    case NodeType.SimpleText:
+      return Sk.SimpleText(props);
     case NodeType.TextPath:
       return Sk.TextPath(props);
     case NodeType.TextBlob:

--- a/package/src/renderer/__tests__/ImageFilters.spec.tsx
+++ b/package/src/renderer/__tests__/ImageFilters.spec.tsx
@@ -8,7 +8,7 @@ import {
   Offset,
   RoundedRect,
   Shadow,
-  Text,
+  SimpleText,
 } from "../components";
 
 import {
@@ -26,13 +26,13 @@ describe("Test Image Filters", () => {
     const surface = drawOnNode(
       <>
         <Fill color="white" />
-        <Text text="Hello World" x={96} y={96} font={font} />
-        <Text text="Hello World" x={96} y={192} font={font}>
+        <SimpleText text="Hello World" x={96} y={96} font={font} />
+        <SimpleText text="Hello World" x={96} y={192} font={font}>
           <Morphology radius={3} />
-        </Text>
-        <Text text="Hello World" x={96} y={288} font={font}>
+        </SimpleText>
+        <SimpleText text="Hello World" x={96} y={288} font={font}>
           <Morphology radius={1} operator="erode" />
-        </Text>
+        </SimpleText>
       </>
     );
     processResult(surface, docPath("image-filters/morphology.png"));

--- a/package/src/renderer/__tests__/Text.spec.tsx
+++ b/package/src/renderer/__tests__/Text.spec.tsx
@@ -4,7 +4,14 @@ import nodePath from "path";
 import React from "react";
 
 import { processResult, docPath } from "../../__tests__/setup";
-import { TextPath, Fill, Text, Glyphs, TextBlob, Group } from "../components";
+import {
+  TextPath,
+  Fill,
+  SimpleText,
+  Glyphs,
+  TextBlob,
+  Group,
+} from "../components";
 
 import {
   drawOnNode,
@@ -21,7 +28,7 @@ describe("Test different text examples", () => {
     const surface = drawOnNode(
       <>
         <Fill color="white" />
-        <Text x={0} y={fontSize} font={font} text="Hello World" />
+        <SimpleText x={0} y={fontSize} font={font} text="Hello World" />
       </>
     );
     processResult(surface, docPath("text/hello-world.png"));
@@ -88,7 +95,7 @@ describe("Test different text examples", () => {
     const surface = drawOnNode(
       <>
         <Fill color="white" />
-        <Text text="🙋🌎" font={emojiFont} y={fontSize} x={0} />
+        <SimpleText text="🙋🌎" font={emojiFont} y={fontSize} x={0} />
       </>
     );
     processResult(surface, docPath("text/text-emoji.png"));
@@ -111,14 +118,14 @@ describe("Test different text examples", () => {
     const padding = 16;
     const surface = drawOnNode(
       <>
-        <Text
+        <SimpleText
           text={text}
           font={font}
           y={height / 2}
           x={(width - font.getTextWidth(text)) / 2}
         />
 
-        <Text
+        <SimpleText
           text={text}
           font={font}
           y={height / 2 + fontSize + padding}

--- a/package/src/renderer/components/text/Text.tsx
+++ b/package/src/renderer/components/text/Text.tsx
@@ -11,3 +11,15 @@ SimpleText.defaultProps = {
   x: 0,
   y: 0,
 };
+
+export const Text = (props: SkiaProps<SimpleTextProps>) => {
+  console.log(
+    "<Text /> is now <SimpleText />. In the next release <Text /> will have a new API."
+  );
+  return <skSimpleText {...props} />;
+};
+
+Text.defaultProps = {
+  x: 0,
+  y: 0,
+};

--- a/package/src/renderer/components/text/Text.tsx
+++ b/package/src/renderer/components/text/Text.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
 import type { SkiaProps } from "../../processors";
-import type { TextProps } from "../../../dom/types";
+import type { SimpleTextProps } from "../../../dom/types";
 
-export const Text = (props: SkiaProps<TextProps>) => {
-  return <skText {...props} />;
+export const SimpleText = (props: SkiaProps<SimpleTextProps>) => {
+  return <skSimpleText {...props} />;
 };
 
-Text.defaultProps = {
+SimpleText.defaultProps = {
   x: 0,
   y: 0,
 };


### PR DESCRIPTION
The idea behind this renaming is that people can simply use `<SimpleText />` to not break their current app and they will be able to migrate to the new Text API (via <Text />) at their own pace.