### PR TITLE
Optimisation: Removed extra use of ref counting when swapping property values

### DIFF
--- a/package/cpp/rnskia/dom/base/NodeProp.h
+++ b/package/cpp/rnskia/dom/base/NodeProp.h
@@ -86,9 +86,7 @@ public:
       {
         // Swap buffers
         std::lock_guard<std::mutex> lock(_swapMutex);
-        auto tmp = _value;
-        _value = _buffer;
-        _buffer = tmp;
+        _value.swap(_buffer);
 
         // turn off pending changes flag
         _hasNewValue = false;


### PR DESCRIPTION
The method updatePendingChanges() for props swaps buffers, but the swap started showing up in the profiler for big DOM trees.

This commit simplifies this by using the std::shared_ptr `swap` method directly. This causes no inc/dec of the ref counts - just changes the pointers in the fastest way.