### PR TITLE
Fixed issue with snapshots being in wrong colors on iOS

### DIFF
--- a/package/ios/RNSkia-iOS/ViewScreenshotService.mm
+++ b/package/ios/RNSkia-iOS/ViewScreenshotService.mm
@@ -33,6 +33,15 @@
   UIGraphicsImageRendererFormat *format =
       [UIGraphicsImageRendererFormat defaultFormat];
   format.opaque = NO;
+
+  // Explicitly ask for the standard format to get ARGB 32bits and not 64bits.
+  if (@available(iOS 12.0, *)) {
+    format.preferredRange = UIGraphicsImageRendererFormatRangeStandard;
+  } else {
+    // Fallback on earlier versions
+    format.prefersExtendedRange = false;
+  }
+
   UIGraphicsImageRenderer *renderer =
       [[UIGraphicsImageRenderer alloc] initWithSize:size format:format];
 
@@ -68,9 +77,12 @@
       (void *)dataRef);
 
   // Make SkImageInfo
+  // We're using kBGRA_8888_SkColorType since this is what we get when the
+  // UIGraphicsImageRenderer uses the standard format (the extended is using
+  // 64bits so it is not suitable for us).
   SkImageInfo info =
       SkImageInfo::Make(static_cast<int>(width), static_cast<int>(height),
-                        kRGBA_8888_SkColorType, kPremul_SkAlphaType);
+                        kBGRA_8888_SkColorType, kPremul_SkAlphaType);
 
   // ... and then create the SkImage itself!
   return SkImage::MakeRasterData(info, skData, bytesPerRow);


### PR DESCRIPTION
- Added explicit setting that we don't want the extended 64-bits format for our image data
- Added correct color type (ARGB - or BGRA) for the pixel data.

fixes #1558