### PR TITLE
Rename E2E to CI on client side and use it for the emoji test

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Run e2e Tests
         working-directory: package
-        run: yarn e2e
+        run: CI=true yarn e2e
 
       - uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build app
         working-directory: example
-        run: E2E=true yarn ios --simulator 'iPhone 14 Pro'
+        run: CI=true yarn ios --simulator 'iPhone 14 Pro'
 
       # - name: Run e2e tests
       #   working-directory: package

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -23,7 +23,7 @@ import {
   Wallet,
   Severance,
 } from "./Examples";
-import { E2E, Tests } from "./Tests";
+import { CI, Tests } from "./Tests";
 import { HomeScreen } from "./Home";
 import type { StackParamList } from "./types";
 import { useAssets } from "./Tests/useAssets";
@@ -102,7 +102,7 @@ const App = () => {
       <StatusBar hidden />
       <NavigationContainer linking={linking}>
         <Stack.Navigator screenOptions={{ headerLeft: HeaderLeft }}>
-          {E2E ? [E2ETests, Home] : [Home, E2ETests]}
+          {CI ? [E2ETests, Home] : [Home, E2ETests]}
           <Stack.Screen
             name="Vertices"
             component={Vertices}

--- a/example/src/Tests/Tests.tsx
+++ b/example/src/Tests/Tests.tsx
@@ -8,12 +8,12 @@ import type { SerializedNode } from "./deserialize";
 import { parseNode, parseProps } from "./deserialize";
 import { useClient } from "./useClient";
 
-export const E2E = process.env.E2E === "true";
+export const CI = process.env.CI === "true";
 const scale = 3 / PixelRatio.get();
 const size = 256 * scale;
 // Maximum time to draw: 250 on iOS, 500ms on Android, 1000ms on CI
 // eslint-disable-next-line no-nested-ternary
-const timeToDraw = E2E ? 1500 : Platform.OS === "ios" ? 250 : 500;
+const timeToDraw = CI ? 1500 : Platform.OS === "ios" ? 250 : 500;
 
 interface TestsProps {
   assets: { [key: string]: any };

--- a/package/src/__tests__/setup.ts
+++ b/package/src/__tests__/setup.ts
@@ -9,7 +9,7 @@ import type { SkSurface, SkImage } from "../skia/types";
 import { JsiSkSurface } from "../skia/web/JsiSkSurface";
 
 export const E2E = process.env.E2E === "true";
-export const CI = process.env.GITHUB_JOB !== undefined;
+export const CI = process.env.CI === "true";
 export const itFailsE2e = E2E ? it.failing : it;
 export const itRunsE2eOnly = E2E ? it : it.skip;
 export const itRunsNodeOnly = E2E ? it.skip : it;


### PR DESCRIPTION
We forgot to pass an explicit env variable to run the emoji test, added a CI variable for that and decided to rename E2E to CI on the example app since it describes better what the environement is.