### PR TITLE
#1262: Added support for RN 0.71 build

### DIFF
--- a/package/android/CMakeLists.txt
+++ b/package/android/CMakeLists.txt
@@ -12,6 +12,11 @@ set (SKIA_SKSHAPER_LIB "skshaper")
 #set (SKIA_SKPARAGRAPH_LIB "skparagraph")
 #set (SKIA_SKUNICODE_LIB "skunicode")
 
+# Clear some variables
+unset(LIBRN_DIR CACHE)
+unset(libfbjni_link_DIRS CACHE)
+unset(libfbjni_include_DIRS CACHE)
+
 set(build_DIR ${CMAKE_SOURCE_DIR}/build)
 file(GLOB LIBRN_DIR "${PREBUILT_DIR}/${ANDROID_ABI}")
 file(GLOB libfbjni_link_DIRS "${build_DIR}/fbjni*.aar/jni/${ANDROID_ABI}")
@@ -114,49 +119,72 @@ find_library(
         LOG_LIB
         log
 )
-
 message("-- LOG     : " ${LOG_LIB})
 
- if(${REACT_NATIVE_VERSION} LESS 66)
-         # JSI lib didn't exist on RN 0.65 and before. Simply omit it.
-         set (JSI_LIB "")
- else()
-         # RN 0.66 distributes libjsi.so, can be used instead of compiling jsi.cpp manually.
-         find_library(
-                 JSI_LIB
-                 jsi
-                 PATHS ${LIBRN_DIR}
-                 NO_CMAKE_FIND_ROOT_PATH
-         )
- endif()
+if(${REACT_NATIVE_VERSION} GREATER_EQUAL 71)
+    # We need to find packages since from RN 0.71 binaries are prebuilt
+    find_package(fbjni REQUIRED CONFIG)
+    find_package(ReactAndroid REQUIRED CONFIG)
+endif()
 
- message("-- JSI     : " ${JSI_LIB})
-
-find_library(
-        REACT_LIB
-        react_nativemodule_core
+unset(JSI_LIB CACHE)
+if(${REACT_NATIVE_VERSION} LESS 66)
+    # JSI lib didn't exist on RN 0.65 and before. Simply omit it.
+    set (JSI_LIB "")
+elseif(${REACT_NATIVE_VERSION} GREATER_EQUAL 71)
+    # RN 0.71 distributes prebuilt binaries.
+    set (JSI_LIB ReactAndroid::jsi)
+else()
+    # RN 0.66 distributes libjsi.so, can be used instead of compiling jsi.cpp manually.
+    find_library(
+        JSI_LIB
+        jsi
         PATHS ${LIBRN_DIR}
         NO_CMAKE_FIND_ROOT_PATH
-)
+    )
+endif()
+message("-- JSI     : " ${JSI_LIB})
 
