### PR TITLE
Fix radii for the RRect API on Web

### DIFF
--- a/package/src/renderer/__tests__/e2e/API.spec.tsx
+++ b/package/src/renderer/__tests__/e2e/API.spec.tsx
@@ -1,0 +1,27 @@
+import { surface } from "../setup";
+
+describe("API", () => {
+  it("Should do rect marshalling properly (1)", async () => {
+    const result = await surface.eval((Skia) => {
+      const rrect = Skia.RRectXY(Skia.XYWHRect(0, 0, 100, 100), 200, 200);
+      return { rx: rrect.rx, ry: rrect.ry };
+    });
+    expect(result).toEqual({ rx: 50, ry: 50 });
+  });
+
+  it("Should do rect marshalling properly (2)", async () => {
+    const result = await surface.eval((Skia) => {
+      const rrect = Skia.RRectXY(Skia.XYWHRect(0, 0, 100, 100), 0, 0);
+      return rrect.rx + rrect.ry;
+    });
+    expect(result).toBe(0);
+  });
+
+  it("Should do rect marshalling properly (3)", async () => {
+    const result = await surface.eval((Skia) => {
+      const rrect = Skia.RRectXY(Skia.XYWHRect(0, 0, 100, 100), 10, 20);
+      return { rx: rrect.rx, ry: rrect.ry };
+    });
+    expect(result).toEqual({ rx: 10, ry: 20 });
+  });
+});

--- a/package/src/skia/web/JsiSkRRect.ts
+++ b/package/src/skia/web/JsiSkRRect.ts
@@ -1,6 +1,6 @@
 import type { CanvasKit, RRect } from "canvaskit-wasm";
 
-import type { SkRRect } from "../types";
+import type { SkRect, SkRRect } from "../types";
 
 import { BaseHostObject } from "./Host";
 import { JsiSkRect } from "./JsiSkRect";
@@ -20,7 +20,18 @@ export class JsiSkRRect
     );
   }
 
-  constructor(CanvasKit: CanvasKit, ref: RRect) {
+  constructor(CanvasKit: CanvasKit, rect: SkRect, rx: number, ry: number) {
+    // based on https://github.com/google/skia/blob/main/src/core/SkRRect.cpp#L51
+    if (rx === Infinity || ry === Infinity) {
+      rx = ry = 0;
+    }
+    if (rect.width < rx + rx || rect.height < ry + ry) {
+      // At most one of these two divides will be by zero, and neither numerator is zero.
+      const scale = Math.min(rect.width / (rx + rx), rect.height / (ry + ry));
+      rx *= scale;
+      ry *= scale;
+    }
+    const ref = CanvasKit.RRectXY(JsiSkRect.fromValue(CanvasKit, rect), rx, ry);
     super(CanvasKit, ref, "RRect");
   }
 

--- a/package/src/skia/web/JsiSkia.ts
+++ b/package/src/skia/web/JsiSkia.ts
@@ -45,10 +45,7 @@ export const JsiSkApi = (CanvasKit: CanvasKit): Skia => ({
     throw new Error("Not implemented on React Native Web");
   },
   RRectXY: (rect: SkRect, rx: number, ry: number) =>
-    new JsiSkRRect(
-      CanvasKit,
-      CanvasKit.RRectXY(JsiSkRect.fromValue(CanvasKit, rect), rx, ry)
-    ),
+    new JsiSkRRect(CanvasKit, rect, rx, ry),
   RSXform: (scos: number, ssin: number, tx: number, ty: number) =>
     new JsiSkRSXform(CanvasKit, Float32Array.of(scos, ssin, tx, ty)),
   Color,


### PR DESCRIPTION
In SkRRect, the contructor modifies the radii if needed:  based on https://github.com/google/skia/blob/main/src/core/SkRRect.cpp#L51
This constructor is unfortunately not exposed via CanvasKit so we had to do the check manually.