### PR TITLE
Update babel config to transpile nullish-coalescing-operator

### DIFF
--- a/package/.babelrc
+++ b/package/.babelrc
@@ -1,0 +1,33 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "browsers": [
+            ">1%",
+            "last 2 chrome versions",
+            "last 2 edge versions",
+            "last 2 firefox versions",
+            "last 2 safari versions",
+            "not dead",
+            "not ie <= 11",
+            "not op_mini all",
+            "not android <= 4.4",
+            "not samsung <= 4"
+          ],
+          "node": "16"
+        },
+        "useBuiltIns": false,
+        "modules": false
+      }
+    ],
+    "@babel/preset-react",
+    "@babel/preset-typescript",
+    "@babel/preset-flow"
+  ],
+  "plugins": [
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-nullish-coalescing-operator"
+  ]
+}

--- a/package/package.json
+++ b/package/package.json
@@ -91,6 +91,7 @@
     "typescript": "4.8.3"
   },
   "dependencies": {
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
     "canvaskit-wasm": "0.36.1",
     "react-reconciler": "0.26.2"
   },
@@ -103,7 +104,12 @@
     "output": "lib",
     "targets": [
       "commonjs",
-      "module",
+      [
+        "module",
+        {
+          "configFile": "./.babelrc"
+        }
+      ],
       "typescript"
     ]
   }


### PR DESCRIPTION
fixes #1030

This PR adds the babelrc config file, which is a copy of the config used in bob-build (the one we use: https://github.com/callstack/react-native-builder-bob/blob/main/packages/react-native-builder-bob/src/utils/compile.ts#L65) and extends it with `@babel/plugin-proposal-nullish-coalescing-operator`