### PR TITLE
Optimisation: Optimised some tight loops in C++

### DIFF
--- a/package/cpp/rnskia/RNSkPlatformContext.h
+++ b/package/cpp/rnskia/RNSkPlatformContext.h
@@ -178,12 +178,8 @@ public:
     if (!_isValid) {
       return;
     }
-    std::unordered_map<size_t, std::function<void(bool)>> tmp;
-    {
-      std::lock_guard<std::mutex> lock(_drawCallbacksLock);
-      tmp.insert(_drawCallbacks.cbegin(), _drawCallbacks.cend());
-    }
-    for (auto it = tmp.begin(); it != tmp.end(); it++) {
+    std::lock_guard<std::mutex> lock(_drawCallbacksLock);
+    for (auto it = _drawCallbacks.begin(); it != _drawCallbacks.end(); it++) {
       it->second(invalidated);
     }
   }

--- a/package/cpp/rnskia/values/RNSkReadonlyValue.h
+++ b/package/cpp/rnskia/values/RNSkReadonlyValue.h
@@ -142,12 +142,8 @@ protected:
    @param runtime Current JS Runtime
    */
   void notifyListeners(jsi::Runtime &runtime) {
-    std::unordered_map<long, std::function<void(jsi::Runtime &)>> tmp;
-    {
-      std::lock_guard<std::mutex> lock(_mutex);
-      tmp.insert(_listeners.cbegin(), _listeners.cend());
-    }
-    for (const auto &listener : tmp) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    for (const auto &listener : _listeners) {
       listener.second(runtime);
     }
   }


### PR DESCRIPTION
This optimization takes the CPU meter from 32-35% usage down to 31-33% on iOS.

When running tight loops we previously copied the contents of the vector we wanted to loop through in two different areas; the RNSkReadonlyValue and the RNSkPlatformContext notifiers. This was done to avoid crash if we were inserting elements at the same time as we were enumerating - and we also had some locking going on in there.

This has now been removed and replaced by a tight loop that does not allocate new elements. The new loops are protected by a lock.