### PR TITLE
An extra std::move nulls out the context param

### DIFF
--- a/package/cpp/rnskia/RNSkJsView.cpp
+++ b/package/cpp/rnskia/RNSkJsView.cpp
@@ -8,7 +8,7 @@ RNSkJsRenderer::RNSkJsRenderer(std::function<void()> requestRedraw,
                                std::shared_ptr<RNSkPlatformContext> context)
     : RNSkRenderer(requestRedraw),
       _jsiCanvas(std::make_shared<JsiSkCanvas>(context)),
-      _platformContext(std::move(context)),
+      _platformContext(context),
       _infoObject(std::make_shared<RNSkInfoObject>()),
       _jsDrawingLock(std::make_shared<std::timed_mutex>()),
       _gpuDrawingLock(std::make_shared<std::timed_mutex>()),


### PR DESCRIPTION
When creating a JS based renderer we are passing the platform context - the ctor is using std::move to move the reference which causes use of the context later to be nullptr - resulting in nullptr being returned when trying to get the platform context from within the renderer scope.

This can be seen if you try to access the platform context from within any JsiSkCanvas method in a sample using a SkiaViews.