### PR TITLE
fix: Move `dispatchMainThread` and `takeViewScreenshot` arguments to `RNSkiOSPlatformContext`

### DIFF
--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #import <React/RCTBridge.h>
+#import <React/RCTBridge+Private.h>
 
 #include <functional>
 #include <memory>

--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
@@ -63,11 +63,13 @@ sk_sp<SkSurface> RNSkiOSPlatformContext::makeOffscreenSurface(int width,
 }
 
 void RNSkiOSPlatformContext::runOnMainThread(std::function<void()> func) {
-  _dispatchMainThread(func);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    func();
+  });
 }
 
 sk_sp<SkImage> RNSkiOSPlatformContext::takeScreenshotFromViewTag(size_t tag) {
-  return _takeViewScreenshot(tag);
+  return [_screenshotService screenshotOfViewWithTag:[NSNumber numberWithLong:viewTag]];
 }
 
 void RNSkiOSPlatformContext::startDrawLoop() {

--- a/package/ios/RNSkia-iOS/SkiaManager.mm
+++ b/package/ios/RNSkia-iOS/SkiaManager.mm
@@ -9,12 +9,10 @@
 #import <ReactCommon/RCTTurboModule.h>
 
 #import "RNSkiOSPlatformContext.h"
-#import "ViewScreenshotService.h"
 
 @implementation SkiaManager {
   std::shared_ptr<RNSkia::RNSkManager> _skManager;
   std::shared_ptr<RNSkia::RNSkiOSPlatformContext> _platformContext;
-  ViewScreenshotService *_screenshot;
   __weak RCTBridge *weakBridge;
 }
 
@@ -36,32 +34,16 @@
     RCTCxxBridge *cxxBridge = (RCTCxxBridge *)bridge;
     if (cxxBridge.runtime) {
 
-      auto callInvoker = bridge.jsCallInvoker;
       facebook::jsi::Runtime *jsRuntime =
           (facebook::jsi::Runtime *)cxxBridge.runtime;
 
-      // Create screenshot manager
-      _screenshot =
-          [[ViewScreenshotService alloc] initWithUiManager:bridge.uiManager];
-
-      auto takeScreenshot = [self](size_t viewTag) {
-        return [_screenshot
-            screenshotOfViewWithTag:[NSNumber numberWithLong:viewTag]];
-      };
-
-      auto dispatchOnMainThread = [self](std::function<void()> fp) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-          fp();
-        });
-      };
-
       // Create platform context
       _platformContext = std::make_shared<RNSkia::RNSkiOSPlatformContext>(
-          jsRuntime, callInvoker, std::move(dispatchOnMainThread),
-          std::move(takeScreenshot));
+          jsRuntime, bridge);
 
       // Create the RNSkiaManager (cross platform)
-      _skManager = std::make_shared<RNSkia::RNSkManager>(jsRuntime, callInvoker,
+      _skManager = std::make_shared<RNSkia::RNSkManager>(jsRuntime,
+                                                         bridge.callInvoker,
                                                          _platformContext);
     }
   }


### PR DESCRIPTION
* Moves the two platform specific functions to the `RNSkiOSPlatformContext` class to make it more encapsulated
* Changes one argument from `callInvoker` to `bridge`