### PR TITLE
Added using runtime ICU on Android flag when building Skia

### DIFF
--- a/package/cpp/rnskia/RNSkDomView.cpp
+++ b/package/cpp/rnskia/RNSkDomView.cpp
@@ -86,8 +86,7 @@ void RNSkDomRenderer::renderCanvas(SkCanvas *canvas, float scaledWidth,
   if (_drawingContext == nullptr) {
     auto paint = std::make_shared<SkPaint>();
     paint->setAntiAlias(true);
-    _drawingContext =
-        std::make_shared<DrawingContext>(paint, 1.0f);
+    _drawingContext = std::make_shared<DrawingContext>(paint, 1.0f);
 
     _drawingContext->setRequestRedraw([weakSelf = weak_from_this()]() {
       auto self = weakSelf.lock();

--- a/scripts/skia-configuration.ts
+++ b/scripts/skia-configuration.ts
@@ -66,6 +66,7 @@ export const configurations: Configuration = {
     args: [
       ["ndk", `"${NdkDir}"`],
       ["skia_use_system_freetype2", false],
+      ["skia_use_runtime_icu", true],
       ["skia_use_gl", true],
       ["cc", '"clang"'],
       ["cxx", '"clang++"'],


### PR DESCRIPTION
To reduce the file size of the Skia library on Android we should use the runtime version available when building Skia. This is enabled using the `skia_use_runtime_icu=true` build configuration. This reduces the file size on Android from 9 to 5,6 mb.

NOTE: This fix requires building the Skia libs (running Build SKIA action).

Tested on Android (iOS is not affected, but tested there as well).