### PR TITLE
#1403 Added diposing of native resources 

### DIFF
--- a/package/cpp/api/JsiSkData.h
+++ b/package/cpp/api/JsiSkData.h
@@ -30,6 +30,13 @@ public:
 
   JSI_EXPORT_PROPERTY_GETTERS(JSI_EXPORT_PROP_GET(JsiSkData, __typename__))
 
+  JSI_HOST_FUNCTION(dispose) {
+    setObject(nullptr);
+    return jsi::Value::undefined();
+  }
+
+  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkData, dispose))
+
   /**
     Returns the underlying object from a host object of this type
    */

--- a/package/cpp/api/JsiSkImage.h
+++ b/package/cpp/api/JsiSkImage.h
@@ -104,12 +104,18 @@ public:
     return jsi::String::createFromAscii(runtime, buffer);
   }
 
+  JSI_HOST_FUNCTION(dispose) {
+    setObject(nullptr);
+    return jsi::Value::undefined();
+  }
+
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkImage, width),
                        JSI_EXPORT_FUNC(JsiSkImage, height),
                        JSI_EXPORT_FUNC(JsiSkImage, makeShaderOptions),
                        JSI_EXPORT_FUNC(JsiSkImage, makeShaderCubic),
                        JSI_EXPORT_FUNC(JsiSkImage, encodeToBytes),
-                       JSI_EXPORT_FUNC(JsiSkImage, encodeToBase64))
+                       JSI_EXPORT_FUNC(JsiSkImage, encodeToBase64),
+                       JSI_EXPORT_FUNC(JsiSkImage, dispose))
 
   JsiSkImage(std::shared_ptr<RNSkPlatformContext> context,
              const sk_sp<SkImage> image)

--- a/package/cpp/api/JsiSkSVG.h
+++ b/package/cpp/api/JsiSkSVG.h
@@ -30,6 +30,13 @@ public:
 
   JSI_EXPORT_PROPERTY_GETTERS(JSI_EXPORT_PROP_GET(JsiSkSVG, __typename__))
 
+  JSI_HOST_FUNCTION(dispose) {
+    setObject(nullptr);
+    return jsi::Value::undefined();
+  }
+
+  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkSVG, dispose))
+
   /**
     Returns the underlying object from a host object of this type
    */

--- a/package/cpp/api/JsiSkTypeface.h
+++ b/package/cpp/api/JsiSkTypeface.h
@@ -29,6 +29,13 @@ public:
 
   JSI_EXPORT_PROPERTY_GETTERS(JSI_EXPORT_PROP_GET(JsiSkTypeface, __typename__))
 
+  JSI_HOST_FUNCTION(dispose) {
+    setObject(nullptr);
+    return jsi::Value::undefined();
+  }
+
+  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkTypeface, dispose))
+
   JsiSkTypeface(std::shared_ptr<RNSkPlatformContext> context,
                 sk_sp<SkTypeface> typeface)
       : JsiSkWrappingSkPtrHostObject(std::move(context), std::move(typeface)) {}

--- a/package/cpp/rnskia/dom/base/JsiDomRenderNode.h
+++ b/package/cpp/rnskia/dom/base/JsiDomRenderNode.h
@@ -132,7 +132,6 @@ public:
    */
   void resetPendingChanges() override { JsiDomNode::resetPendingChanges(); }
 
-  
   /**
    Overridden dispose to release resources
    */
@@ -215,7 +214,7 @@ protected:
       invalidateContext();
     }
   }
-  
+
 private:
   /**
    Clips the canvas depending on the clip property

--- a/package/cpp/rnskia/dom/base/JsiDomRenderNode.h
+++ b/package/cpp/rnskia/dom/base/JsiDomRenderNode.h
@@ -132,6 +132,15 @@ public:
    */
   void resetPendingChanges() override { JsiDomNode::resetPendingChanges(); }
 
+  
+  /**
+   Overridden dispose to release resources
+   */
+  void dispose(bool immediate) override {
+    JsiDomNode::dispose(immediate);
+    _paintCache.clear();
+  }
+
 protected:
   /**
    Invalidates and marks then context as changed.
@@ -206,7 +215,7 @@ protected:
       invalidateContext();
     }
   }
-
+  
 private:
   /**
    Clips the canvas depending on the clip property
@@ -232,6 +241,10 @@ private:
   }
 
   struct PaintCache {
+    void clear() {
+      parent = nullptr;
+      child = nullptr;
+    }
     std::shared_ptr<SkPaint> parent;
     std::shared_ptr<SkPaint> child;
   };

--- a/package/src/skia/types/Data/Data.ts
+++ b/package/src/skia/types/Data/Data.ts
@@ -1,6 +1,6 @@
-import type { SkJSIInstance } from "../JsiInstance";
+import type { JsiDisposable, SkJSIInstance } from "../JsiInstance";
 
-export type SkData = SkJSIInstance<"Data">;
+export type SkData = SkJSIInstance<"Data"> & JsiDisposable;
 
 type RNModule = number;
 type ESModule = {

--- a/package/src/skia/types/Image/Image.ts
+++ b/package/src/skia/types/Image/Image.ts
@@ -1,5 +1,5 @@
 import type { SkMatrix } from "../Matrix";
-import type { SkJSIInstance } from "../JsiInstance";
+import type { JsiDisposable, SkJSIInstance } from "../JsiInstance";
 import type { TileMode } from "../ImageFilter";
 import type { SkShader } from "../Shader";
 
@@ -20,7 +20,7 @@ export enum ImageFormat {
   WEBP = 6,
 }
 
-export interface SkImage extends SkJSIInstance<"Image"> {
+export interface SkImage extends SkJSIInstance<"Image">, JsiDisposable {
   /**
    * Returns the possibly scaled height of the image.
    */

