### PR TITLE
fix: Provide default implementation for virtual methods `startDrawLoop` and `stopDrawLoop`

### DIFF
--- a/package/android/cpp/rnskia-android/RNSkAndroidPlatformContext.h
+++ b/package/android/cpp/rnskia-android/RNSkAndroidPlatformContext.h
@@ -24,6 +24,10 @@ public:
         [this]() { notifyDrawLoop(false); });
   }
 
+  ~RNSkAndroidPlatformContext() {
+    stopDrawLoop();
+  }
+
   void performStreamOperation(
       const std::string &sourceUri,
       const std::function<void(std::unique_ptr<SkStreamAsset>)> &op) override {

--- a/package/cpp/rnskia/RNSkPlatformContext.h
+++ b/package/cpp/rnskia/RNSkPlatformContext.h
@@ -188,8 +188,9 @@ public:
     }
   }
 
-  virtual void startDrawLoop() = 0;
-  virtual void stopDrawLoop() = 0;
+  // default implementation does nothing, so it can be called from virtual destructor.
+  virtual void startDrawLoop() {}
+  virtual void stopDrawLoop() {}
 
 private:
   float _pixelDensity;

--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
@@ -48,6 +48,7 @@ public:
   ~RNSkiOSPlatformContext() {
     CFNotificationCenterRemoveEveryObserver(
         CFNotificationCenterGetLocalCenter(), this);
+    stopDrawLoop();
   }
 
   void startDrawLoop() override;


### PR DESCRIPTION
`startDrawLoop` and `stopDrawLoop` had no default implementation (`= 0`), but they were called from the destructor (`~RNSkPlatformContext`).

A C++ destructor runs after all of it subclasses destructors ran, meaning that the subclasses (`RNSkiOSPlatformContext` or `RNAndroidPlatformContext`) had already been destroyed and cleaned up their v-tables.
This means that this would crash with the error `Pure virtual function called!`.

To fix this, we provide default implementations, so that the functions aren't purely virtual anymore and can still be safely called. We assume that the subclasses have cleaned up themselves properly.