### PR TITLE
Build Android app before turning on emulator on Android

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -76,6 +76,10 @@ jobs:
           path: example/android/app/build
           key: ${{ runner.os }}-build-${{ env.cache-name }}-example-${{ hashFiles('**/react-native/package.json') }}
   
+      - name: Build Android app
+        working-directory: example/android
+        run: ./gradlew assembleDebug
+  
       - name: SKDs - download required images
         run: $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "system-images;android-30;default;x86_64"
 
@@ -97,7 +101,7 @@ jobs:
         working-directory: example
         run: E2E=true yarn start &
 
-      - name: Build App
+      - name: Install App
         working-directory: example
         run: E2E=true yarn android
 


### PR DESCRIPTION
Lately the Android Github action has been extremely flaky and it seems like many open source projects are affected by the same issue (see https://github.com/mockito/mockito/pull/2903).
More specifically, the issue if that once we finished to build the app, the emulator is not responsive anymore.

While there doesn't seem to be any great solution for this yet, I was wondering if we should build the  app before starting the emulator. One possible cause of this problem is that the github image is so constraint in resources that it may crash the emulator. Overall I think it is good to build the app first anyways, if the CI fails because of a build error, we will get the error much faster.

Another suggestion was to downgrade the Android API version.