+unset(REACT_LIB CACHE)
+if(${REACT_NATIVE_VERSION} GREATER_EQUAL 71)
+    # RN 0.71 distributes prebuilt binaries.
+    set (REACT_LIB ReactAndroid::react_nativemodule_core)
+else()
+    find_library(
+            REACT_LIB
+            react_nativemodule_core
+            PATHS ${LIBRN_DIR}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
+endif()
 message("-- REACT   : " ${REACT_LIB})
 
-find_library(
-        FBJNI_LIBRARY 
-        fbjni 
-        PATHS ${libfbjni_link_DIRS}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-
+unset(FBJNI_LIBRARY CACHE)
+if(${REACT_NATIVE_VERSION} GREATER_EQUAL 71)
+    # RN 0.71 distributes prebuilt binaries.
+    set (FBJNI_LIBRARY fbjni::fbjni)
+else()
+    find_library(
+            FBJNI_LIBRARY
+            fbjni
+            PATHS ${libfbjni_link_DIRS}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
+endif()
 message("-- FBJNI   : " ${FBJNI_LIBRARY})
 
-find_library(
-        TURBOMODULES_LIB
-        turbomodulejsijni
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-
+unset(TURBOMODULES_LIB CACHE)
+if(${REACT_NATIVE_VERSION} GREATER_EQUAL 71)
+    # RN 0.71 distributes prebuilt binaries.
+    set (TURBOMODULES_LIB "ReactAndroid::turbomodulejsijni")
+else()
+    find_library(
+            TURBOMODULES_LIB
+            turbomodulejsijni
+            PATHS ${LIBRN_DIR}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
+endif()
 message("-- TURBO   : " ${TURBOMODULES_LIB})
 
 # Link

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -47,7 +47,7 @@ def nodeModules = findNodeModules(projectDir)
 logger.warn("react-native-skia: node_modules/ found at: ${nodeModules}")
 
 def sourceBuild = false
-def defaultDir = null
+def defaultDir
 
 if (rootProject.ext.has('reactNativeAndroidRoot')) {
   defaultDir = rootProject.ext.get('reactNativeAndroidRoot')
@@ -55,7 +55,7 @@ if (rootProject.ext.has('reactNativeAndroidRoot')) {
     sourceBuild = true
     defaultDir = project(':ReactAndroid').projectDir
 } else {
-  defaultDir = file("$nodeModules/react-native/android")
+  defaultDir = file("$nodeModules/react-native")
 }
 
 if (!defaultDir.exists()) {
@@ -78,7 +78,7 @@ if (gradle.startParameter.taskRequests.args[0].toString().contains("Release")) {
 
 def reactProperties = new Properties()
 file("$nodeModules/react-native/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
-def FULL_RN_VERSION = reactProperties.getProperty("VERSION_NAME")
+def FULL_RN_VERSION =  (System.getenv("REACT_NATIVE_OVERRIDE_VERSION") ?: reactProperties.getProperty("VERSION_NAME"))
 def REACT_NATIVE_VERSION = FULL_RN_VERSION.split("\\.")[1].toInteger()
 
 logger.warn("react-native-skia: RN Version: ${REACT_NATIVE_VERSION} / ${FULL_RN_VERSION}")
@@ -136,6 +136,10 @@ android {
         }
     }
 
+    buildFeatures {
+        prefab true
+    }
+
     packagingOptions {
         excludes = [
              "**/libc++_shared.so",
@@ -145,8 +149,6 @@ android {
              "**/libturbomodulejsijni.so"
         ]
     }
-
-
 
     // Create new configurations that can be referred to in dependencies.
     // The Android Gradle Plugin 3.* does not allow hooking into existing
@@ -181,17 +183,25 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
 
-    //noinspection GradleDynamicVersion
-    extractHeaders("com.facebook.fbjni:fbjni:0.2.2:headers")
-    //noinspection GradleDynamicVersion
-    extractJNI("com.facebook.fbjni:fbjni:0.2.2")
+    if (REACT_NATIVE_VERSION < 71) {
+        logger.warn("react-native-skia: Extracting files from AAR (pre RN 0.71)")
+        //noinspection GradleDynamicVersion
+        extractHeaders("com.facebook.fbjni:fbjni:0.2.2:headers")
+        //noinspection GradleDynamicVersion
+        extractJNI("com.facebook.fbjni:fbjni:0.2.2")
+    }
 
     if (!sourceBuild) {
         def rnAarMatcher = "**/react-native/**/*${buildType}.aar"
         if (REACT_NATIVE_VERSION < 69) {
+            logger.warn("react-native-skia: aar state pre 69. match **/**/*.aar")
             rnAarMatcher = "**/**/*.aar"
+        } else if (REACT_NATIVE_VERSION >= 71) {
+            logger.warn("react-native-skia: aar state post 70, do nothing")
+            return
         }
-        def rnAAR = fileTree("${nodeModules}/react-native/android").matching({ it.include rnAarMatcher }).singleFile        
+        def rnAAR = fileTree("${nodeModules}/react-native/android").matching({ it.include rnAarMatcher }).singleFile
+        logger.warn("react-native-skia: Extracting JNI files (pre RN 0.71) ${rnAAR}")
         extractJNI(files(rnAAR))
     }
 }


### PR DESCRIPTION
Added support for building Android on RN 0.71 with prefab support and also backwards compatibility with pre RN 0.71.

Also added removal of cached CMake values to better support upgrading from one version to another.

This is both reported as a bug and also asked for by Expo who will include / need this in their next release.

#Fixes #1262