### PR TITLE
This fixes issue with header search paths for monorepo

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -659,7 +659,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 9f7c9137605e72ca0343db4cea88006cb94856dd
   React-logger: 957e5dc96d9dbffc6e0f15e0ee4d2b42829ff207
   react-native-safe-area-context: dfe5aa13bee37a0c7e8059d14f72ffc076d120e9
-  react-native-skia: 295bce84f094f49690b98aad3dff9789b5c9a91d
+  react-native-skia: 914835a9d66b979d915352b428d723e3f4f8dbd9
   React-perflogger: af8a3d31546077f42d729b949925cc4549f14def
   React-RCTActionSheet: 57cc5adfefbaaf0aae2cf7e10bccd746f2903673
   React-RCTAnimation: 11c61e94da700c4dc915cf134513764d87fc5e2b

--- a/example/ios/RNSkia.xcodeproj/project.pbxproj
+++ b/example/ios/RNSkia.xcodeproj/project.pbxproj
@@ -211,7 +211,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "RNSkia" */;
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "rnskia" */;
 			compatibilityVersion = "Xcode 12.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -689,7 +689,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "RNSkia" */ = {
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "rnskia" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				83CBBA201A601CBA00E9B192 /* Debug */,

--- a/package/react-native-skia.podspec
+++ b/package/react-native-skia.podspec
@@ -25,11 +25,7 @@ Pod::Spec.new do |s|
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SK_GL=1 SK_METAL=1',
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
     'DEFINES_MODULE' => 'YES',
-    "HEADER_SEARCH_PATHS" => '"$(PODS_ROOT)/../../node_modules/@shopify/react-native-skia/cpp/" ' + 
-                             '"$(PODS_ROOT)/../../node_modules/@shopify/react-native-skia/cpp/api/" ' + 
-                             '"$(PODS_ROOT)/../../node_modules/@shopify/react-native-skia/cpp/rnskia/" ' + 
-                             '"$(PODS_ROOT)/../../node_modules/@shopify/react-native-skia/cpp/rnskia/dom/" ' + 
-                             '"$(PODS_ROOT)/../../node_modules/@shopify/react-native-skia/cpp/skia/"'
+    "HEADER_SEARCH_PATHS" => '"$(PODS_TARGET_SRCROOT)/cpp/"/**'
   }
 
   s.frameworks = 'GLKit', 'MetalKit'
@@ -45,7 +41,7 @@ Pod::Spec.new do |s|
   # All iOS cpp/h files
   s.source_files = [
     "ios/**/*.{h,c,cc,cpp,m,mm,swift}",  
-    "cpp/**/*.{h,cpp}"    
+    "cpp/**/*.{h,cpp}"
   ]
 
   s.dependency "React"


### PR DESCRIPTION
Instead of hardcoding a relative path we now use the $PODS_TARGET_SRCROOT constant which should fix the issue with node_modules being located a level above in mono repos.

I've also tested this with `use_frameworks! linkage: :static` now and it seems to be working as well.

Tests:

1) Pod install and build / run on iOS should work out of the box
2) Add `use_frameworks! linkage: :static` and disable flipper ->  Pod install and build / run on iOS should work out of the box

Both these are now working on my side. Also asked OP to verify that his monorepo setup is working.

fixes #1477
fixes #652 (again?)