### PR TITLE
#716: Fixed gravity on metal layer to avoid animations on size change on iOS

### DIFF
--- a/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
+++ b/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
@@ -41,7 +41,7 @@ RNSkCanvasProvider(requestRedraw),
   _layer.opaque = false;
   _layer.contentsScale = _context->getPixelDensity();
   _layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-  _layer.contentsGravity = kCAGravityBottomRight;
+  _layer.contentsGravity = kCAGravityBottomLeft;
 }
 
 RNSkMetalCanvasProvider::~RNSkMetalCanvasProvider() {


### PR DESCRIPTION
By some strange reason (we've seen this before - and also tried to fix it before) the CAMetalLayer resizes itself in an animated way when changing size.

This is something we don't want, and we've had a few issues regarding this.

This fixes the problem by setting the gravity on the layer to bottom left - this removes the error we're seeing in the reports.

Fixes #716

Simple reproduction - paste into App.tsx in our example. Before this fix the size changes of the image is animated (by Metal / iOS), after the fix changes should happen directly:

```tsx
import React, { useEffect, useState } from "react";
import { Canvas, Image, useImage } from "@shopify/react-native-skia";
import { View } from "react-native";

const START_SIZE = 200;

const App = () => {
  const [imageSize, setImageSize] = useState(START_SIZE);

  useEffect(() => {
    let interval = setInterval(() => {
      setImageSize(Math.random() * 200 + START_SIZE);
    }, 1000);
    return () => {
      if (interval) clearInterval(interval);
    };
  }, []);

  const skiaImage = useImage(require("./assets/oslo.jpg"));

  return (
    <View style={{ margin: 12 }}>
      <Canvas
        style={{
          width: imageSize,
          height: imageSize,
        }}
      >
        {!!skiaImage && (
          <Image
            x={0}
            y={0}
            width={imageSize}
            height={imageSize}
            image={skiaImage}
            fit="cover"
          />
        )}
      </Canvas>
    </View>
  );
};

// eslint-disable-next-line import/no-default-export
export default App;
```