### PR TITLE
Ignore "META-INF" resources in build.gradle

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -149,7 +149,8 @@ android {
              "**/libfbjni.so",
              "**/libjsi.so",
              "**/libreact_nativemodule_core.so",
-             "**/libturbomodulejsijni.so"
+             "**/libturbomodulejsijni.so",
+             "META-INF/**"
         ]
     }
 


### PR DESCRIPTION
Encountered this error while building an Android app:

`FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':shopify_react-native-skia:mergeDebugAndroidTestJavaResource'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
   > 23 files found with path 'META-INF/MANIFEST.MF' from inputs:
      - /Users/andranikm/.gradle/caches/modules-2/files-2.1/androidx.collection/collection/1.1.0/1f27220b47669781457de0d600849a5de0e89909/collection-1.1.0.jar
      - /Users/andranikm/.gradle/caches/transforms-3/90bfebe09471e4ffca0fe59ef3f63767/transformed/jetified-resourceinspection-annotation-1.0.0.jar
      - /Users/andranikm/.gradle/caches/transforms-3/c5f61a8f055854cde502dba5a420f528/transformed/jetified-concurrent-futures-1.0.0.jar
      - /Users/andranikm/.gradle/caches/modules-2/files-2.1/androidx.arch.core/core-common/2.1.0/b3152fc64428c9354344bd89848ecddc09b6f07e/core-common-2.1.0.jar
      - /Users/andranikm/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-common/2.4.0/1fdb7349701e9cf2f0a69fc10642b6fef6bb3e12/lifecycle-common-2.4.0.jar
      - /Users/andranikm/.gradle/caches/modules-2/files-2.1/androidx.annotation/annotation/1.3.0/21f49f5f9b85fc49de712539f79123119740595/annotation-1.3.0.jar
      - /Users/andranikm/.gradle/caches/transforms-3/b084fc0fa9509ad37d8a3bc96000d6a9/transformed/jetified-soloader-0.10.4/jars/classes.jar
      - /Users/andranikm/.gradle/caches/transforms-3/81d5ddf10a5ee5e57002cd61f9196fe7/transformed/jetified-nativeloader-0.10.4.jar
      - /Users/andranikm/.gradle/caches/transforms-3/7b1df78e82128c7841d6e0ac19a08f89/transformed/jetified-annotation-0.10.4.jar
      - /Users/andranikm/.gradle/caches/transforms-3/5a3bc7e84c5b9df5af051a5cd6110fed/transformed/jetified-bolts-tasks-1.4.0.jar
      - /Users/andranikm/.gradle/caches/transforms-3/12e95f6942d215ad24d8adb75d748211/transformed/jetified-infer-annotation-0.18.0.jar
      - /Users/andranikm/.gradle/caches/transforms-3/54200fd41d33d291c3fef35cbc5d2a6d/transformed/jetified-jsr305-3.0.2.jar
      - /Users/andranikm/.gradle/caches/transforms-3/4938b876588e9a4da86af7796e4f38f4/transformed/jetified-kotlin-annotations-jvm-1.3.72.jar
      - /Users/andranikm/.gradle/caches/transforms-3/afd6e3991bf736261d5d13ecbe77dff4/transformed/jetified-okhttp-urlconnection-4.9.2.jar
      - /Users/andranikm/.gradle/caches/transforms-3/75cacbdcb8365c92fcd342604cd6e83f/transformed/jetified-okhttp-4.9.2.jar
      - /Users/andranikm/.gradle/caches/transforms-3/c4ad7fe9df48e86e378941e9d29035fd/transformed/jetified-okio-jvm-2.9.0.jar
      - /Users/andranikm/.gradle/caches/transforms-3/07cf3ee6fb3461dbe86ceade05fd043d/transformed/jetified-kotlin-stdlib-jdk8-1.6.10.jar
      - /Users/andranikm/.gradle/caches/transforms-3/089c8481fc9f5f2b44b8d4af3c71f836/transformed/jetified-kotlin-stdlib-jdk7-1.6.10.jar
      - /Users/andranikm/.gradle/caches/transforms-3/fe5916f1079d4c4c2c3b440b22c34f46/transformed/jetified-kotlin-stdlib-1.6.10.jar
      - /Users/andranikm/.gradle/caches/transforms-3/ab1c0f88659340fd1fe55711467f3cea/transformed/jetified-annotations-13.0.jar
      - /Users/andranikm/.gradle/caches/transforms-3/0ba89d6be17480a6e579e6657e91c4ce/transformed/jetified-kotlin-stdlib-common-1.6.10.jar
      - /Users/andranikm/.gradle/caches/transforms-3/971f6226bbc76595933aa73c5666dcb0/transformed/jetified-proguard-annotations-1.19.0.jar
      - /Users/andranikm/.gradle/caches/transforms-3/fd65b47f38057589b91fbad2cf7b285c/transformed/jetified-listenablefuture-1.0.jar
     Adding a packagingOptions block may help, please refer to
     https://developer.android.com/reference/tools/gradle-api/7.3/com/android/build/api/dsl/ResourcesPackagingOptions
     for more information

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
java.lang.StackOverflowError (no error message)

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
==============================================================================

* Get more help at https://help.gradle.org

BUILD FAILED in 4m 5s
1667 actionable tasks: 1667 executed`

**Current stack:**

RN - 0.71.6
@shopify/react-native-skia - 0.1.183
gradle - 7.3.1
ndkVersion - 23.1.7779620
kotlimVersion - 1.7.20
targetSdk - 33
builtToolsVersion - 33.0.0

**Command used to build**

`./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release`

Found that patching @shopify/react-native-skia/android/build.gradle helps this issue. Original solution found in this issue: https://github.com/Shopify/react-native-skia/issues/728

