### PR TITLE
#1524 support null for image, svg and font properties

### DIFF
--- a/docs/docs/backdrop-filters.md
+++ b/docs/docs/backdrop-filters.md
@@ -10,6 +10,7 @@ In Skia, backdrop filters are equivalent to their [CSS counterpart](https://deve
 The [clipping mask](/docs/group#clipping-operations) will be used to restrict the area of the backdrop filter.
 
 ## Backdrop Filter
+
 Applies an image filter to the area behind the canvas or behind a defined clipping mask. The first child of a backdrop filter is the image filter to use. All properties from the [group component](/docs/group) can be applied to a backdrop filter.
 
 ### Example
@@ -17,7 +18,14 @@ Applies an image filter to the area behind the canvas or behind a defined clippi
 Apply a black and white color matrix to the clipping area:
 
 ```tsx twoslash
-import { Canvas, BackdropFilter, Fill, Image, ColorMatrix, useImage } from "@shopify/react-native-skia";
+import {
+  Canvas,
+  BackdropFilter,
+  Fill,
+  Image,
+  ColorMatrix,
+  useImage,
+} from "@shopify/react-native-skia";
 
 // https://kazzkiq.github.io/svg-color-filter/
 const BLACK_AND_WHITE = [
@@ -26,19 +34,10 @@ const BLACK_AND_WHITE = [
 
 const Filter = () => {
   const image = useImage(require("./assets/oslo.jpg"));
-  if (!image) {
-    return null;
-  }
+
   return (
     <Canvas style={{ width: 256, height: 256 }}>
-      <Image
-        image={image}
-        x={0}
-        y={0}
-        width={256}
-        height={256}
-        fit="cover"
-      />
+      <Image image={image} x={0} y={0} width={256} height={256} fit="cover" />
       <BackdropFilter
         clip={{ x: 0, y: 128, width: 256, height: 128 }}
         filter={<ColorMatrix matrix={BLACK_AND_WHITE} />}
@@ -54,34 +53,29 @@ const Filter = () => {
 
 Creates a backdrop blur. All properties from the [group component](/docs/group) can be applied to a backdrop filter.
 
-| Name      | Type                |  Description                                             |
-|:----------|:--------------------|:---------------------------------------------------------|
-| blur      | `number`            | Blur radius                                              |
+| Name | Type     | Description |
+| :--- | :------- | :---------- |
+| blur | `number` | Blur radius |
 
 ## Example
 
 ```tsx twoslash
-import { Canvas, Fill, Image, BackdropBlur, ColorMatrix, useImage } from "@shopify/react-native-skia";
+import {
+  Canvas,
+  Fill,
+  Image,
+  BackdropBlur,
+  ColorMatrix,
+  useImage,
+} from "@shopify/react-native-skia";
 
 const Filter = () => {
   const image = useImage(require("./assets/oslo.jpg"));
-  if (!image) {
-    return null;
-  }
+
   return (
     <Canvas style={{ width: 256, height: 256 }}>
-      <Image
-        image={image}
-        x={0}
-        y={0}
-        width={256}
-        height={256}
-        fit="cover"
-      />
-      <BackdropBlur
-        blur={4}
-        clip={{ x: 0, y: 128, width: 256, height: 128 }}
-      >
+      <Image image={image} x={0} y={0} width={256} height={256} fit="cover" />
+      <BackdropBlur blur={4} clip={{ x: 0, y: 128, width: 256, height: 128 }}>
         <Fill color="rgba(0, 0, 0, 0.2)" />
       </BackdropBlur>
     </Canvas>

--- a/docs/docs/color-filters.md
+++ b/docs/docs/color-filters.md
@@ -8,37 +8,33 @@ slug: /color-filters
 ## Color Matrix
 
 Creates a color filter using the provided color matrix.
-A playground to build color matrices is available [here](https://fecolormatrix.com/). 
+A playground to build color matrices is available [here](https://fecolormatrix.com/).
 
-| Name      | Type          |  Description                               |
-|:----------|:--------------|:-------------------------------------------|
+| Name      | Type          | Description                                |
+| :-------- | :------------ | :----------------------------------------- |
 | matrix    | `number[]`    | Color Matrix (5x4)                         |
 | children? | `ColorFilter` | Optional color filter to be applied first. |
 
 ```tsx twoslash
-import { Canvas, ColorMatrix, Image, useImage } from "@shopify/react-native-skia";
+import {
+  Canvas,
+  ColorMatrix,
+  Image,
+  useImage,
+} from "@shopify/react-native-skia";
 
 const MatrixColorFilter = () => {
   const image = useImage(require("./assets/oslo.jpg"));
-  if (!image) {
-    return null;
-  }
+
   return (
     <Canvas style={{ flex: 1 }}>
-      <Image
-          x={0}
-          y={0}
-          width={256}
-          height={256}
-          image={image}
-          fit="cover"
-        >
-          <ColorMatrix
-            matrix={[
-              -0.578, 0.99, 0.588, 0, 0, 0.469, 0.535, -0.003, 0, 0, 0.015,
-              1.69, -0.703, 0, 0, 0, 0, 0, 1, 0,
-            ]}
-          />
+      <Image x={0} y={0} width={256} height={256} image={image} fit="cover">
+        <ColorMatrix
+          matrix={[
+            -0.578, 0.99, 0.588, 0, 0, 0.469, 0.535, -0.003, 0, 0, 0.015, 1.69,
+            -0.703, 0, 0, 0, 0, 0, 1, 0,
+          ]}
+        />
       </Image>
     </Canvas>
   );
@@ -51,15 +47,15 @@ const MatrixColorFilter = () => {
 
 Creates a color filter with the given color and blend mode.
 
-| Name       | Type          |  Description                                      |
-|:-----------|:--------------|:--------------------------------------------------|
-| color      | `Color`       | Color                                             |
-| mode       | `BlendMode`   | see [blend modes](paint/properties.md#blend-mode).|
-| children?  | `ColorFilter` | Optional color filter to be applied first.        |
+| Name      | Type          | Description                                        |
+| :-------- | :------------ | :------------------------------------------------- |
+| color     | `Color`       | Color                                              |
+| mode      | `BlendMode`   | see [blend modes](paint/properties.md#blend-mode). |
+| children? | `ColorFilter` | Optional color filter to be applied first.         |
 
 ```tsx twoslash
 import { Canvas, BlendColor, Group, Circle } from "@shopify/react-native-skia";
- 
+
 const MatrixColorFilter = () => {
   const r = 128;
   return (
@@ -80,19 +76,23 @@ const MatrixColorFilter = () => {
 
 Creates a color filter that is linearly interpolated between two other color filters.
 
-| Name      | Type          |  Description                               |
-|:----------|:--------------|:-------------------------------------------|
-| t         | `number`      | Value between 0 and 1.                     |
-| children  | `ColorFilter` | The two filters to interpolate from.       |
+| Name     | Type          | Description                          |
+| :------- | :------------ | :----------------------------------- |
+| t        | `number`      | Value between 0 and 1.               |
+| children | `ColorFilter` | The two filters to interpolate from. |
 
 ```tsx twoslash
-import { Canvas,ColorMatrix, Image, useImage, Lerp } from "@shopify/react-native-skia";
+import {
+  Canvas,
+  ColorMatrix,
+  Image,
+  useImage,
+  Lerp,
+} from "@shopify/react-native-skia";
 
 const MatrixColorFilter = () => {
   const image = useImage(require("./assets/oslo.jpg"));
-  if (!image) {
-    return null;
-  }
+
   const blackAndWhite = [
     0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0,
   ];
@@ -101,22 +101,11 @@ const MatrixColorFilter = () => {
   ];
   return (
     <Canvas style={{ flex: 1 }}>
-      <Image
-          x={0}
-          y={0}
-          width={256}
-          height={256}
-          image={image}
-          fit="cover"
-        >
-          <Lerp t={0.5}>
-            <ColorMatrix
-              matrix={purple}
-            />
-            <ColorMatrix
-              matrix={blackAndWhite}
-            />
-          </Lerp>
+      <Image x={0} y={0} width={256} height={256} image={image} fit="cover">
+        <Lerp t={0.5}>
+          <ColorMatrix matrix={purple} />
+          <ColorMatrix matrix={blackAndWhite} />
+        </Lerp>
       </Image>
     </Canvas>
   );
@@ -127,13 +116,19 @@ const MatrixColorFilter = () => {
 
 Creates a color filter that converts between linear colors and sRGB colors.
 
-| Name       | Type          |  Description                                      |
-|:-----------|:--------------|:--------------------------------------------------|
-| children?  | `ColorFilter` | Optional color filter to be applied first.        |
+| Name      | Type          | Description                                |
+| :-------- | :------------ | :----------------------------------------- |
+| children? | `ColorFilter` | Optional color filter to be applied first. |
 
 ```tsx twoslash
-import { Canvas, BlendColor, Group, Circle, LinearToSRGBGamma } from "@shopify/react-native-skia";
- 
+import {
+  Canvas,
+  BlendColor,
+  Group,
+  Circle,
+  LinearToSRGBGamma,
+} from "@shopify/react-native-skia";
+
 const MatrixColorFilter = () => {
   const r = 128;
   return (
@@ -153,13 +148,19 @@ const MatrixColorFilter = () => {
 
 Creates a color filter that converts between sRGB colors and linear colors.
 
-| Name       | Type          |  Description                                      |
-|:-----------|:--------------|:--------------------------------------------------|
-| children?  | `ColorFilter` | Optional color filter to be applied first.        |
+| Name      | Type          | Description                                |
+| :-------- | :------------ | :----------------------------------------- |
+| children? | `ColorFilter` | Optional color filter to be applied first. |
 
 ```tsx twoslash
-import { Canvas, BlendColor, Group, Circle, SRGBToLinearGamma } from "@shopify/react-native-skia";
- 
+import {
+  Canvas,
+  BlendColor,
+  Group,
+  Circle,
+  SRGBToLinearGamma,
+} from "@shopify/react-native-skia";
+
 const MatrixColorFilter = () => {
   const r = 128;
   return (

--- a/docs/docs/group.md
+++ b/docs/docs/group.md
@@ -8,26 +8,27 @@ slug: /group
 The Group component is an essential construct in React Native Skia.
 Group components can be deeply nested with one another.
 It can apply the following operations to its children:
-* [Paint properties](#paint-properties)
-* [Transformations](#transformations)
-* [Clipping operations](#clipping-operations)
-* [Bitmap Effects](#bitmap-effects)
 
-| Name       | Type               |  Description                                                  |
-|:-----------|:-------------------|:--------------------------------------------------------------|
-| transform? | `Transform2d`      | [Same API that's in React Native](https://reactnative.dev/docs/transforms). The default origin of the transformation is, however, different. It is the center object in React Native and the top-left corner in Skia. |
-| origin?    | `Point`            | Sets the origin of the transformation. This property is not inherited by its children. |
-| clip?   | `RectOrRRectOrPath`     | Rectangle, rounded rectangle, or Path to use to clip the children. |
-| invertClip? | `boolean`         | Invert the clipping region: parts outside the clipping region will be shown and, inside will be hidden. |
-| layer? | `RefObject<Paint>` | Draws the children as a bitmap and applies the effects provided by the paint. |
+- [Paint properties](#paint-properties)
+- [Transformations](#transformations)
+- [Clipping operations](#clipping-operations)
+- [Bitmap Effects](#bitmap-effects)
+
+| Name        | Type                | Description                                                                                                                                                                                                           |
+| :---------- | :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| transform?  | `Transform2d`       | [Same API that's in React Native](https://reactnative.dev/docs/transforms). The default origin of the transformation is, however, different. It is the center object in React Native and the top-left corner in Skia. |
+| origin?     | `Point`             | Sets the origin of the transformation. This property is not inherited by its children.                                                                                                                                |
+| clip?       | `RectOrRRectOrPath` | Rectangle, rounded rectangle, or Path to use to clip the children.                                                                                                                                                    |
+| invertClip? | `boolean`           | Invert the clipping region: parts outside the clipping region will be shown and, inside will be hidden.                                                                                                               |
+| layer?      | `RefObject<Paint>`  | Draws the children as a bitmap and applies the effects provided by the paint.                                                                                                                                         |
 
 ## Paint Properties
 
 Its children will inherit all paint attributes applied to a group. These attributes can be properties like `color` or `style` or children like `<Shader />`, or `<ImageFilter />` for instance ([see painting](/docs/paint/overview)).
 
 ```tsx twoslash
-import {Canvas, Circle, Group} from "@shopify/react-native-skia";
- 
+import { Canvas, Circle, Group } from "@shopify/react-native-skia";
+
 export const PaintDemo = () => {
   const r = 128;
   return (
@@ -54,7 +55,7 @@ The origin property is a helper to set the origin of the transformation. This pr
 ### Simple Transformation
 
 ```tsx twoslash
-import {Canvas, Fill, Group, RoundedRect} from "@shopify/react-native-skia";
+import { Canvas, Fill, Group, RoundedRect } from "@shopify/react-native-skia";
 
 const SimpleTransform = () => {
   return (
@@ -73,7 +74,7 @@ const SimpleTransform = () => {
 ### Transformation of Origin
 
 ```tsx twoslash
-import {Canvas, Fill, Group, RoundedRect} from "@shopify/react-native-skia";
+import { Canvas, Fill, Group, RoundedRect } from "@shopify/react-native-skia";
 
 const SimpleTransform = () => {
   return (
@@ -93,7 +94,6 @@ const SimpleTransform = () => {
 
 ![Origin Transformation](assets/group/origin-transform.png)
 
-
 ## Clipping Operations
 
 `clip` provides a clipping region that sets what part of the children should be shown.
@@ -103,7 +103,16 @@ When using `invertClip`, everything outside the clipping region will be shown, a
 ### Clip Rectangle
 
 ```tsx twoslash
-import {Canvas, Group, Image, useImage, Skia, rrect, rect, Fill} from "@shopify/react-native-skia";
+import {
+  Canvas,
+  Group,
+  Image,
+  useImage,
+  Skia,
+  rrect,
+  rect,
+  Fill,
+} from "@shopify/react-native-skia";
 
 const size = 256;
 const padding = 32;
@@ -111,9 +120,7 @@ const padding = 32;
 const Clip = () => {
   const image = useImage(require("./assets/oslo.jpg"));
   const rct = rect(padding, padding, size - padding * 2, size - padding * 2);
-  if (!image) {
-    return null;
-  }
+
   return (
     <Canvas style={{ flex: 1 }}>
       <Fill color="lightblue" />
@@ -137,7 +144,15 @@ const Clip = () => {
 ### Clip Rounded Rectangle
 
 ```tsx twoslash
-import {Canvas, Group, Image, useImage, Skia, rrect, rect} from "@shopify/react-native-skia";
+import {
+  Canvas,
+  Group,
+  Image,
+  useImage,
+  Skia,
+  rrect,
+  rect,
+} from "@shopify/react-native-skia";
 
 const size = 256;
 const padding = 32;
@@ -145,10 +160,12 @@ const r = 8;
 
 const Clip = () => {
   const image = useImage(require("./assets/oslo.jpg"));
-  const roundedRect = rrect(rect(padding, padding, size - padding * 2, size - padding * 2), r, r);
-  if (!image) {
-    return null;
-  }
+  const roundedRect = rrect(
+    rect(padding, padding, size - padding * 2, size - padding * 2),
+    r,
+    r
+  );
+
   return (
     <Canvas style={{ flex: 1 }}>
       <Group clip={roundedRect}>
@@ -171,27 +188,24 @@ const Clip = () => {
 ### Clip Path
 
 ```tsx twoslash
-import {Canvas, Group, Image, useImage, Skia} from "@shopify/react-native-skia";
+import {
+  Canvas,
+  Group,
+  Image,
+  useImage,
+  Skia,
+} from "@shopify/react-native-skia";
 
 const Clip = () => {
   const image = useImage(require("./assets/oslo.jpg"));
   const star = Skia.Path.MakeFromSVGString(
     "M 128 0 L 168 80 L 256 93 L 192 155 L 207 244 L 128 202 L 49 244 L 64 155 L 0 93 L 88 80 L 128 0 Z"
   )!;
-  if (!image) {
-    return null;
-  }
+
   return (
     <Canvas style={{ flex: 1 }}>
       <Group clip={star}>
-        <Image
-          image={image}
-          x={0}
-          y={0}
-          width={256}
-          height={256}
-          fit="cover"
-        />
+        <Image image={image} x={0} y={0} width={256} height={256} fit="cover" />
       </Group>
     </Canvas>
   );
@@ -200,31 +214,27 @@ const Clip = () => {
 
 <img src={require("/static/img/group/clip-path.png").default} width="256" height="256" />
 
-
 ### Invert Clip
 
 ```tsx twoslash
-import {Canvas, Group, Image, useImage, Skia} from "@shopify/react-native-skia";
+import {
+  Canvas,
+  Group,
+  Image,
+  useImage,
+  Skia,
+} from "@shopify/react-native-skia";
 
 const Clip = () => {
   const image = useImage(require("./assets/oslo.jpg"));
   const star = Skia.Path.MakeFromSVGString(
     "M 128 0 L 168 80 L 256 93 L 192 155 L 207 244 L 128 202 L 49 244 L 64 155 L 0 93 L 88 80 L 128 0 Z"
   )!;
-  if (!image) {
-    return null;
-  }
+
   return (
     <Canvas style={{ flex: 1 }}>
       <Group clip={star} invertClip>
-        <Image
-          image={image}
-          x={0}
-          y={0}
-          width={256}
-          height={256}
-          fit="cover"
-        />
+        <Image image={image} x={0} y={0} width={256} height={256} fit="cover" />
       </Group>
     </Canvas>
   );
@@ -240,28 +250,33 @@ You can use it to apply effects.
 This is particularly useful to build effects that need to be applied to a group of elements and not one in particular.
 
 ```tsx twoslash
-import {Canvas, Group, Circle, Blur, Paint, ColorMatrix} from "@shopify/react-native-skia";
+import {
+  Canvas,
+  Group,
+  Circle,
+  Blur,
+  Paint,
+  ColorMatrix,
+} from "@shopify/react-native-skia";
 
 const Clip = () => {
   return (
     <Canvas style={{ flex: 1 }}>
       <Group
         color="lightblue"
-        layer={<Paint>
-          <Blur blur={20} />
-          <ColorMatrix
-            matrix={[
-              1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 18, -7,
-            ]}
-          />
-        </Paint>}
+        layer={
+          <Paint>
+            <Blur blur={20} />
+            <ColorMatrix
+              matrix={[
+                1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 18, -7,
+              ]}
+            />
+          </Paint>
+        }
       >
         <Circle cx={0} cy={128} r={128 * 0.95} />
-        <Circle
-          cx={256}
-          cy={128}
-          r={128 * 0.95}
-        />
+        <Circle cx={256} cy={128} r={128 * 0.95} />
       </Group>
     </Canvas>
   );
@@ -270,15 +285,14 @@ const Clip = () => {
 
 <img alt="Rasterize" src={require("/static/img/group/rasterize.png").default} width="256" height="256" />
 
-
 ## Fitbox
 
 The `FitBox` component is based on the `Group` component and allows you to scale drawings to fit into a destination rectangle automatically.
 
-| Name | Type     |  Description                                       |
-|:-----|:---------|:---------------------------------------------------|
-| src  | `SKRect` | Bounding rectangle of the drawing before scaling  |
-| dst  | `SKRect` | Bounding rectangle of the drawing after scale      |
+| Name | Type     | Description                                                                                                                                                  |
+| :--- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| src  | `SKRect` | Bounding rectangle of the drawing before scaling                                                                                                             |
+| dst  | `SKRect` | Bounding rectangle of the drawing after scale                                                                                                                |
 | fit? | `Fit`    | Method to make the image fit into the rectangle. Value can be `contain`, `fill`, `cover` `fitHeight`, `fitWidth`, `scaleDown`, `none` (default is `contain`) |
 
 ### Example
@@ -295,7 +309,7 @@ Its bounding source rectangle is `0, 0, 664, 308`:
 We would like to automatically scale that path to our canvas of size `256 x 256`:
 
 ```tsx twoslash
-import {Canvas, FitBox, Path, rect} from "@shopify/react-native-skia";
+import { Canvas, FitBox, Path, rect } from "@shopify/react-native-skia";
 
 const Hello = () => {
   return (
@@ -311,8 +325,7 @@ const Hello = () => {
       </FitBox>
     </Canvas>
   );
-}
+};
 ```
 
 <img src={require("/static/img/group/scale-path.png").default} width="256" height="256" />
-

--- a/docs/docs/image-filters/morphology.md
+++ b/docs/docs/image-filters/morphology.md
@@ -22,9 +22,6 @@ import {Canvas, Text, Morphology, useFont} from "@shopify/react-native-skia";
 
 export const MorphologyDemo = () => {
   const font = useFont(require("./SF-Pro.ttf"), 24);
-  if (font === null) {
-    return null;
-  }
   return (
     <Canvas style={{ width: 256, height: 256 }}>
       <Text

--- a/docs/docs/image.md
+++ b/docs/docs/image.md
@@ -45,16 +45,7 @@ const ImageDemo = () => {
   const image = useImage(require("./assets/oslo.jpg"));
   return (
     <Canvas style={{ flex: 1 }}>
-      {image && (
-        <Image
-          image={image}
-          fit="contain"
-          x={0}
-          y={0}
-          width={256}
-          height={256}
-        />
-      )}
+      <Image image={image} fit="contain" x={0} y={0} width={256} height={256} />
     </Canvas>
   );
 };

--- a/docs/docs/text/blob.md
+++ b/docs/docs/text/blob.md
@@ -21,9 +21,6 @@ import {Canvas, TextBlob, Skia, useFont} from "@shopify/react-native-skia";
 
 export const HelloWorld = () => {
   const font = useFont(require("./SF-Pro.ttf"), 24);
-  if (!font) {
-    return null;
-  }
   const blob = Skia.TextBlob.MakeFromText("Hello World!", font);
   return (
       <Canvas style={{ flex: 1 }}>

--- a/docs/docs/text/blob.md
+++ b/docs/docs/text/blob.md
@@ -21,6 +21,9 @@ import {Canvas, TextBlob, Skia, useFont} from "@shopify/react-native-skia";
 
 export const HelloWorld = () => {
   const font = useFont(require("./SF-Pro.ttf"), 24);
+  if (font === null) {
+    return null;
+  }
   const blob = Skia.TextBlob.MakeFromText("Hello World!", font);
   return (
       <Canvas style={{ flex: 1 }}>

--- a/docs/docs/text/glyphs.md
+++ b/docs/docs/text/glyphs.md
@@ -22,6 +22,9 @@ import {Canvas, Glyphs, vec, useFont} from "@shopify/react-native-skia";
 export const HelloWorld = () => {
   const fontSize = 32;
   const font = useFont(require("./my-font.otf"), fontSize);
+  if (font === null) {
+    return null;
+  }
   const glyphs = font
     .getGlyphIDs("Hello World!")
     .map((id, i) => ({ id, pos: vec(0, (i + 1) * fontSize) }));

--- a/docs/docs/text/glyphs.md
+++ b/docs/docs/text/glyphs.md
@@ -22,9 +22,6 @@ import {Canvas, Glyphs, vec, useFont} from "@shopify/react-native-skia";
 export const HelloWorld = () => {
   const fontSize = 32;
   const font = useFont(require("./my-font.otf"), fontSize);
-  if (font === null) {
-    return null;
-  }
   const glyphs = font
     .getGlyphIDs("Hello World!")
     .map((id, i) => ({ id, pos: vec(0, (i + 1) * fontSize) }));

--- a/docs/docs/text/path.md
+++ b/docs/docs/text/path.md
@@ -24,9 +24,6 @@ path.addCircle(size, size, size/2);
 
 export const HelloWorld = () => {
   const font = useFont(require("./my-font.ttf"), 24);
-  if (font === null) {
-    return null;
-  }
   return (
     <Canvas style={{ flex: 1 }}>
       <Fill color="white" />

--- a/docs/docs/text/text.md
+++ b/docs/docs/text/text.md
@@ -23,9 +23,6 @@ import {Canvas, Text, useFont, Fill} from "@shopify/react-native-skia";
 export const HelloWorld = () => {
   const fontSize = 32;
   const font = useFont(require("./my-font.ttf"), fontSize);
-  if (font === null) {
-    return null;
-  }
   return (
     <Canvas style={{ flex: 1 }}>
       <Fill color="white" />
@@ -42,7 +39,6 @@ export const HelloWorld = () => {
 
 <img src={require("/static/img/text/hello-world.png").default} width="256" height="256" />
 
-
 ### Emojis
 
 ```tsx twoslash
@@ -51,9 +47,6 @@ import {Canvas, Text, useFont, Fill} from "@shopify/react-native-skia";
 export const HelloWorld = () => {
   const fontSize = 32;
   const font = useFont(require("./NotoColorEmoji.ttf"), fontSize);
-  if (font === null) {
-    return null;
-  }
   return (
     <Canvas style={{ flex: 1 }}>
       <Fill color="white" />

--- a/example/src/Examples/API/BlendModes.tsx
+++ b/example/src/Examples/API/BlendModes.tsx
@@ -64,9 +64,6 @@ const dst = Skia.Path.MakeFromSVGString(
 
 export const BlendModes = () => {
   const font = useFont(require("../../assets/SF-Pro-Display-Bold.otf"), 50);
-  if (font === null) {
-    return null;
-  }
   return (
     <Canvas style={{ flex: 1 }}>
       <Group blendMode="multiply">

--- a/example/src/Examples/API/Clipping.tsx
+++ b/example/src/Examples/API/Clipping.tsx
@@ -41,9 +41,7 @@ export const Clipping = () => {
   const progress = useLoop({ duration: 3000 });
   const x = useComputedValue(() => mix(progress.current, 0, 200), [progress]);
   const oslo = useImage(require("../../assets/oslo.jpg"));
-  if (oslo === null) {
-    return null;
-  }
+
   return (
     <ScrollView>
       <Canvas style={{ width, height: SIZE + 32 }}>

--- a/example/src/Examples/API/ColorFilter.tsx
+++ b/example/src/Examples/API/ColorFilter.tsx
@@ -118,9 +118,6 @@ export const ColorFilter = () => {
   );
 
   const r = IMG_HEIGHT;
-  if (!image) {
-    return null;
-  }
 
   return (
     <ScrollView>

--- a/example/src/Examples/API/Freeze.tsx
+++ b/example/src/Examples/API/Freeze.tsx
@@ -20,9 +20,6 @@ export const FreezeExample = () => {
     [clock]
   );
 
-  if (font === null) {
-    return null;
-  }
   return (
     <Canvas style={{ flex: 1, margin: 50 }}>
       <Group origin={{ x: size / 2, y: size / 2 }} transform={transform}>

--- a/example/src/Examples/API/ImageFilters.tsx
+++ b/example/src/Examples/API/ImageFilters.tsx
@@ -19,9 +19,7 @@ import { Examples, SIZE } from "./components/Examples";
 
 const DisplacementMapDemo = () => {
   const image = useImage(require("../../assets/oslo.jpg"));
-  if (!image) {
-    return null;
-  }
+
   return (
     <Group>
       <DisplacementMap channelX="r" channelY="a" scale={20}>
@@ -33,9 +31,7 @@ const DisplacementMapDemo = () => {
 };
 const OffsetDemo = () => {
   const image = useImage(require("../../assets/oslo.jpg"));
-  if (!image) {
-    return null;
-  }
+
   return (
     <Group>
       <Fill color="lightblue" />

--- a/example/src/Examples/API/ImageFilters.tsx
+++ b/example/src/Examples/API/ImageFilters.tsx
@@ -52,9 +52,7 @@ const OffsetDemo = () => {
 
 const MorphologyDemo = () => {
   const font = useFont(require("../../assets/SF-Mono-Semibold.otf"), 24);
-  if (font === null) {
-    return null;
-  }
+
   return (
     <Group>
       <Text text="Hello World" x={32} y={32} font={font} />

--- a/example/src/Examples/API/Images.tsx
+++ b/example/src/Examples/API/Images.tsx
@@ -69,41 +69,37 @@ export const Images = () => {
                     height={height}
                     color="lightblue"
                   />
-                  {oslo ? (
-                    <Image
-                      image={oslo}
-                      x={x}
-                      y={y}
-                      width={width}
-                      height={height}
-                      fit={fit}
-                    />
-                  ) : null}
+                  <Image
+                    image={oslo}
+                    x={x}
+                    y={y}
+                    width={width}
+                    height={height}
+                    fit={fit}
+                  />
                 </React.Fragment>
               );
             })}
           </Canvas>
         </React.Fragment>
       ))}
-      {coffee ? (
-        <Canvas
-          style={{
-            alignSelf: "center",
-            width: 320,
-            height: 180,
-            marginVertical: PAD,
-          }}
-        >
-          <Image
-            image={coffee}
-            x={0}
-            y={0}
-            width={320}
-            height={180}
-            fit="contain"
-          />
-        </Canvas>
-      ) : null}
+      <Canvas
+        style={{
+          alignSelf: "center",
+          width: 320,
+          height: 180,
+          marginVertical: PAD,
+        }}
+      >
+        <Image
+          image={coffee}
+          x={0}
+          y={0}
+          width={320}
+          height={180}
+          fit="contain"
+        />
+      </Canvas>
     </ScrollView>
   );
 };

--- a/example/src/Examples/API/Path.tsx
+++ b/example/src/Examples/API/Path.tsx
@@ -119,6 +119,9 @@ export const PathExample = () => {
       ),
     [progress]
   );
+  if (!font) {
+    return null;
+  }
   const textPath =
     Platform.OS === "web"
       ? Skia.Path.MakeFromSVGString(

--- a/example/src/Examples/API/Path.tsx
+++ b/example/src/Examples/API/Path.tsx
@@ -119,9 +119,6 @@ export const PathExample = () => {
       ),
     [progress]
   );
-  if (!font) {
-    return null;
-  }
   const textPath =
     Platform.OS === "web"
       ? Skia.Path.MakeFromSVGString(

--- a/example/src/Examples/API/SVG.tsx
+++ b/example/src/Examples/API/SVG.tsx
@@ -7,9 +7,7 @@ export const SVG = () => {
   const svg = useSVG(require("./tiger.svg"));
   return (
     <Canvas style={{ flex: 1 }}>
-      {svg ? (
-        <ImageSVG svg={svg} x={0} y={0} width={width / 2} height={height / 2} />
-      ) : null}
+      <ImageSVG svg={svg} x={0} y={0} width={width / 2} height={height / 2} />
     </Canvas>
   );
 };

--- a/example/src/Examples/API/Snapshot.tsx
+++ b/example/src/Examples/API/Snapshot.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import {
   View,
   StyleSheet,
@@ -7,7 +7,7 @@ import {
   useWindowDimensions,
   ScrollView,
 } from "react-native";
-import { SkImage, useValue } from "@shopify/react-native-skia";
+import type { SkImage } from "@shopify/react-native-skia";
 import {
   Canvas,
   Fill,
@@ -19,6 +19,7 @@ import {
   mix,
   Shader,
   ImageShader,
+  useValue,
 } from "@shopify/react-native-skia";
 import { Switch } from "react-native-gesture-handler";
 
@@ -47,7 +48,7 @@ export const Snapshot = () => {
       return;
     }
     image.current = await makeImageFromView(viewRef);
-  }, []);
+  }, [image]);
 
   return (
     <View style={{ flex: 1 }}>

--- a/example/src/Examples/API/Snapshot.tsx
+++ b/example/src/Examples/API/Snapshot.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   View,
   StyleSheet,

--- a/example/src/Examples/API/Snapshot.tsx
+++ b/example/src/Examples/API/Snapshot.tsx
@@ -7,7 +7,7 @@ import {
   useWindowDimensions,
   ScrollView,
 } from "react-native";
-import type { SkImage } from "@shopify/react-native-skia";
+import { SkImage, useValue } from "@shopify/react-native-skia";
 import {
   Canvas,
   Fill,
@@ -41,14 +41,14 @@ export const Snapshot = () => {
     [progress]
   );
 
-  const [image, setImage] = useState<SkImage | null>(null);
+  const image = useValue<SkImage | null>(null);
   const takeSnapshot = useCallback(async () => {
     if (viewRef.current == null) {
       return;
     }
-    const snapshot = await makeImageFromView(viewRef);
-    setImage(snapshot);
+    image.current = await makeImageFromView(viewRef);
   }, []);
+
   return (
     <View style={{ flex: 1 }}>
       <View ref={viewRef} style={styles.view}>
@@ -57,20 +57,18 @@ export const Snapshot = () => {
       <Button title="Take snapshot" onPress={takeSnapshot} />
       <Canvas style={styles.canvas}>
         <Fill color="white" />
-        {image ? (
-          <Fill>
-            <Shader source={source} uniforms={uniforms}>
-              <ImageShader
-                image={image}
-                fit="contain"
-                x={20}
-                y={20}
-                width={width - 40}
-                height={width - 120}
-              />
-            </Shader>
-          </Fill>
-        ) : null}
+        <Fill>
+          <Shader source={source} uniforms={uniforms}>
+            <ImageShader
+              image={image}
+              fit="contain"
+              x={20}
+              y={20}
+              width={width - 40}
+              height={width - 120}
+            />
+          </Shader>
+        </Fill>
       </Canvas>
     </View>
   );

--- a/example/src/Examples/Aurora/components/CoonsPatchMeshGradient.tsx
+++ b/example/src/Examples/Aurora/components/CoonsPatchMeshGradient.tsx
@@ -173,9 +173,7 @@ export const CoonsPatchMeshGradient = ({
 
   const onTouch = useHandles(meshGesture, defaultMesh, window);
   const mesh = play ? meshNoise : meshGesture;
-  if (image === null) {
-    return null;
-  }
+
   return (
     <Canvas style={{ width, height }} onTouch={onTouch}>
       <Group>

--- a/example/src/Examples/Filters/Filters.tsx
+++ b/example/src/Examples/Filters/Filters.tsx
@@ -32,9 +32,7 @@ export const Filters = () => {
   );
 
   const image = useImage(require("../../assets/oslo.jpg"));
-  if (image === null) {
-    return null;
-  }
+
   return (
     <Canvas style={{ width, height }} onTouch={() => setState((i) => i + 1)}>
       <Fill>

--- a/example/src/Examples/Glassmorphism/Card.tsx
+++ b/example/src/Examples/Glassmorphism/Card.tsx
@@ -57,9 +57,6 @@ export const Glassmorphism = () => {
     () => [{ translateY: x.current }, { translateX: y.current }],
     [x, y]
   );
-  if (titleFont === null || subtitleFont === null || font === null) {
-    return null;
-  }
   return (
     <Canvas style={{ flex: 1 }} onTouch={onTouch} debug>
       <Background />

--- a/example/src/Examples/Graphs/Slider.tsx
+++ b/example/src/Examples/Graphs/Slider.tsx
@@ -53,9 +53,6 @@ export const Slider: React.FC<GraphProps> = ({ height, width }) => {
     [touchPos]
   );
 
-  if (font === null) {
-    return null;
-  }
   return (
     <View style={{ height, marginBottom: 10 }}>
       <Canvas style={styles.graph} onTouch={touchHandler}>

--- a/example/src/Examples/Neumorphism/Dashboard/Dashboard.tsx
+++ b/example/src/Examples/Neumorphism/Dashboard/Dashboard.tsx
@@ -57,9 +57,7 @@ export const Neumorphism = () => {
       runSpring(translateY, 0);
     },
   });
-  if (!font) {
-    return null;
-  }
+
   return (
     <Canvas style={{ flex: 1 }} mode="continuous" onTouch={onTouch}>
       <Group transform={transform}>

--- a/example/src/Examples/Neumorphism/Dashboard/components/Control.tsx
+++ b/example/src/Examples/Neumorphism/Dashboard/components/Control.tsx
@@ -22,7 +22,7 @@ interface ControlProps {
   label: string;
   children: ReactNode;
   active?: boolean;
-  font: SkFont;
+  font: SkFont | null;
 }
 
 export const Control = ({
@@ -34,6 +34,9 @@ export const Control = ({
   progress,
   active = false,
 }: ControlProps) => {
+  if (font === null) {
+    return null;
+  }
   const labelWidth = font.getTextWidth(label);
   return (
     <Group transform={translate({ x: x + 30, y: y + 30 })}>

--- a/example/src/Examples/Neumorphism/Dashboard/components/Mode.tsx
+++ b/example/src/Examples/Neumorphism/Dashboard/components/Mode.tsx
@@ -24,9 +24,7 @@ export const Mode = ({ translateY }: ModeProps) => {
     [translateY]
   );
   const image = useImage(require("./settings.png"));
-  if (!image) {
-    return null;
-  }
+
   return (
     <Group transform={transform}>
       <BackdropBlur blur={40 / 3} clip={clip}>

--- a/example/src/Examples/Neumorphism/Dashboard/components/ProgressBar.tsx
+++ b/example/src/Examples/Neumorphism/Dashboard/components/ProgressBar.tsx
@@ -38,9 +38,7 @@ export const ProgressBar = ({ progress }: ProgressBarProps) => {
     () => `${Math.round(progress.current * 100)}°C`,
     [progress]
   );
-  if (font === null) {
-    return null;
-  }
+
   const textWidth = font.getTextWidth("00°C");
   return (
     <Group transform={translate({ x: 100, y: 223 })}>

--- a/example/src/Examples/Neumorphism/Dashboard/components/ProgressBar.tsx
+++ b/example/src/Examples/Neumorphism/Dashboard/components/ProgressBar.tsx
@@ -38,7 +38,9 @@ export const ProgressBar = ({ progress }: ProgressBarProps) => {
     () => `${Math.round(progress.current * 100)}°C`,
     [progress]
   );
-
+  if (font === null) {
+    return null;
+  }
   const textWidth = font.getTextWidth("00°C");
   return (
     <Group transform={translate({ x: 100, y: 223 })}>

--- a/example/src/Examples/Neumorphism/Dashboard/components/Title.tsx
+++ b/example/src/Examples/Neumorphism/Dashboard/components/Title.tsx
@@ -11,10 +11,7 @@ interface Title {
 
 export const Title = ({ title }: Title) => {
   const font = useFont(require("./SF-Pro-Display-Bold.otf"), 28);
-  if (!font) {
-    return null;
-  }
-  const titleWidth = font.getTextWidth(title);
+  const titleWidth = font?.getTextWidth(title) ?? 0;
   const offsetX = 30 + BUTTON_SIZE;
   const space = 298 - offsetX;
   return (
@@ -25,7 +22,7 @@ export const Title = ({ title }: Title) => {
       <Text
         text={title}
         x={offsetX + (space - titleWidth) / 2}
-        y={BUTTON_SIZE - font.getSize()}
+        y={BUTTON_SIZE - (font?.getSize() ?? 0)}
         font={font}
         color="white"
       />

--- a/example/src/Examples/Performance/PerformanceCanvases.tsx
+++ b/example/src/Examples/Performance/PerformanceCanvases.tsx
@@ -29,9 +29,6 @@ export const PerformanceDrawingTest: React.FC = () => {
     return () => clearTimeout(to);
   }, []);
 
-  if (image === null) {
-    return null;
-  }
   return (
     <View style={styles.container}>
       <View style={styles.mode}>

--- a/example/src/Examples/Vertices/Vertices.tsx
+++ b/example/src/Examples/Vertices/Vertices.tsx
@@ -6,7 +6,6 @@ import {
   vec,
   useComputedValue,
   Vertices,
-  useImage,
   Skia,
   isEdge,
 } from "@shopify/react-native-skia";
@@ -49,7 +48,6 @@ export const Demo = () => {
     [indices]
   );
 
-  const oslo = useImage(require("../../assets/oslo.jpg"));
   const clock = useClockValue();
 
   const vertices = useComputedValue(

--- a/example/src/Examples/Vertices/Vertices.tsx
+++ b/example/src/Examples/Vertices/Vertices.tsx
@@ -66,9 +66,7 @@ export const Demo = () => {
       }),
     [clock]
   );
-  if (!oslo) {
-    return null;
-  }
+
   return (
     <Canvas style={{ width, height }}>
       <Vertices

--- a/example/src/Examples/Wallet/components/Label.tsx
+++ b/example/src/Examples/Wallet/components/Label.tsx
@@ -52,10 +52,8 @@ export const Label = ({ state, y, graphs, width, height }: LabelProps) => {
     const titleWidth = titleFont.getTextWidth(title);
     return width / 2 - titleWidth / 2;
   }, [state, titleFont]);
-  if (!titleFont || !subtitleFont) {
-    return null;
-  }
-  const subtitleWidth = subtitleFont.getTextWidth(subtitle);
+
+  const subtitleWidth = subtitleFont?.getTextWidth(subtitle) ?? 0;
   return (
     <>
       <Text

--- a/package/cpp/rnskia/dom/base/NodePropsContainer.h
+++ b/package/cpp/rnskia/dom/base/NodePropsContainer.h
@@ -54,7 +54,7 @@ public:
   void updatePendingValues() {
     for (auto &prop : _properties) {
       prop->updatePendingChanges();
-      if (!prop->isSet() && prop->isRequired()) {
+      if (prop->isRequired() && !prop->isSet()) {
         throw std::runtime_error("Missing one or more required properties " +
                                  std::string(prop->getName()) + " in the " +
                                  _type + " component.");

--- a/package/cpp/rnskia/dom/nodes/JsiGlyphsNode.h
+++ b/package/cpp/rnskia/dom/nodes/JsiGlyphsNode.h
@@ -20,12 +20,14 @@ protected:
     auto x = _xProp->value().getAsNumber();
     auto y = _yProp->value().getAsNumber();
     auto font = _fontProp->getDerivedValue();
-    auto glyphInfo = _glyphsProp->getDerivedValue();
+    if (font != nullptr) {
+      auto glyphInfo = _glyphsProp->getDerivedValue();
 
-    context->getCanvas()->drawGlyphs(
-        static_cast<int>(glyphInfo->glyphIds.size()),
-        glyphInfo->glyphIds.data(), glyphInfo->positions.data(),
-        SkPoint::Make(x, y), *font, *context->getPaint());
+      context->getCanvas()->drawGlyphs(
+          static_cast<int>(glyphInfo->glyphIds.size()),
+          glyphInfo->glyphIds.data(), glyphInfo->positions.data(),
+          SkPoint::Make(x, y), *font, *context->getPaint());
+    }
   }
 
   void defineProperties(NodePropsContainer *container) override {
@@ -36,7 +38,6 @@ protected:
     _xProp = container->defineProperty<NodeProp>("x");
     _yProp = container->defineProperty<NodeProp>("y");
 
-    _fontProp->require();
     _glyphsProp->require();
     _xProp->require();
     _yProp->require();

--- a/package/cpp/rnskia/dom/nodes/JsiImageNode.h
+++ b/package/cpp/rnskia/dom/nodes/JsiImageNode.h
@@ -16,16 +16,19 @@ public:
 protected:
   void draw(DrawingContext *context) override {
     auto rects = _imageProps->getDerivedValue();
+    auto image = _imageProps->getImage();
+    if (image == nullptr) {
+      return;
+    }
 
     context->getCanvas()->drawImageRect(
-        _imageProps->getImage(), rects->src, rects->dst, SkSamplingOptions(),
+        image, rects->src, rects->dst, SkSamplingOptions(),
         context->getPaint().get(), SkCanvas::kStrict_SrcRectConstraint);
   }
 
   void defineProperties(NodePropsContainer *container) override {
     JsiDomDrawingNode::defineProperties(container);
     _imageProps = container->defineProperty<ImageProps>();
-    _imageProps->require();
   }
 
 private:

--- a/package/cpp/rnskia/dom/nodes/JsiImageSvgNode.h
+++ b/package/cpp/rnskia/dom/nodes/JsiImageSvgNode.h
@@ -17,21 +17,21 @@ public:
 protected:
   void draw(DrawingContext *context) override {
     auto svgDom = _svgDomProp->getDerivedValue();
-    auto rect = _rectProp->getDerivedValue();
+    if (svgDom != nullptr) {
+      auto rect = _rectProp->getDerivedValue();
 
-    context->getCanvas()->save();
-    context->getCanvas()->translate(rect->x(), rect->y());
-    svgDom->setContainerSize(SkSize::Make(rect->width(), rect->height()));
-    svgDom->render(context->getCanvas());
-    context->getCanvas()->restore();
+      context->getCanvas()->save();
+      context->getCanvas()->translate(rect->x(), rect->y());
+      svgDom->setContainerSize(SkSize::Make(rect->width(), rect->height()));
+      svgDom->render(context->getCanvas());
+      context->getCanvas()->restore();
+    }
   }
 
   void defineProperties(NodePropsContainer *container) override {
     JsiDomDrawingNode::defineProperties(container);
     _svgDomProp = container->defineProperty<SvgProp>("svg");
     _rectProp = container->defineProperty<RectProps>("rect");
-
-    _svgDomProp->require();
   }
 
 private:

--- a/package/cpp/rnskia/dom/nodes/JsiShaderNodes.h
+++ b/package/cpp/rnskia/dom/nodes/JsiShaderNodes.h
@@ -91,6 +91,10 @@ public:
   void decorate(DeclarationContext *context) override {
 
     auto image = _imageProps->getImage();
+    if (image == nullptr) {
+      return;
+    }
+
     auto rect = _imageProps->getRect();
     auto lm =
         _transformProp->isSet() ? _transformProp->getDerivedValue() : nullptr;
@@ -144,7 +148,7 @@ protected:
     _transformProp->require();
 
     // Add and require the image
-    container->defineProperty<NodeProp>("image")->require();
+    container->defineProperty<NodeProp>("image");
   }
 
 private:

--- a/package/cpp/rnskia/dom/nodes/JsiShaderNodes.h
+++ b/package/cpp/rnskia/dom/nodes/JsiShaderNodes.h
@@ -102,7 +102,7 @@ public:
     if (rect != nullptr && lm != nullptr) {
       auto rc = _imageProps->getDerivedValue();
       auto m3 = _imageProps->rect2rect(rc->src, rc->dst);
-      if (_transformProp->isChanged()) {
+      if (_transformProp->isChanged() || _imageProps->isChanged()) {
         // To modify the matrix we need to copy it since we're not allowed to
         // modify values contained in properties - this would have caused the
         // matrix to be translated and scaled more and more for each render

--- a/package/cpp/rnskia/dom/nodes/JsiTextNode.h
+++ b/package/cpp/rnskia/dom/nodes/JsiTextNode.h
@@ -21,9 +21,11 @@ protected:
     auto y = _yProp->value().getAsNumber();
     auto font = _fontProp->getDerivedValue();
 
-    context->getCanvas()->drawSimpleText(text, strlen(text),
-                                         SkTextEncoding::kUTF8, x, y, *font,
-                                         *context->getPaint());
+    if (font != nullptr) {
+      context->getCanvas()->drawSimpleText(text, strlen(text),
+                                           SkTextEncoding::kUTF8, x, y, *font,
+                                           *context->getPaint());
+    }
   }
 
   void defineProperties(NodePropsContainer *container) override {
@@ -34,7 +36,6 @@ protected:
     _xProp = container->defineProperty<NodeProp>("x");
     _yProp = container->defineProperty<NodeProp>("y");
 
-    _fontProp->require();
     _textProp->require();
     _xProp->require();
     _yProp->require();

--- a/package/cpp/rnskia/dom/nodes/JsiTextPathNode.h
+++ b/package/cpp/rnskia/dom/nodes/JsiTextPathNode.h
@@ -16,7 +16,9 @@ public:
 protected:
   void draw(DrawingContext *context) override {
     auto blob = _textBlobProp->getDerivedValue();
-    context->getCanvas()->drawTextBlob(blob, 0, 0, *context->getPaint());
+    if (blob != nullptr) {
+      context->getCanvas()->drawTextBlob(blob, 0, 0, *context->getPaint());
+    }
   }
 
   void defineProperties(NodePropsContainer *container) override {

--- a/package/cpp/rnskia/dom/props/FontProp.h
+++ b/package/cpp/rnskia/dom/props/FontProp.h
@@ -17,17 +17,22 @@ public:
   }
 
   void updateDerivedValue() override {
-    if (!_fontProp->isSet() ||
-        _fontProp->value().getType() != PropType::HostObject) {
-      throw std::runtime_error("Expected SkFont object for the Font property.");
-    }
+    if (_fontProp->isSet()) {
+      if (_fontProp->value().getType() == PropType::HostObject) {
+        auto ptr = _fontProp->value().getAs<JsiSkFont>();
+        if (ptr == nullptr) {
+          throw std::runtime_error(
+              "Expected SkFont object for the Font property.");
+        }
+        setDerivedValue(ptr->getObject());
 
-    auto ptr = _fontProp->value().getAs<JsiSkFont>();
-    if (ptr == nullptr) {
-      throw std::runtime_error("Expected SkFont object for the Font property.");
+      } else {
+        throw std::runtime_error(
+            "Expected SkFont object or null/undefined for the Font property.");
+      }
+    } else {
+      setDerivedValue(nullptr);
     }
-
-    setDerivedValue(ptr->getObject());
   }
 
 private:

--- a/package/cpp/rnskia/dom/props/ImageProps.h
+++ b/package/cpp/rnskia/dom/props/ImageProps.h
@@ -76,6 +76,7 @@ public:
   void updateDerivedValue() override {
     auto image = _imageProp->getDerivedValue();
     if (image == nullptr) {
+      setDerivedValue(nullptr);
       return;
     }
 

--- a/package/cpp/rnskia/dom/props/ImageProps.h
+++ b/package/cpp/rnskia/dom/props/ImageProps.h
@@ -32,20 +32,32 @@ public:
   }
 
   void updateDerivedValue() override {
-    if (!_imageProp->isSet() ||
-        _imageProp->value().getType() != PropType::HostObject) {
-      throw std::runtime_error("Expected SkImage object for the " +
-                               std::string(getName()) + " property.");
+    if (_imageProp->isSet()) {
+      // Check for host object
+      if (_imageProp->value().getType() == PropType::HostObject) {
+        // This should be an SkImage wrapper:
+        auto ptr = std::dynamic_pointer_cast<JsiSkImage>(
+            _imageProp->value().getAsHostObject());
+        if (ptr == nullptr) {
+          // If not - throw an exception
+          throw std::runtime_error("Expected SkImage object for the " +
+                                   std::string(getName()) +
+                                   " property. Got a " +
+                                   _imageProp->value().getTypeAsString(
+                                       _imageProp->value().getType()) +
+                                   ".");
+        }
+        setDerivedValue(ptr->getObject());
+      } else {
+        // Should be a host object if set
+        throw std::runtime_error(
+            "Expected SkImage object or null/undefined for the " +
+            std::string(getName()) + " property.");
+      }
+    } else {
+      // Set to null
+      setDerivedValue(nullptr);
     }
-
-    auto ptr = std::dynamic_pointer_cast<JsiSkImage>(
-        _imageProp->value().getAsHostObject());
-    if (ptr == nullptr) {
-      throw std::runtime_error("Expected SkImage object for the " +
-                               std::string(getName()) + " property.");
-    }
-
-    setDerivedValue(ptr->getObject());
   }
 
 private:
@@ -62,11 +74,11 @@ public:
   }
 
   void updateDerivedValue() override {
-    if (!_imageProp->isSet()) {
-      throw std::runtime_error("Image property is not set on the Image node.");
+    auto image = _imageProp->getDerivedValue();
+    if (image == nullptr) {
+      return;
     }
 
-    auto image = _imageProp->getDerivedValue();
     auto imageRect = SkRect::MakeXYWH(0, 0, image->width(), image->height());
 
     auto rect = _rectProp->getDerivedValue() ? *_rectProp->getDerivedValue()
@@ -77,6 +89,7 @@ public:
   }
 
   sk_sp<SkImage> getImage() { return _imageProp->getDerivedValue(); }
+
   std::shared_ptr<const SkRect> getRect() {
     return _rectProp->getDerivedValue();
   }

--- a/package/cpp/rnskia/dom/props/SvgProp.h
+++ b/package/cpp/rnskia/dom/props/SvgProp.h
@@ -17,19 +17,25 @@ public:
   }
 
   void updateDerivedValue() override {
-    if (_imageSvgProp->value().getType() != PropType::HostObject) {
-      throw std::runtime_error(
-          "Expected SkSvgDom object for the svg property.");
-    }
+    if (_imageSvgProp->isSet()) {
 
-    auto ptr = std::dynamic_pointer_cast<JsiSkSVG>(
-        _imageSvgProp->value().getAsHostObject());
-    if (ptr == nullptr) {
-      throw std::runtime_error(
-          "Expected SkSvgDom object for the svg property.");
-    }
+      if (_imageSvgProp->value().getType() == PropType::HostObject) {
 
-    setDerivedValue(ptr->getObject());
+        auto ptr = std::dynamic_pointer_cast<JsiSkSVG>(
+            _imageSvgProp->value().getAsHostObject());
+        if (ptr == nullptr) {
+          throw std::runtime_error(
+              "Expected SkSvgDom object for the svg property.");
+        }
+        setDerivedValue(ptr->getObject());
+      } else {
+        throw std::runtime_error(
+            "Expected SkSvgDom object or null/undefined for the svg property.");
+      }
+
+    } else {
+      setDerivedValue(nullptr);
+    }
   }
 
 private:

--- a/package/cpp/rnskia/dom/props/TextBlobProp.h
+++ b/package/cpp/rnskia/dom/props/TextBlobProp.h
@@ -46,7 +46,6 @@ public:
     _pathProp = defineProperty<PathProp>("path");
     _offsetProp = defineProperty<NodeProp>("initialOffset");
 
-    _fontProp->require();
     _textProp->require();
     _pathProp->require();
     _offsetProp->require();
@@ -58,66 +57,70 @@ public:
     auto path = _pathProp->getDerivedValue();
     auto offset = _offsetProp->value().getAsNumber();
 
-    // Get glyphs
-    auto numGlyphIds =
-        font->countText(text.c_str(), text.length(), SkTextEncoding::kUTF8);
+    if (font != nullptr) {
+      // Get glyphs
+      auto numGlyphIds =
+          font->countText(text.c_str(), text.length(), SkTextEncoding::kUTF8);
 
-    std::vector<SkGlyphID> glyphIds;
-    glyphIds.reserve(numGlyphIds);
-    auto ids = font->textToGlyphs(
-        text.c_str(), text.length(), SkTextEncoding::kUTF8,
-        static_cast<SkGlyphID *>(glyphIds.data()), numGlyphIds);
+      std::vector<SkGlyphID> glyphIds;
+      glyphIds.reserve(numGlyphIds);
+      auto ids = font->textToGlyphs(
+          text.c_str(), text.length(), SkTextEncoding::kUTF8,
+          static_cast<SkGlyphID *>(glyphIds.data()), numGlyphIds);
 
-    // Get glyph widths
-    int glyphsSize = static_cast<int>(ids);
-    std::vector<SkScalar> widthPtrs;
-    widthPtrs.resize(glyphsSize);
-    font->getWidthsBounds(glyphIds.data(), numGlyphIds,
-                          static_cast<SkScalar *>(widthPtrs.data()), nullptr,
-                          nullptr); // TODO: Should we use paint somehow here?
+      // Get glyph widths
+      int glyphsSize = static_cast<int>(ids);
+      std::vector<SkScalar> widthPtrs;
+      widthPtrs.resize(glyphsSize);
+      font->getWidthsBounds(glyphIds.data(), numGlyphIds,
+                            static_cast<SkScalar *>(widthPtrs.data()), nullptr,
+                            nullptr); // TODO: Should we use paint somehow here?
 
-    std::vector<SkRSXform> rsx;
-    SkContourMeasureIter meas(*path, false, 1);
+      std::vector<SkRSXform> rsx;
+      SkContourMeasureIter meas(*path, false, 1);
 
-    auto cont = meas.next();
-    auto dist = offset;
+      auto cont = meas.next();
+      auto dist = offset;
 
-    for (size_t i = 0; i < text.length() && cont != nullptr; ++i) {
-      auto width = widthPtrs[i];
-      dist += width / 2;
-      if (dist > cont->length()) {
-        // jump to next contour
-        cont = meas.next();
-        if (cont == nullptr) {
-          // We have come to the end of the path - terminate the string
-          // right here.
-          text = text.substr(0, i);
-          break;
+      for (size_t i = 0; i < text.length() && cont != nullptr; ++i) {
+        auto width = widthPtrs[i];
+        dist += width / 2;
+        if (dist > cont->length()) {
+          // jump to next contour
+          cont = meas.next();
+          if (cont == nullptr) {
+            // We have come to the end of the path - terminate the string
+            // right here.
+            text = text.substr(0, i);
+            break;
+          }
+          dist = width / 2;
         }
-        dist = width / 2;
-      }
-      // Gives us the (x, y) coordinates as well as the cos/sin of the tangent
-      // line at that position.
-      SkPoint pos;
-      SkVector tan;
-      if (!cont->getPosTan(dist, &pos, &tan)) {
-        throw std::runtime_error(
-            "Could not calculate distance when resolving text path");
-      }
-      auto px = pos.x();
-      auto py = pos.y();
-      auto tx = tan.x();
-      auto ty = tan.y();
+        // Gives us the (x, y) coordinates as well as the cos/sin of the tangent
+        // line at that position.
+        SkPoint pos;
+        SkVector tan;
+        if (!cont->getPosTan(dist, &pos, &tan)) {
+          throw std::runtime_error(
+              "Could not calculate distance when resolving text path");
+        }
+        auto px = pos.x();
+        auto py = pos.y();
+        auto tx = tan.x();
+        auto ty = tan.y();
 
-      auto adjustedX = px - (width / 2) * tx;
-      auto adjustedY = py - (width / 2) * ty;
+        auto adjustedX = px - (width / 2) * tx;
+        auto adjustedY = py - (width / 2) * ty;
 
-      rsx.push_back(SkRSXform::Make(tx, ty, adjustedX, adjustedY));
-      dist += width / 2;
+        rsx.push_back(SkRSXform::Make(tx, ty, adjustedX, adjustedY));
+        dist += width / 2;
+      }
+
+      setDerivedValue(SkTextBlob::MakeFromRSXform(text.c_str(), text.length(),
+                                                  rsx.data(), *font));
+    } else {
+      setDerivedValue(nullptr);
     }
-
-    setDerivedValue(SkTextBlob::MakeFromRSXform(text.c_str(), text.length(),
-                                                rsx.data(), *font));
   }
 
 private:

--- a/package/src/dom/nodes/drawings/ImageNode.ts
+++ b/package/src/dom/nodes/drawings/ImageNode.ts
@@ -15,6 +15,12 @@ export class ImageNode extends JsiDrawingNode<
 
   deriveProps() {
     const { image } = this.props;
+    if (!image) {
+      return {
+        src: { x: 0, y: 0, width: 0, height: 0 },
+        dst: { x: 0, y: 0, width: 0, height: 0 },
+      };
+    }
     const fit = this.props.fit ?? "contain";
     const rect = processRect(this.Skia, this.props);
     const { src, dst } = fitRects(
@@ -36,6 +42,8 @@ export class ImageNode extends JsiDrawingNode<
       throw new Error("ImageNode: src and dst are undefined");
     }
     const { src, dst } = this.derived;
-    canvas.drawImageRect(image, src, dst, paint);
+    if (image) {
+      canvas.drawImageRect(image, src, dst, paint);
+    }
   }
 }

--- a/package/src/dom/nodes/drawings/ImageSVG.ts
+++ b/package/src/dom/nodes/drawings/ImageSVG.ts
@@ -15,7 +15,9 @@ export class ImageSVGNode extends JsiDrawingNode<ImageSVGProps, null> {
 
   draw({ canvas }: DrawingContext) {
     const { svg } = this.props;
-    if (!svg) return;
+    if (!svg) {
+      return;
+    }
     const { x, y, width, height } = processRect(this.Skia, this.props);
     canvas.save();
     canvas.translate(x, y);

--- a/package/src/dom/nodes/drawings/ImageSVG.ts
+++ b/package/src/dom/nodes/drawings/ImageSVG.ts
@@ -15,6 +15,7 @@ export class ImageSVGNode extends JsiDrawingNode<ImageSVGProps, null> {
 
   draw({ canvas }: DrawingContext) {
     const { svg } = this.props;
+    if (!svg) return;
     const { x, y, width, height } = processRect(this.Skia, this.props);
     canvas.save();
     canvas.translate(x, y);

--- a/package/src/dom/nodes/drawings/Text.ts
+++ b/package/src/dom/nodes/drawings/Text.ts
@@ -22,11 +22,16 @@ export class TextNode extends JsiDrawingNode<TextProps, null> {
 
   draw({ canvas, paint }: DrawingContext) {
     const { text, x, y, font } = this.props;
-    canvas.drawText(text, x, y, paint, font);
+    if (font) {
+      canvas.drawText(text, x, y, paint, font);
+    }
   }
 }
 
-export class TextPathNode extends JsiDrawingNode<TextPathProps, SkTextBlob> {
+export class TextPathNode extends JsiDrawingNode<
+  TextPathProps,
+  SkTextBlob | null
+> {
   constructor(ctx: NodeContext, props: TextPathProps) {
     super(ctx, NodeType.TextPath, props);
   }
@@ -34,6 +39,9 @@ export class TextPathNode extends JsiDrawingNode<TextPathProps, SkTextBlob> {
   deriveProps() {
     const path = processPath(this.Skia, this.props.path);
     const { font, initialOffset } = this.props;
+    if (!font) {
+      return null;
+    }
     let { text } = this.props;
     const ids = font.getGlyphIDs(text);
     const widths = font.getGlyphWidths(ids);
@@ -117,6 +125,8 @@ export class GlyphsNode extends JsiDrawingNode<GlyphsProps, ProcessedGlyphs> {
     }
     const { glyphs, positions } = this.derived;
     const { x, y, font } = this.props;
-    canvas.drawGlyphs(glyphs, positions, x, y, font, paint);
+    if (font) {
+      canvas.drawGlyphs(glyphs, positions, x, y, font, paint);
+    }
   }
 }

--- a/package/src/dom/nodes/paint/Shaders.ts
+++ b/package/src/dom/nodes/paint/Shaders.ts
@@ -60,6 +60,10 @@ export class ImageShaderNode extends ShaderDeclaration<ImageShaderProps> {
 
   decorate(ctx: DeclarationContext) {
     const { fit, image, tx, ty, fm, mm, ...imageShaderProps } = this.props;
+    if (!image) {
+      return;
+    }
+
     const rct = getRect(this.Skia, imageShaderProps);
     const m3 = this.Skia.Matrix();
     if (rct) {

--- a/package/src/dom/types/Drawings.ts
+++ b/package/src/dom/types/Drawings.ts
@@ -109,14 +109,14 @@ export interface DiffRectProps extends DrawingNodeProps {
 }
 
 export interface TextProps extends DrawingNodeProps {
-  font: SkFont;
+  font: SkFont | null;
   text: string;
   x: number;
   y: number;
 }
 
 export interface TextPathProps extends DrawingNodeProps {
-  font: SkFont;
+  font: SkFont | null;
   text: string;
   path: PathDef;
   initialOffset: number;
@@ -134,7 +134,7 @@ export interface Glyph {
 }
 
 export interface GlyphsProps extends DrawingNodeProps {
-  font: SkFont;
+  font: SkFont | null;
   x: number;
   y: number;
   glyphs: Glyph[];

--- a/package/src/dom/types/Drawings.ts
+++ b/package/src/dom/types/Drawings.ts
@@ -35,7 +35,7 @@ export interface DrawingNodeProps extends GroupProps {
 export type ImageProps = DrawingNodeProps &
   RectDef & {
     fit?: Fit;
-    image: SkImage;
+    image: SkImage | null;
   };
 
 export type CircleProps = CircleDef & DrawingNodeProps;

--- a/package/src/dom/types/Drawings.ts
+++ b/package/src/dom/types/Drawings.ts
@@ -91,7 +91,7 @@ export interface VerticesProps extends DrawingNodeProps {
 }
 
 export type ImageSVGProps = RectDef & {
-  svg: SkSVG;
+  svg: SkSVG | null;
 } & DrawingNodeProps;
 
 export interface PictureProps extends DrawingNodeProps {

--- a/package/src/dom/types/Shaders.ts
+++ b/package/src/dom/types/Shaders.ts
@@ -30,7 +30,7 @@ export interface ImageShaderProps extends TransformProps, Partial<RectCtor> {
   mm: SkEnum<typeof MipmapMode>;
   fit: Fit;
   rect?: SkRect;
-  image: SkImage;
+  image: SkImage | null;
 }
 
 export interface ColorProps {


### PR DESCRIPTION
Added support for accepting null as value for `image`, `font` and `svg` properties.

This makes it possible to use a Skia Value as the property for the above types, and also helps developers using `useFont`, `useImage` and `useSvg` so that they don't need to null check their code all the time.

- Updated types
- Updated native implementation to support null values
- Updated ts / web implementation
- Updated documentation
- Updated examples

fixes #1524 