### PR TITLE
Keep the root paint stable on RN Web

### DIFF
--- a/package/src/views/SkiaDomView.web.tsx
+++ b/package/src/views/SkiaDomView.web.tsx
@@ -9,6 +9,8 @@ import type { SkiaDomViewProps, TouchInfo } from "./types";
 const pd = PixelRatio.get();
 
 export class SkiaDomView extends SkiaBaseWebView<SkiaDomViewProps> {
+  private paint = Skia.Paint();
+
   constructor(props: SkiaDomViewProps) {
     super(props);
   }
@@ -22,10 +24,9 @@ export class SkiaDomView extends SkiaBaseWebView<SkiaDomViewProps> {
       this.props.onSize.current = { width, height };
     }
     if (this.props.root) {
-      const paint = Skia.Paint();
       const ctx = {
         canvas,
-        paint,
+        paint: this.paint,
         opacity: 1,
       };
       canvas.save();


### PR DESCRIPTION
By creating a new paint on every frame, the declaration caching is never hit.
Because SkiaRoot wraps the content into a Group, it is safe to keep the paint for every draw. It is not expected to be mutated.