### PR TITLE
Fix makeImageSnapshot regression

### DIFF
--- a/package/cpp/api/JsiSkSurface.h
+++ b/package/cpp/api/JsiSkSurface.h
@@ -54,8 +54,9 @@ public:
     } else {
       image = getObject()->makeImageSnapshot();
     }
+    auto result = image->makeNonTextureImage();
     return jsi::Object::createFromHostObject(
-        runtime, std::make_shared<JsiSkImage>(getContext(), std::move(image)));
+        runtime, std::make_shared<JsiSkImage>(getContext(), std::move(result)));
   }
 
   JSI_EXPORT_PROPERTY_GETTERS(JSI_EXPORT_PROP_GET(JsiSkSurface, __typename__))


### PR DESCRIPTION
fixes #1459

I didn't manage yet to find a way to not transfer the bytes outside the gpu, to be investigated.