### PR TITLE
fix: remove jcenter from android repositories

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -162,7 +162,6 @@ android {
 
 repositories {
     // ref: https://www.baeldung.com/maven-local-repository
-    jcenter()
     mavenLocal()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -161,17 +161,23 @@ android {
 }
 
 repositories {
-    // ref: https://www.baeldung.com/maven-local-repository
-    mavenLocal()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "$rootDir/../node_modules/react-native/android"
+        url("$rootDir/../node_modules/react-native/android")
     }
     maven {
         // Android JSC is installed from npm
-        url "$rootDir/../node_modules/jsc-android/dist"
+        url("$rootDir/../node_modules/jsc-android/dist")
+    }
+    mavenCentral {
+        // We don't want to fetch react-native from Maven Central as there are
+        // older versions over there.
+        content {
+            excludeGroup "com.facebook.react"
+        }
     }
     google()
+    maven { url 'https://www.jitpack.io' }
 }
 
 dependencies {


### PR DESCRIPTION
This should fix build for Android because jcenter was shutdown.

fixes #1039