### PR TITLE
Added fluent api for building matrices

### DIFF
--- a/package/cpp/api/JsiSkMatrix.h
+++ b/package/cpp/api/JsiSkMatrix.h
@@ -47,39 +47,39 @@ public:
   JSI_HOST_FUNCTION(concat) {
     auto m3 = JsiSkMatrix::fromValue(runtime, arguments[0]);
     getObject()->preConcat(*m3);
-    return jsi::Value::undefined();
+    return thisValue.asObject(runtime);
   }
 
   JSI_HOST_FUNCTION(translate) {
     auto x = arguments[0].asNumber();
     auto y = arguments[1].asNumber();
     getObject()->preTranslate(x, y);
-    return jsi::Value::undefined();
+    return thisValue.asObject(runtime);
   }
 
   JSI_HOST_FUNCTION(scale) {
     auto x = arguments[0].asNumber();
     auto y = count > 1 ? arguments[1].asNumber() : 1;
     getObject()->preScale(x, y);
-    return jsi::Value::undefined();
+    return thisValue.asObject(runtime);
   }
 
   JSI_HOST_FUNCTION(skew) {
     auto x = arguments[0].asNumber();
     auto y = arguments[1].asNumber();
     getObject()->preSkew(x, y);
-    return jsi::Value::undefined();
+    return thisValue.asObject(runtime);
   }
 
   JSI_HOST_FUNCTION(rotate) {
     auto a = arguments[0].asNumber();
     getObject()->preRotate(SkRadiansToDegrees(a));
-    return jsi::Value::undefined();
+    return thisValue.asObject(runtime);
   }
 
   JSI_HOST_FUNCTION(identity) {
     getObject()->setIdentity();
-    return jsi::Value::undefined();
+    return thisValue.asObject(runtime);
   }
 
   JSI_HOST_FUNCTION(get) {

--- a/package/src/renderer/__tests__/Transform.spec.tsx
+++ b/package/src/renderer/__tests__/Transform.spec.tsx
@@ -26,9 +26,10 @@ describe("Renderer", () => {
     const size = width;
     const matrix = Skia.Matrix();
     const origin = Skia.Point(size / 2, size / 2);
-    matrix.translate(origin.x, origin.y);
-    matrix.scale(0.5);
-    matrix.translate(-origin.x, -origin.y);
+    matrix
+      .translate(origin.x, origin.y)
+      .scale(0.5)
+      .translate(-origin.x, -origin.y);
     expect(matrix.get()).toStrictEqual([0.5, 0, 192, 0, 0.5, 192, 0, 0, 1]);
     const surface = drawOnNode(
       <Group matrix={matrix}>

--- a/package/src/skia/types/Matrix.ts
+++ b/package/src/skia/types/Matrix.ts
@@ -16,12 +16,12 @@ export const isMatrix = (obj: unknown): obj is SkMatrix =>
   obj !== null && (obj as SkJSIInstance<string>).__typename__ === "Matrix";
 
 export interface SkMatrix extends SkJSIInstance<"Matrix"> {
-  concat: (matrix: SkMatrix) => void;
-  translate: (x: number, y: number) => void;
-  scale: (x: number, y?: number) => void;
-  skew: (x: number, y: number) => void;
-  rotate: (theta: number) => void;
-  identity: () => void;
+  concat: (matrix: SkMatrix) => SkMatrix;
+  translate: (x: number, y: number) => SkMatrix;
+  scale: (x: number, y?: number) => SkMatrix;
+  skew: (x: number, y: number) => SkMatrix;
+  rotate: (theta: number) => SkMatrix;
+  identity: () => SkMatrix;
   get: () => number[];
 }
 

--- a/package/src/skia/web/JsiSkMatrix.ts
+++ b/package/src/skia/web/JsiSkMatrix.ts
@@ -16,6 +16,7 @@ export class JsiSkMatrix
     this.ref.set(
       this.CanvasKit.Matrix.multiply(this.ref, JsiSkMatrix.fromValue(matrix))
     );
+    return this;
   }
 
   translate(x: number, y: number) {
@@ -25,6 +26,7 @@ export class JsiSkMatrix
         Float32Array.of(...this.CanvasKit.Matrix.translated(x, y))
       )
     );
+    return this;
   }
 
   scale(x: number, y?: number) {
@@ -34,6 +36,7 @@ export class JsiSkMatrix
         Float32Array.of(...this.CanvasKit.Matrix.scaled(x, y ?? x))
       )
     );
+    return this;
   }
 
   skew(x: number, y: number) {
@@ -43,6 +46,7 @@ export class JsiSkMatrix
         Float32Array.of(...this.CanvasKit.Matrix.skewed(x, y))
       )
     );
+    return this;
   }
 
   rotate(value: number) {
@@ -52,10 +56,12 @@ export class JsiSkMatrix
         Float32Array.of(...this.CanvasKit.Matrix.rotated(value))
       )
     );
+    return this;
   }
 
   identity() {
     this.ref.set(this.CanvasKit.Matrix.identity());
+    return this;
   }
 
   get() {


### PR DESCRIPTION
Previously we had to write like this when using the SkMatrix class:

```ts
matrix.translate(origin.x, origin.y)
matrix.scale(0.5)
matrix.translate(-origin.x, -origin.y);
```

This commit adds support for writing it in a fluent way:

```ts
matrix.translate(origin.x, origin.y)
  .scale(0.5)
  .translate(-origin.x, -origin.y);
```

This will make it easier to use Matrix objects in declarative interpolations.

The PR implements the above API in native (C++) and on web, and a test that shows that this works.

Memory issues with creating host objects has also been fixed by the JsiSkMatrix c++ class returning its plain javascript object as return value.