### PR TITLE
chore: android prefab flatten cpp files

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -272,11 +272,18 @@ task extractJNIFiles {
 extractJNIFiles.mustRunAfter extractAARHeaders
 
 if (ENABLE_PREFAB) {
-    // Package everything with the original file structure
+    // Package all the cpp code in a flattened directory structure
     task prepareHeaders(type: Copy) {
         from('./cpp')
         into "${project.buildDir}/headers/rnskia/"
         includeEmptyDirs = false
+        include '**/*'
+        eachFile {
+            // flatten the directory structure
+            String path = it.path
+            path = path.substring(path.lastIndexOf('/') + 1)
+            it.path = path
+        }
     }
     preBuild.dependsOn(prepareHeaders)
 }

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -277,7 +277,7 @@ if (ENABLE_PREFAB) {
         from('./cpp')
         into "${project.buildDir}/headers/rnskia/"
         includeEmptyDirs = false
-        include '**/*'
+        include '**/*.h'
         eachFile {
             // flatten the directory structure
             String path = it.path

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -274,14 +274,20 @@ extractJNIFiles.mustRunAfter extractAARHeaders
 if (ENABLE_PREFAB) {
     // Package all the cpp code in a flattened directory structure
     task prepareHeaders(type: Copy) {
-        from('./cpp')
+        from("./cpp")
         into "${project.buildDir}/headers/rnskia/"
         includeEmptyDirs = false
-        include '**/*.h'
+        include "**/*.h"
         eachFile {
-            // flatten the directory structure
             String path = it.path
-            path = path.substring(path.lastIndexOf('/') + 1)
+
+            // Skip flattening third_party dir
+            if (path.contains("api/third_party")) {
+                path = path.substring("api/".length())
+            } else {
+                // flatten anything else
+                path = path.substring(path.lastIndexOf("/") + 1)
+            }
             it.path = path
         }
     }


### PR DESCRIPTION
# Problem 

In the cpp files of RNSkia no relative paths are used in the #include directives.
So for example:

```cpp
#include "include/core/SkImage.h"
```

just becomes:

```cpp
#include "SkImage.h"
```

Right now the android package is configured to package all cpp (header) files with the original directory structure, so the structure becomes

```
build/
  headers/
    rnskia/
      api/
      jni/
      jsi/
      rnskia/
      skia/
...
```

When trying to use skia's code in your own library you will run into issues. For example if you try to include:

```
#include "rnskia/RNSkView.h"
```

it will fail during compiling, as in `RNSkView.h` it tries to include:

```
#include "SkCanvas.h"
```

which it can't resolve, as it is stored right now in `skia/includes/core/SkCanvas.h`

# Solution

We simply need to flatten the cpp files for the prefab package. Actually the same happens on iOS and it's working there.

## Other solutions

Another solution could be for library developers to include all relative paths in their CMake but I figure it would be cleaner if it would work the same on iOS and android.
  