### PR TITLE
Skia m108

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build-skia": "yarn build-skia-ios && yarn build-skia-android",
     "clean-skia": "yarn rimraf ./package/libs && yarn rimraf ./externals/skia/out",
     "copy-skia-include-headers": "yarn rimraf ./package/cpp/skia/include/ && cp -a ./externals/skia/include/. ./package/cpp/skia/include",
-    "copy-skia-module-headers": "yarn rimraf ./package/cpp/skia/modules/ && mkdir -p ./package/cpp/skia/modules/svg/include && mkdir -p ./package/cpp/skia/modules/skresources/include && cp -a ./externals/skia/modules/svg/include/. ./package/cpp/skia/modules/svg/include && cp -a ./externals/skia/modules/skresources/include/. ./package/cpp/skia/modules/skresources/include",
+    "copy-skia-module-headers": "yarn rimraf ./package/cpp/skia/modules/ && mkdir -p ./package/cpp/skia/modules/svg/include && mkdir -p ./package/cpp/skia/modules/skcms && mkdir -p ./package/cpp/skia/modules/skresources/include && cp -a ./externals/skia/modules/svg/include/. ./package/cpp/skia/modules/svg/include && cp -a ./externals/skia/modules/skresources/include/. ./package/cpp/skia/modules/skresources/include && cp -a ./externals/skia/modules/skcms/. ./package/cpp/skia/modules/skcms",
     "copy-skia-headers": "yarn copy-skia-module-headers && yarn copy-skia-include-headers",
     "build-npm": "yarn ts-node ./scripts/build-npm-package.ts",
     "get-filename-npm": "yarn ts-node ./scripts/get-npm-filename.ts",

--- a/package/cpp/api/JsiSkImageFilterFactory.h
+++ b/package/cpp/api/JsiSkImageFilterFactory.h
@@ -204,7 +204,7 @@ public:
   JSI_HOST_FUNCTION(MakeRuntimeShader) {
     auto rtb = JsiSkRuntimeShaderBuilder::fromValue(runtime, arguments[0]);
 
-    const char *childName = nullptr;
+    const char *childName = "";
     if (!arguments[1].isNull() && !arguments[1].isUndefined()) {
       childName = arguments[1].asString(runtime).utf8(runtime).c_str();
     }

--- a/package/cpp/api/JsiSkPath.h
+++ b/package/cpp/api/JsiSkPath.h
@@ -14,6 +14,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
 
+#include <SkPathEffect.h>
 #include <SkDashPathEffect.h>
 #include <SkParsePath.h>
 #include <SkPath.h>

--- a/package/cpp/api/JsiSkPath.h
+++ b/package/cpp/api/JsiSkPath.h
@@ -14,10 +14,10 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
 
-#include <SkPathEffect.h>
 #include <SkDashPathEffect.h>
 #include <SkParsePath.h>
 #include <SkPath.h>
+#include <SkPathEffect.h>
 #include <SkPathOps.h>
 #include <SkPathTypes.h>
 #include <SkString.h>

--- a/package/cpp/api/JsiSkRuntimeEffect.h
+++ b/package/cpp/api/JsiSkRuntimeEffect.h
@@ -99,7 +99,7 @@ public:
       throw jsi::JSError(runtime, "invalid uniform index");
     }
     auto it = getObject()->uniforms().begin() + i;
-    return jsi::String::createFromAscii(runtime, it->name.c_str());
+    return jsi::String::createFromAscii(runtime, std::string(it->name));
   }
 
   JSI_HOST_FUNCTION(getUniform) {


### PR DESCRIPTION
This PR upgrades our Skia build system to the m108 milestone of Skia.

https://skia.googlesource.com/skia/+/refs/heads/main/RELEASE_NOTES.txt

NOTE: Remember to build Skia Binaries after merging - and THEN build a new Skia release.
NOTE 2: The Skia M108 branch will fail since it tries to build and link with the current artifacts using m103.