### PR TITLE
Fixed rendering arefacts after background mode

### DIFF
--- a/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
+++ b/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
@@ -66,6 +66,16 @@ void RNSkMetalCanvasProvider::renderToCanvas(const std::function<void(SkCanvas*)
     return;
   }
   
+  // Make sure to NOT render or try any render operations while we're in the background or inactive.
+  // This will cause an error that might clear the CAMetalLayer so that the canvas is empty when
+  // the app receives focus again.
+  // Reference: https://github.com/Shopify/react-native-skia/issues/1257
+  auto state = UIApplication.sharedApplication.applicationState;
+  if (state == UIApplicationStateBackground || state == UIApplicationStateInactive)
+  {
+    
+  }
+  
   // Get render context for current thread
   auto renderContext = getMetalRenderContext();
   


### PR DESCRIPTION
If you run this example and move the app to the background and then to the foreground you'll see some artifacts - the canvas is either empty or just red in my test.

By looking in the Xcode logs I can see an error message showing when I move the app to the background which kind of explains the issue:

2023-01-06 12:39:13.599047+0100 RNSkia[15890:4023482] GrMtlCommandBuffer: tried to create MTLRenderCommandEncoder while in background. After some investigation I found out that when the app is sent to the background it receives a size message which ends up requesting a redraw for the Skia View. The redraw is performed about the same time as the app is marked as being in the background - and the Metal subsystem will complain with the above message - and then the Metal layer will be in an undefined state which results in artefacts when we return from background mode.

Reproduction

Paste the following into your App.tsx file:

import React, { useEffect, useState } from "react"; import { StyleSheet, Text, SafeAreaView } from "react-native"; import {
  Text as SkiaText,
  useFont,
  Canvas,
  Fill,
} from "@shopify/react-native-skia";

const fontFile = require("./assets/SF-Mono-Semibold.otf"); const App = () => {
  const font = useFont(fontFile, 20);
  return (
    <SafeAreaView style={styles.container}>
      <Text style={styles.text}>Timer:</Text>
      <Text style={styles.text}>SKIA TEXT:</Text>

      <Canvas style={styles.canvas}>
        <Fill color="#FF0000" />
        {font && (
          <SkiaText
            x={10}
            y={15}
            color={"#000000"}
            font={font}
            text={"Hello friends"}
          />
        )}
      </Canvas>
    </SafeAreaView>
  );
};

// eslint-disable-next-line import/no-default-export export default App;

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: "center",
    padding: 20,
    backgroundColor: "green",
  },
  canvas: {
    borderColor: "blue",
    borderWidth: 5,
    width: 200,
    height: 200,
  },
  text: {
    fontWeight: "bold",
    fontSize: 16,
    marginTop: 40,
  },
});