### PR TITLE
#1260: Fix storage type of drawCallback

### DIFF
--- a/package/cpp/rnskia/RNSkJsiViewApi.h
+++ b/package/cpp/rnskia/RNSkJsiViewApi.h
@@ -55,8 +55,8 @@ public:
     auto info = getEnsuredViewInfo(nativeId);
 
     std::lock_guard<std::mutex> lock(_mutex);
-    info->props.emplace(arguments[1].asString(runtime).utf8(runtime),
-                        RNJsi::JsiValueWrapper(runtime, arguments[2]));
+    info->props.insert_or_assign(arguments[1].asString(runtime).utf8(runtime),
+                                 RNJsi::JsiValueWrapper(runtime, arguments[2]));
 
     // Now let's see if we have a view that we can update
     if (info->view != nullptr) {


### PR DESCRIPTION
After debugging the Transforms example it seemed that updating the drawCallback was not working correctly and after changing the storage type from a direct object to a shared pointer replacing worked as expected.

fixes #1260