### PR TITLE
fix: Add `JSI_EXPORT_FUNC_NAMED` to `JsiHostObject.h`

### DIFF
--- a/package/cpp/jsi/JsiHostObject.h
+++ b/package/cpp/jsi/JsiHostObject.h
@@ -42,6 +42,17 @@
   jsi::Value STR_CAT(STR_GET, NAME)(jsi::Runtime & runtime)
 
 /**
+ * Creates a JSI export function declaration with a specific name
+ */
+#define JSI_EXPORT_FUNC_NAMED(CLASS, FUNCTION, NAME)                           \
+  {                                                                            \
+#NAME, (jsi::Value(JsiHostObject::*)(                                      \
+               jsi::Runtime & runtime, const jsi::Value &thisValue,            \
+               const jsi::Value *arguments, size_t)) &                         \
+               CLASS::FUNCTION                                                 \
+  }
+
+/**
  * Creates a JSI export function declaration
  */
 #define JSI_EXPORT_FUNC(CLASS, FUNCTION)                                       \


### PR DESCRIPTION
Makes it uniform with RNWorklets::JsiHostObject