### PR TITLE
Fixed issue with JS thread add/remove nodes in render cycle 

### DIFF
--- a/package/cpp/rnskia/dom/base/JsiDependencyManager.h
+++ b/package/cpp/rnskia/dom/base/JsiDependencyManager.h
@@ -114,13 +114,12 @@ public:
     _subscriptions.emplace(node.get(), unsubscribers);
 
     // Set callback for unsubscribing
-    node->setDisposeCallback(
-        [node = node.get(), weakSelf = weak_from_this()]() {
-          auto self = weakSelf.lock();
-          if (self) {
-            self->unsubscribeNode(node);
-          }
-        });
+    node->setDisposeCallback([node, weakSelf = weak_from_this()]() {
+      auto self = weakSelf.lock();
+      if (self) {
+        self->unsubscribeNode(node.get());
+      }
+    });
 
     return jsi::Value::undefined();
   }

--- a/package/cpp/rnskia/dom/props/PaintProps.h
+++ b/package/cpp/rnskia/dom/props/PaintProps.h
@@ -150,8 +150,7 @@ public:
     // AntiAlias
     if (_antiAlias->isSet() &&
         (_antiAlias->isChanged() || context->isChanged())) {
-      context->getMutablePaint()->setAntiAlias(
-          _antiAlias->value().getAsBool());
+      context->getMutablePaint()->setAntiAlias(_antiAlias->value().getAsBool());
     }
   }
 


### PR DESCRIPTION
When the reconciler is building / setting up, we might get into a situation where the Skia Dom View tries to render before the reconciler is complete - meaning that we might get added/removed/inserted nodes while we're rendering. This will cause the DOM tree to become invalid as we render and caused the crash described in #1122.

- Added list of node operations that are saved and not executed before the main thread is ready when it comes to updating children
- Fixed use of pointer -> shared pointer in dependency manager when unsubscribing to the node
- Clang format

fixes #1122 