### PR TITLE
#1216: Remove use of PointerEvents.canBeTouchTarget

### DIFF
--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaBaseView.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaBaseView.java
@@ -32,11 +32,6 @@ public abstract class SkiaBaseView extends ReactViewGroup implements TextureView
 
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
-        // We do not accept the touch event if this view is not supposed to receive it.
-        if (!PointerEvents.canBeTouchTarget(getPointerEvents())) {
-            return false;
-        }
-
         // https://developer.android.com/training/gestures/multi
         int action = ev.getActionMasked();
 


### PR DESCRIPTION
This function was introduced in React Native 0.68 and should not be used if we want to keep our backwards compatibility on Android.

Luckily this call isn't necessary to implement / support the pointer events example anyways, so it can be removed.

This commit removes this.

Fixes #1216