### PR TITLE
#1197: Changed Views to be driven by ReactViewManager

### DIFF
--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaBaseView.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaBaseView.java
@@ -7,25 +7,36 @@ import android.view.Surface;
 import android.view.TextureView;
 
 import com.facebook.jni.annotations.DoNotStrip;
+import com.facebook.react.uimanager.PointerEvents;
+import com.facebook.react.views.view.ReactViewGroup;
 
-public abstract class SkiaBaseView extends TextureView implements TextureView.SurfaceTextureListener {
+public abstract class SkiaBaseView extends ReactViewGroup implements TextureView.SurfaceTextureListener {
 
     @DoNotStrip
     private Surface mSurface;
+    private TextureView mTexture;
 
     public SkiaBaseView(Context context) {
         super(context);
-        setSurfaceTextureListener(this);
-        setOpaque(false);
+        mTexture = new TextureView(context);
+        mTexture.setSurfaceTextureListener(this);
+        mTexture.setOpaque(false);
+        addView(mTexture);
     }
 
     @Override
-    public void setBackgroundColor(int color) {
-        // Texture view does not support setting the background color.
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+        mTexture.layout(0, 0, this.getMeasuredWidth(), this.getMeasuredHeight());
     }
 
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
+        // We do not accept the touch event if this view is not supposed to receive it.
+        if (!PointerEvents.canBeTouchTarget(getPointerEvents())) {
+            return false;
+        }
+
         // https://developer.android.com/training/gestures/multi
         int action = ev.getActionMasked();
 

--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaBaseViewManager.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaBaseViewManager.java
@@ -1,0 +1,34 @@
+package com.shopify.reactnative.skia;
+
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.views.view.ReactViewGroup;
+import com.facebook.react.views.view.ReactViewManager;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public abstract class SkiaBaseViewManager extends ReactViewManager {
+
+    @Override
+    public void setNativeId(@NonNull ReactViewGroup view, @Nullable String nativeId) {
+        super.setNativeId(view, nativeId);
+        int nativeIdResolved = Integer.parseInt(nativeId);
+        ((SkiaBaseView)view).registerView(nativeIdResolved);
+    }
+
+    @ReactProp(name = "mode")
+    public void setMode(ReactViewGroup view, String mode) {
+        ((SkiaBaseView)view).setMode(mode);
+    }
+
+    @ReactProp(name = "debug")
+    public void setDebug(ReactViewGroup view, boolean show) {
+        ((SkiaBaseView)view).setDebugMode(show);
+    }
+
+    @Override
+    public void onDropViewInstance(@NonNull ReactViewGroup view) {
+        super.onDropViewInstance(view);
+        ((SkiaBaseView)view).unregisterView();
+    }
+}

--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDomViewManager.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDomViewManager.java
@@ -1,17 +1,9 @@
 package com.shopify.reactnative.skia;
 
-import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.uimanager.BaseViewManager;
-import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.annotations.ReactProp;
-
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
-import java.util.HashMap;
-
-public class SkiaDomViewManager extends BaseViewManager<SkiaDomView, LayoutShadowNode> {
+public class SkiaDomViewManager extends SkiaBaseViewManager {
 
     @NonNull
     @Override
@@ -19,46 +11,9 @@ public class SkiaDomViewManager extends BaseViewManager<SkiaDomView, LayoutShado
         return "SkiaDomView";
     }
 
-    @Override
-    public LayoutShadowNode createShadowNodeInstance() {
-        return new LayoutShadowNode();
-    }
-
-    @Override
-    public Class<? extends LayoutShadowNode> getShadowNodeClass() {
-        return LayoutShadowNode.class;
-    }
-
-    @Override
-    public void updateExtraData(SkiaDomView root, Object extraData) {
-    }
-
-    @Override
-    public void setNativeId(@NonNull SkiaDomView view, @Nullable String nativeId) {
-        super.setNativeId(view, nativeId);
-        int nativeIdResolved = Integer.parseInt(nativeId);
-        view.registerView(nativeIdResolved);
-    }
-
-    @ReactProp(name = "mode")
-    public void setMode(SkiaDomView view, String mode) {
-        view.setMode(mode);
-    }
-
-    @ReactProp(name = "debug")
-    public void setDebug(SkiaDomView view, boolean show) {
-        view.setDebugMode(show);
-    }
-
-    @Override
-    public void onDropViewInstance(@NonNull SkiaDomView view) {
-        super.onDropViewInstance(view);
-        view.unregisterView();
-    }
-
     @NonNull
     @Override
-    protected SkiaDomView createViewInstance(@NonNull ThemedReactContext reactContext) {
+    public SkiaDomView createViewInstance(@NonNull ThemedReactContext reactContext) {
         return new SkiaDomView(reactContext);
     }
 }

--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDrawViewManager.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDrawViewManager.java
@@ -1,14 +1,9 @@
 package com.shopify.reactnative.skia;
 
-import com.facebook.react.uimanager.BaseViewManager;
-import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.annotations.ReactProp;
-
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
-public class SkiaDrawViewManager extends BaseViewManager<SkiaDrawView, LayoutShadowNode> {
+public class SkiaDrawViewManager extends SkiaBaseViewManager {
 
     @NonNull
     @Override
@@ -16,46 +11,9 @@ public class SkiaDrawViewManager extends BaseViewManager<SkiaDrawView, LayoutSha
         return "SkiaDrawView";
     }
 
-    @Override
-    public LayoutShadowNode createShadowNodeInstance() {
-        return new LayoutShadowNode();
-    }
-
-    @Override
-    public Class<? extends LayoutShadowNode> getShadowNodeClass() {
-        return LayoutShadowNode.class;
-    }
-
-    @Override
-    public void updateExtraData(SkiaDrawView root, Object extraData) {
-    }
-
-    @Override
-    public void setNativeId(@NonNull SkiaDrawView view, @Nullable String nativeId) {
-        super.setNativeId(view, nativeId);
-        int nativeIdResolved = Integer.parseInt(nativeId);
-        view.registerView(nativeIdResolved);
-    }
-
-    @ReactProp(name = "mode")
-    public void setMode(SkiaDrawView view, String mode) {
-        view.setMode(mode);
-    }
-
-    @ReactProp(name = "debug")
-    public void setDebug(SkiaDrawView view, boolean show) {
-        view.setDebugMode(show);
-    }
-
-    @Override
-    public void onDropViewInstance(@NonNull SkiaDrawView view) {
-        super.onDropViewInstance(view);
-        view.unregisterView();
-    }
-
     @NonNull
     @Override
-    protected SkiaDrawView createViewInstance(@NonNull ThemedReactContext reactContext) {
+    public SkiaDrawView createViewInstance(@NonNull ThemedReactContext reactContext) {
         return new SkiaDrawView(reactContext);
     }
 }

--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaPictureViewManager.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaPictureViewManager.java
@@ -1,17 +1,9 @@
 package com.shopify.reactnative.skia;
 
-import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.uimanager.BaseViewManager;
-import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.annotations.ReactProp;
-
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
-import java.util.HashMap;
-
-public class SkiaPictureViewManager extends BaseViewManager<SkiaPictureView, LayoutShadowNode> {
+public class SkiaPictureViewManager extends SkiaBaseViewManager {
 
     @NonNull
     @Override
@@ -19,46 +11,9 @@ public class SkiaPictureViewManager extends BaseViewManager<SkiaPictureView, Lay
         return "SkiaPictureView";
     }
 
-    @Override
-    public LayoutShadowNode createShadowNodeInstance() {
-        return new LayoutShadowNode();
-    }
-
-    @Override
-    public Class<? extends LayoutShadowNode> getShadowNodeClass() {
-        return LayoutShadowNode.class;
-    }
-
-    @Override
-    public void updateExtraData(SkiaPictureView root, Object extraData) {
-    }
-
-    @Override
-    public void setNativeId(@NonNull SkiaPictureView view, @Nullable String nativeId) {
-        super.setNativeId(view, nativeId);
-        int nativeIdResolved = Integer.parseInt(nativeId);
-        view.registerView(nativeIdResolved);
-    }
-
-    @ReactProp(name = "mode")
-    public void setMode(SkiaPictureView view, String mode) {
-        view.setMode(mode);
-    }
-
-    @ReactProp(name = "debug")
-    public void setDebug(SkiaPictureView view, boolean show) {
-        view.setDebugMode(show);
-    }
-
-    @Override
-    public void onDropViewInstance(@NonNull SkiaPictureView view) {
-        super.onDropViewInstance(view);
-        view.unregisterView();
-    }
-
     @NonNull
     @Override
-    protected SkiaPictureView createViewInstance(@NonNull ThemedReactContext reactContext) {
+    public SkiaPictureView createViewInstance(@NonNull ThemedReactContext reactContext) {
         return new SkiaPictureView(reactContext);
     }
 }


### PR DESCRIPTION
On Android we were using regular views and viewmanagers to drive our native views. To be able to take advantage of the React Native functionality on views the Skia Views should be backed by a React View Manager which will ensure some functionality that will work out of the box.

This fixes #1197 and pointer events (use example in 1197 to test), and also allows for setting backgroundColor as style for a Canvas.

All tests and examples have been tested and works.