### PR TITLE
Improvements in e2e typings

### DIFF
--- a/package/src/renderer/__tests__/e2e/Rect.spec.tsx
+++ b/package/src/renderer/__tests__/e2e/Rect.spec.tsx
@@ -2,28 +2,28 @@ import { surface } from "../setup";
 
 describe("Rects and rounded rects", () => {
   it("The rounded rectangle radii should be scale to its maximum value", async () => {
-    let result = await surface.eval((Skia) => {
+    const result = await surface.eval((Skia) => {
       const rrect = Skia.RRectXY(Skia.XYWHRect(0, 0, 100, 100), 200, 200);
       return { rx: rrect.rx, ry: rrect.ry };
     });
     expect(result).toEqual({ rx: 50, ry: 50 });
 
-    result = await surface.eval((Skia) => {
+    const result1 = await surface.eval((Skia) => {
       const rrect = Skia.RRectXY(Skia.XYWHRect(0, 0, 100, 100), 200, 20);
       return { rx: rrect.rx, ry: rrect.ry };
     });
-    expect(result).toEqual({ rx: 50, ry: 5 });
+    expect(result1).toEqual({ rx: 50, ry: 5 });
 
-    result = await surface.eval((Skia) => {
+    const result2 = await surface.eval((Skia) => {
       const rrect = Skia.RRectXY(Skia.XYWHRect(0, 0, 100, 100), 0, 0);
       return rrect.rx + rrect.ry;
     });
-    expect(result).toBe(0);
+    expect(result2).toBe(0);
 
-    result = await surface.eval((Skia) => {
+    const result3 = await surface.eval((Skia) => {
       const rrect = Skia.RRectXY(Skia.XYWHRect(0, 0, 100, 100), 10, 20);
       return { rx: rrect.rx, ry: rrect.ry };
     });
-    expect(result).toEqual({ rx: 10, ry: 20 });
+    expect(result3).toEqual({ rx: 10, ry: 20 });
   });
 });


### PR DESCRIPTION
This allows for the context and result of `surface.eval` to be precisely typed.