### PR TITLE
Fix typo in group.md

### DIFF
--- a/docs/docs/group.md
+++ b/docs/docs/group.md
@@ -15,7 +15,7 @@ It can apply the following operations to its children:
 
 | Name       | Type               |  Description                                                  |
 |:-----------|:-------------------|:--------------------------------------------------------------|
-| transform? | `Transform2d`      | [Same API than in React Native](https://reactnative.dev/docs/transforms). The default origin of the transformation is, however, different. It is the center object in React Native and the top-left corner in Skia. |
+| transform? | `Transform2d`      | [Same API that's in React Native](https://reactnative.dev/docs/transforms). The default origin of the transformation is, however, different. It is the center object in React Native and the top-left corner in Skia. |
 | origin?    | `Point`            | Sets the origin of the transformation. This property is not inherited by its children. |
 | clip?   | `RectOrRRectOrPath`     | Rectangle, rounded rectangle, or Path to use to clip the children. |
 | invertClip? | `boolean`         | Invert the clipping region: parts outside the clipping region will be shown and, inside will be hidden. |


### PR DESCRIPTION
First open source contribution - Quick PR that fixes a typo in the documentation for `<Group>`.