### PR TITLE
Upgraded reanimated to v.2.12 after build failure

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -33,7 +33,7 @@
     "react": "18.1.0",
     "react-dom": "^18.0.0",
     "react-native": "0.70.1",
-    "react-native-reanimated": "2.10.0",
+    "react-native-reanimated": "2.12.0",
     "react-native-safe-area-context": "4.3.4",
     "react-native-screens": "3.17.0",
     "react-native-web": "^0.18.0",


### PR DESCRIPTION
Reanimated now makes our builds fail on Android - it looks like something related was fixed in version 2.11, so this PR upgrades Reanimated to 2.12 in the example package.