### PR TITLE
Add access to system fonts

### DIFF
--- a/example/src/Examples/Wallet/components/Label.tsx
+++ b/example/src/Examples/Wallet/components/Label.tsx
@@ -1,4 +1,4 @@
-import { useFont, Text } from "@shopify/react-native-skia";
+import { Text, Skia } from "@shopify/react-native-skia";
 import React from "react";
 import type { SharedValue } from "react-native-reanimated";
 import { interpolate, useDerivedValue } from "react-native-reanimated";
@@ -8,7 +8,10 @@ import { PADDING } from "../Model";
 
 import type { GraphState } from "./Selection";
 
-const sfMono = require("../../Severance/SF-Mono-Medium.otf");
+const sfMono = Skia.Typeface.MakeFromSystem("Bodoni 72");
+const titleFont = Skia.Font(sfMono, 64);
+const subtitleFont = Skia.Font(sfMono, 24);
+
 const format = (value: number) => {
   "worklet";
   return (
@@ -28,8 +31,6 @@ interface LabelProps {
 }
 
 export const Label = ({ state, y, graphs, width, height }: LabelProps) => {
-  const titleFont = useFont(sfMono, 64);
-  const subtitleFont = useFont(sfMono, 24);
   const translateY = height + PADDING;
   const AJUSTED_SIZE = height - PADDING * 2;
   const text = useDerivedValue(() => {

--- a/package/cpp/api/JsiSkTypefaceFactory.h
+++ b/package/cpp/api/JsiSkTypefaceFactory.h
@@ -25,8 +25,20 @@ public:
         runtime, std::make_shared<JsiSkTypeface>(getContext(), typeface));
   }
 
+  JSI_HOST_FUNCTION(MakeFromSystem) {
+    auto name = arguments[0].asString(runtime).utf8(runtime);
+    auto typeface = getContext()->getTypeFace(name);
+    if (typeface == nullptr) {
+      return jsi::Value::null();
+    }
+    return jsi::Object::createFromHostObject(
+        runtime, std::make_shared<JsiSkTypeface>(getContext(), typeface));
+  }
+
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkTypefaceFactory,
-                                       MakeFreeTypeFaceFromData))
+                                       MakeFreeTypeFaceFromData),
+                        JSI_EXPORT_FUNC(JsiSkTypefaceFactory,
+                                       MakeFromSystem))
 
   explicit JsiSkTypefaceFactory(std::shared_ptr<RNSkPlatformContext> context)
       : JsiSkHostObject(std::move(context)) {}

--- a/package/cpp/rnskia/RNSkPlatformContext.h
+++ b/package/cpp/rnskia/RNSkPlatformContext.h
@@ -16,6 +16,7 @@
 
 #include "SkStream.h"
 #include "SkSurface.h"
+#include "SkTypeface.h"
 
 #pragma clang diagnostic pop
 
@@ -117,6 +118,9 @@ public:
    * @return sk_sp<SkSurface>
    */
   virtual sk_sp<SkSurface> makeOffscreenSurface(int width, int height) = 0;
+
+  // TODO: add style, weight, see https://github.com/facebook/react-native/blob/c447b25c01ce5665a7888ac0f902bdcacb87d6ed/ReactAndroid/src/main/java/com/facebook/react/views/text/TypefaceStyle.java#L45-L55
+  virtual sk_sp<SkTypeface> getTypeFace(const std::string &familyName) = 0;
 
   /**
    * Raises an exception on the platform. This function does not necessarily

--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
@@ -61,6 +61,7 @@ public:
 
   void raiseError(const std::exception &err) override;
   sk_sp<SkSurface> makeOffscreenSurface(int width, int height) override;
+  sk_sp<SkTypeface> getTypeFace(const std::string &familyName) override;
 
   void willInvalidateModules() {
     // We need to do some house-cleaning here!


### PR DESCRIPTION
This is a proof of concept that allows to access system fonts on iOS.
* [ ] Test on Android
* [ ] Build/clean up examples
* [ ] Add family style/weight matching
* [ ] Making sure that the new API is compatible/not conflicting with what we will be using for advanced text layouts.

We need to think about this a little bit more and probably come up with something more refined. What we want to do is to use something like the FontMgr/Typeface provider which is what the paragraph API is using and use the platform context only to provide the platform specific data Skia is looking for.