### PR TITLE
Deprecate useCanvas()

### DIFF
--- a/docs/docs/animations/values.md
+++ b/docs/docs/animations/values.md
@@ -89,16 +89,9 @@ const Demo = () => {
 };
 ```
 
-## Canvas
+## Canvas Size
 
-The `useCanvas` hook returns a `size` value that updates every time the canvas size updates.
-On the first frame, the size is zero.
-
-:::caution
-
-`useCanvas` can only be used inside the Canvas element because it relies on context.
-
-:::
+The `onSize` property will assign a `size` to a Skia value.
 
 ```tsx twoslash
 import React from "react";
@@ -108,22 +101,19 @@ import {
   Group,
   Rect,
   rect,
-  useCanvas,
+  useValue,
   useComputedValue,
 } from "@shopify/react-native-skia";
-
-const MyComp = () => {
-  // 💚 useCanvas() can safely be used here
-  const { size } = useCanvas();
-  // 💚 canvas is a regular skia value that can be used for animations
+const Example = () => {
+  const size = useValue({ width: 0, height: 0 });
   const rct = useComputedValue(() => {
     return rect(0, 0, size.current.width, size.current.height / 2);
   }, [size]);
   return (
+    <Canvas style={{ flex: 1 }} onSize={size}>
     <Group>
       <Fill color="magenta" />
       <Rect color="cyan" rect={rct} />
-      {/* ❌ this won't update since canvas is a skia value */}
       <Rect
         x={0}
         y={0}
@@ -132,14 +122,6 @@ const MyComp = () => {
         color="red"
       />
     </Group>
-  );
-};
-
-const Example = () => {
-  // ❌ Using useCanvas() here would crash
-  return (
-    <Canvas style={{ flex: 1 }}>
-      <MyComp />
     </Canvas>
   );
 };

--- a/docs/docs/canvas/canvas.md
+++ b/docs/docs/canvas/canvas.md
@@ -15,6 +15,7 @@ Behind the scenes, it is using its own React renderer.
 | ref?   | `Ref<SkiaView>` | Reference to the `SkiaView` object |
 | mode?   | `default` or `continuous` | By default, the canvas is only updated when the drawing tree or animation values change. With `mode="continuous"`, the canvas will redraw on every frame |
 | onTouch?    | `TouchHandler` | Touch handler for the Canvas (see [touch handler](/docs/animations/touch-events#usetouchhandler)) |
+| onSize? | `SkiaMutableValue<Size>` | Skia value to which the canvas size will be assigned  (see [canvas size](/docs/animations/values#canvas-size)) |
 | onLayout? | `NativeEvent<LayoutEvent>` | Invoked on mount and on layout changes (see [onLayout](https://reactnative.dev/docs/view#onlayout)) |
 
 ## Getting the Canvas size

--- a/example/src/Examples/API/UseCanvas.tsx
+++ b/example/src/Examples/API/UseCanvas.tsx
@@ -1,17 +1,22 @@
+import type { SkiaValue } from "@shopify/react-native-skia";
 import {
+  useValue,
+  Vector,
   Canvas,
   Fill,
   Group,
   Rect,
   rect,
-  useCanvas,
   useComputedValue,
 } from "@shopify/react-native-skia";
 import React, { useEffect, useRef } from "react";
 import { View, Animated } from "react-native";
 
-const MyComp = () => {
-  const { size } = useCanvas();
+interface MyCompProps {
+  size: SkiaValue<{ width: number; height: number }>;
+}
+
+const MyComp = ({ size }: MyCompProps) => {
   const rct = useComputedValue(() => {
     return rect(0, 0, size.current.width, size.current.height / 2);
   }, [size]);
@@ -24,6 +29,7 @@ const MyComp = () => {
 };
 
 export const UseCanvas = () => {
+  const size = useValue({ width: 0, height: 0 });
   const height = useRef(new Animated.Value(0));
   useEffect(() => {
     Animated.loop(
@@ -36,8 +42,8 @@ export const UseCanvas = () => {
   }, []);
   return (
     <View style={{ flex: 1 }}>
-      <Canvas style={{ flex: 1 }}>
-        <MyComp />
+      <Canvas style={{ flex: 1 }} onSize={size}>
+        <MyComp size={size} />
       </Canvas>
       <Animated.View style={{ height: height.current }} />
     </View>

--- a/package/src/renderer/Canvas.tsx
+++ b/package/src/renderer/Canvas.tsx
@@ -21,6 +21,7 @@ import type { TouchHandler } from "../views";
 import { useValue } from "../values/hooks/useValue";
 import { Skia } from "../skia/Skia";
 import type { SkiaValue } from "../values";
+import type { SkiaMutableValue } from "../../lib/typescript/src/values/types";
 
 import { debug as hostDebug, skHostConfig } from "./HostConfig";
 // import { debugTree } from "./nodes";
@@ -49,10 +50,11 @@ export interface CanvasProps extends ComponentProps<typeof SkiaView> {
   ref?: RefObject<SkiaView>;
   children: ReactNode;
   onTouch?: TouchHandler;
+  onSize?: SkiaMutableValue<{ width: number; height: number }>;
 }
 
 export const Canvas = forwardRef<SkiaView, CanvasProps>(
-  ({ children, style, debug, mode, onTouch }, forwardedRef) => {
+  ({ children, style, debug, mode, onTouch, onSize }, forwardedRef) => {
     const size = useValue({ width: 0, height: 0 });
     const canvasCtx = useMemo(() => ({ Skia, size }), [size]);
     const innerRef = useCanvasRef();
@@ -114,6 +116,9 @@ export const Canvas = forwardRef<SkiaView, CanvasProps>(
           height !== canvasCtx.size.current.height
         ) {
           canvasCtx.size.current = { width, height };
+          if (onSize) {
+            onSize.current = { width, height };
+          }
         }
         paint.reset();
         const ctx = {

--- a/package/src/renderer/useCanvas.ts
+++ b/package/src/renderer/useCanvas.ts
@@ -14,6 +14,10 @@ export const CanvasProvider = CanvasContext.Provider;
 
 export const useCanvas = () => {
   const ctx = useContext(CanvasContext);
+  console.warn(
+    // eslint-disable-next-line max-len
+    "useCanvas is deprecated. use the onSize property instead: https://shopify.github.io/react-native-skia/docs/canvas/overview"
+  );
   if (!ctx) {
     throw new Error("Canvas context is not available");
   }


### PR DESCRIPTION
The goal of this PR is to deprecate useCanvas() with a solution that is symmetric with onTouch.
This symmetry is important for the functionality to  work correctly on the UI thread.