### PR TITLE
Added locking to mapped properties to fix threading issue with Rea

### DIFF
--- a/package/cpp/rnskia/dom/base/JsiDomNode.h
+++ b/package/cpp/rnskia/dom/base/JsiDomNode.h
@@ -98,13 +98,12 @@ public:
     auto propName = arguments[0].asString(runtime).utf8(runtime);
     const jsi::Value &propValue = arguments[1];
 
-    auto mappedProps = _propsContainer->getMappedProperties();
-    auto propMapIt = mappedProps.find(JsiPropId::get(propName));
-    if (propMapIt != mappedProps.end()) {
-      for (auto &prop : propMapIt->second) {
-        prop->updateValue(runtime, propValue);
-      }
-    }
+    // Enumerate all props with this name and update. The
+    // enumerateMappedPropsByName function is thread safe and locks props so it
+    // can be called from all threads.
+    _propsContainer->enumerateMappedPropsByName(propName, [&](NodeProp *prop) {
+      prop->updateValue(runtime, propValue);
+    });
 
     return jsi::Value::undefined();
   }

--- a/package/cpp/rnskia/dom/base/NodePropsContainer.h
+++ b/package/cpp/rnskia/dom/base/NodePropsContainer.h
@@ -41,10 +41,30 @@ public:
   }
 
   /**
-   Returns a list of mappings betwen property names and property objects
+   Enumerate all mapped properties
    */
-  const std::map<PropId, std::vector<NodeProp *>> &getMappedProperties() {
-    return _mappedProperties;
+  void enumerateMappedProps(
+      const std::function<void(const PropId name,
+                               const std::vector<NodeProp *>)> &callback) {
+    std::lock_guard<std::mutex> lock(_mappedPropsLock);
+    for (auto &props : _mappedProperties) {
+      callback(props.first, props.second);
+    }
+  }
+
+  /**
+   Enumerates a named property instances from the mapped properties list
+   */
+  void
+  enumerateMappedPropsByName(const std::string &name,
+                             const std::function<void(NodeProp *)> &callback) {
+    std::lock_guard<std::mutex> lock(_mappedPropsLock);
+    auto propMapIt = _mappedProperties.find(JsiPropId::get(name));
+    if (propMapIt != _mappedProperties.end()) {
+      for (auto &prop : propMapIt->second) {
+        callback(prop);
+      }
+    }
   }
 
   /**
@@ -75,6 +95,7 @@ public:
    Clears all props and data from the container
    */
   void dispose() {
+    std::lock_guard<std::mutex> lock(_mappedPropsLock);
     _properties.clear();
     _mappedProperties.clear();
   }
@@ -83,6 +104,8 @@ public:
    Called when the React / JS side sets properties on a node
    */
   void setProps(jsi::Runtime &runtime, const jsi::Value &maybePropsObject) {
+    std::lock_guard<std::mutex> lock(_mappedPropsLock);
+
     // Clear property mapping
     _mappedProperties.clear();
 
@@ -129,6 +152,7 @@ private:
   std::vector<std::shared_ptr<BaseNodeProp>> _properties;
   std::map<PropId, std::vector<NodeProp *>> _mappedProperties;
   PropId _type;
+  std::mutex _mappedPropsLock;
 };
 
 } // namespace RNSkia


### PR DESCRIPTION
Reanimated calls setProp on the main thread (worklet) while other props are set on the Javascript thread.

The crash we saw was caused by a race condition where setProps was called from the JS thread clearing the mapped properties vector while in the middle of setProp called from the worklet thread.

This commit fixes this by adding a lock and methods for enumerating properties in a safe way.

Changed 
- JsiDependencyManager.h: Wrapped for loop in call to enumerateMappedProps (diff without whitespace to see)
- JsiDomNode.h: Enumeration of props now happens using the safe enumerateMappedPropsByName method in `setProp`
- NodePropsContainer.h: Added locking to mapped props access (specifically clear and fill) with method `enumerateMappedPropsByName` and `enumerateMappedProps`

I've tested this over a long period of time without seeing crashes that would previously occur rather quick with a lot of AnimatedCircle (see original issue #1517 ).