### PR TITLE
Added main thread check

### DIFF
--- a/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
+++ b/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
@@ -73,14 +73,18 @@ void RNSkMetalCanvasProvider::renderToCanvas(
   // background or inactive. This will cause an error that might clear the
   // CAMetalLayer so that the canvas is empty when the app receives focus again.
   // Reference: https://github.com/Shopify/react-native-skia/issues/1257
-  auto state = UIApplication.sharedApplication.applicationState;
-  if (state == UIApplicationStateBackground ||
-      state == UIApplicationStateInactive) {
-    // Request a redraw in the next run loop callback
-    _requestRedraw();
-    // and don't draw now since it might cause errors in the metal renderer if
-    // we try to render while in the background. (see above issue)
-    return;
+  // NOTE: UIApplication.sharedApplication.applicationState can only be
+  // accessed from the main thread so we need to check here.
+  if ([[NSThread currentThread] isMainThread]) {
+    auto state = UIApplication.sharedApplication.applicationState;
+    if (state == UIApplicationStateBackground ||
+        state == UIApplicationStateInactive) {
+      // Request a redraw in the next run loop callback
+      _requestRedraw();
+      // and don't draw now since it might cause errors in the metal renderer if
+      // we try to render while in the background. (see above issue)
+      return;
+    }
   }
 
   // Get render context for current thread


### PR DESCRIPTION
A check to avoid accessing applicationState when not on UI thread has been added, otherwise iOS raises a big warning about doing this. 

This only applies to SkiaViews since they render on a separate thread.
