### PR TITLE
Fix color parsing on RN Web

### DIFF
--- a/package/src/skia/__tests__/Geometry.spec.ts
+++ b/package/src/skia/__tests__/Geometry.spec.ts
@@ -24,10 +24,16 @@ describe("Geometry", () => {
   test("parse #hex with opacity", () => {
     const { Skia } = importSkia();
 
-    const color = Skia.Color("#80808080");
+    let color = Skia.Color("#80808080");
     expect(color[0]).toBeCloseTo(0.5);
     expect(color[1]).toBeCloseTo(0.5);
     expect(color[2]).toBeCloseTo(0.5);
+    expect(color[3]).toBeCloseTo(0.5);
+
+    color = Skia.Color("#ff800080");
+    expect(color[0]).toBeCloseTo(1);
+    expect(color[1]).toBeCloseTo(0.5);
+    expect(color[2]).toBeCloseTo(0);
     expect(color[3]).toBeCloseTo(0.5);
   });
 });

--- a/package/src/skia/__tests__/Geometry.spec.ts
+++ b/package/src/skia/__tests__/Geometry.spec.ts
@@ -12,4 +12,22 @@ describe("Geometry", () => {
     expect(result.width).toBe(140);
     expect(result.height).toBe(60);
   });
+
+  test("parse #hex without opacity", () => {
+    const { Skia } = importSkia();
+
+    const color = Skia.Color("#808080");
+    expect(color[0]).toBeCloseTo(0.5);
+    expect(color[1]).toBeCloseTo(0.5);
+    expect(color[2]).toBeCloseTo(0.5);
+  });
+  test("parse #hex with opacity", () => {
+    const { Skia } = importSkia();
+
+    const color = Skia.Color("#80808080");
+    expect(color[0]).toBeCloseTo(0.5);
+    expect(color[1]).toBeCloseTo(0.5);
+    expect(color[2]).toBeCloseTo(0.5);
+    expect(color[3]).toBeCloseTo(0.5);
+  });
 });

--- a/package/src/skia/web/JsiSkColor.ts
+++ b/package/src/skia/web/JsiSkColor.ts
@@ -241,6 +241,15 @@ const parseCSSColor = (cssStr: string) => {
         return null;
       } // Covers NaN.
       return [(iv & 0xff0000) >> 16, (iv & 0xff00) >> 8, iv & 0xff, 1];
+    } else if (str.length === 9) {
+      var iv = parseInt(str.substr(1, 6), 16); // TODO(deanm): Stricter parsing.
+      const opacity = parseInt(str.substr(7), 16);
+      return [
+        (iv & 0xff0000) >> 16,
+        (iv & 0xff00) >> 8,
+        iv & 0xff,
+        opacity / 255,
+      ];
     }
 
     return null;

--- a/package/src/skia/web/JsiSkColor.ts
+++ b/package/src/skia/web/JsiSkColor.ts
@@ -252,14 +252,6 @@ const parseCSSColor = (cssStr: string) => {
         (iv & 0xff00) >> 8,
         (iv & 0xff) / 255,
       ];
-      /*
-            if (!(iv >= 0 && iv <= 0xffffffff))
-        return {}; // Covers NaN.
-      return {static_cast<uint8_t>(((iv & 0xff000000) >> 24) & 0xff),
-              static_cast<uint8_t>((iv & 0x00ff0000) >> 16),
-              static_cast<uint8_t>((iv & 0x0000ff00) >> 8),
-              static_cast<uint8_t>((iv & 0x000000ff)) / 255.0f};
-              */
     }
 
     return null;

--- a/package/src/skia/web/JsiSkColor.ts
+++ b/package/src/skia/web/JsiSkColor.ts
@@ -242,14 +242,24 @@ const parseCSSColor = (cssStr: string) => {
       } // Covers NaN.
       return [(iv & 0xff0000) >> 16, (iv & 0xff00) >> 8, iv & 0xff, 1];
     } else if (str.length === 9) {
-      var iv = parseInt(str.substr(1, 6), 16); // TODO(deanm): Stricter parsing.
-      const opacity = parseInt(str.substr(7), 16);
+      var iv = parseInt(str.substr(1), 16); // TODO(deanm): Stricter parsing.
+      if (!(iv >= 0 && iv <= 0xffffffff)) {
+        return null; // Covers NaN.
+      }
       return [
+        ((iv & 0xff000000) >> 24) & 0xff,
         (iv & 0xff0000) >> 16,
         (iv & 0xff00) >> 8,
-        iv & 0xff,
-        opacity / 255,
+        (iv & 0xff) / 255,
       ];
+      /*
+            if (!(iv >= 0 && iv <= 0xffffffff))
+        return {}; // Covers NaN.
+      return {static_cast<uint8_t>(((iv & 0xff000000) >> 24) & 0xff),
+              static_cast<uint8_t>((iv & 0x00ff0000) >> 16),
+              static_cast<uint8_t>((iv & 0x0000ff00) >> 8),
+              static_cast<uint8_t>((iv & 0x000000ff)) / 255.0f};
+              */
     }
 
     return null;


### PR DESCRIPTION
Add support for the 0xrrggbbaa syntax on RN web
The JS ans C++ implementations are symmetric there.