### PR TITLE
Add initialisation of uninitialised pointer

### DIFF
--- a/package/cpp/rnskia/dom/base/JsiDomNode.h
+++ b/package/cpp/rnskia/dom/base/JsiDomNode.h
@@ -436,7 +436,7 @@ private:
 
   std::vector<std::function<void()>> _queuedNodeOps;
 
-  JsiDomNode *_parent;
+  JsiDomNode *_parent = nullptr;
 };
 
 } // namespace RNSkia


### PR DESCRIPTION
PR #1168 correctly identifies a crash on Android with the changes from PR #1158. This PR contains a fix for the issue.

The problem was that in #1158 we introduced a pointer to the parent node in the native DOM so that children and parents could notify each other about changes. This was done using a regular pointer to avoid cyclic dependencies with shared ptrs. 

On iOS the pointer was initialised to zero, while on android it was not - causing a seg fault when accessing the invalid pointer.

This PR adds a nullptr initialisation for the parent pointer.

I've done some searches around our code to see if we have the same pattern, but other places we use pointers we also initialise these from the constructors.

This PR closes #1168.