### PR TITLE
Update Surface.MakeOffscren() to work on Node

### DIFF
--- a/package/src/skia/web/JsiSkSurfaceFactory.ts
+++ b/package/src/skia/web/JsiSkSurfaceFactory.ts
@@ -27,9 +27,12 @@ export class JsiSkSurfaceFactory extends Host implements SurfaceFactory {
       surface = this.CanvasKit.MakeSurface(width, height);
     } else {
       const offscreen = new OC(width, height);
-      surface = this.CanvasKit.MakeWebGLCanvasSurface(
-        offscreen as unknown as HTMLCanvasElement
-      );
+      const webglContext = this.CanvasKit.GetWebGLContext(offscreen);
+      const grContext = this.CanvasKit.MakeWebGLContext(webglContext);
+      if (!grContext) {
+        throw new Error("Could not make a graphics context");
+      }
+      surface = this.CanvasKit.MakeRenderTarget(grContext, width, height);
     }
     if (!surface) {
       return null;


### PR DESCRIPTION
On Node, we use a polyfill of OffscreenCanvas. However when using MakeWebGLCanvasSurface, we're not able to "trick" CanvasKit in thinking that the API exists, this check from CanvasKit will fail: https://github.com/google/skia/blob/main/modules/canvaskit/webgl.js#L169

This is a way to workaround the issue and enables Offscreen GPU on Node.