--- a/package/src/skia/types/JsiInstance.ts
+++ b/package/src/skia/types/JsiInstance.ts
@@ -1,3 +1,7 @@
 export interface SkJSIInstance<T extends string> {
   __typename__: T;
 }
+
+export interface JsiDisposable {
+  dispose: () => void;
+}

--- a/package/src/skia/types/SVG/SVG.ts
+++ b/package/src/skia/types/SVG/SVG.ts
@@ -1,3 +1,3 @@
-import type { SkJSIInstance } from "../JsiInstance";
+import type { JsiDisposable, SkJSIInstance } from "../JsiInstance";
 
-export type SkSVG = SkJSIInstance<"SVG">;
+export type SkSVG = SkJSIInstance<"SVG"> & JsiDisposable;

--- a/package/src/skia/types/Typeface/Typeface.ts
+++ b/package/src/skia/types/Typeface/Typeface.ts
@@ -1,3 +1,3 @@
-import type { SkJSIInstance } from "../JsiInstance";
+import type { JsiDisposable, SkJSIInstance } from "../JsiInstance";
 
-export type SkTypeface = SkJSIInstance<"Typeface">;
+export type SkTypeface = SkJSIInstance<"Typeface"> & JsiDisposable;

--- a/package/src/skia/web/JsiSkData.ts
+++ b/package/src/skia/web/JsiSkData.ts
@@ -10,4 +10,8 @@ export class JsiSkData extends HostObject<Data, "Data"> implements SkData {
   constructor(CanvasKit: CanvasKit, ref: Data) {
     super(CanvasKit, ref, "Data");
   }
+
+  dispose() {
+    // Not implemented in data
+  }
 }

--- a/package/src/skia/web/JsiSkImage.ts
+++ b/package/src/skia/web/JsiSkImage.ts
@@ -109,4 +109,8 @@ export class JsiSkImage extends HostObject<Image, "Image"> implements SkImage {
     const bytes = this.encodeToBytes(fmt, quality);
     return toBase64String(bytes);
   }
+
+  dispose() {
+    this.ref.delete();
+  }
 }

--- a/package/src/skia/web/JsiSkTypeface.ts
+++ b/package/src/skia/web/JsiSkTypeface.ts
@@ -25,4 +25,8 @@ export class JsiSkTypeface
     );
     return false;
   }
+
+  dispose() {
+    this.ref.delete();
+  }
 }


### PR DESCRIPTION
## Background 
We have some native resources allocated in our C++ code (namely SkData, SkImage, SkTypeface and SkSvg). These are all allocated and encapsulated inside our Jsi HostObject wrappers.

The problem with this is that for Hermes these allocations aren't counted when looking for candidates for garbage collection, meaning that it is possible to reproduce a memory leak where f.ex nodes in a Skia Canvas are never released properly and the app will crash with an OOM without the garbage collector ever notices.

This is described in detail in multiple issues, @Kudo explains it well [here](https://github.com/Kudo/react-native-v8/issues/36#issuecomment-595013967).

## Fix
Whenever we close a SkiaView we try to clean up to make sure we don't have any hanging nodes or other resources that can leak in the described way. This is done by the SkiaView calling `dispose` on nodes to let the nodes clean up.

This PR extends this functionality to the hooks that loads resources like SkImage, SkTypeface, SkSVG and SkData where these classes also now has a dispose member. In the hooks that loads these resources we now call this dispose method whenever we unmount the loading hooks - this ensures that when we unmount we also clean up our internally allocated memory for these classes in a clean way.

Additionally I've added an explicit call to clear the paint cache in the Render Node in C++ since debugging showed that otherwise the SkPaint in the paint cache would keep a reference to a shader which in turn held a reference to an SkImage - meaning that the image was never released.

## Notes 
This is a Hermes issue - JSC manages to track memory as a total of the allocated memory and can clean up correctly.

## Aknowledgements
Thanks to @Szymon20000 for the original idea 🙏

## References
Fixes #1403 (once more)