### PR TITLE
don't load reanimated on web

### DIFF
--- a/package/src/external/reanimated/import.ts
+++ b/package/src/external/reanimated/import.ts
@@ -1,0 +1,17 @@
+export let Reanimated2: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export let Reanimated3: any;
+export let reanimatedVersion: string;
+
+try {
+  Reanimated2 = require("react-native-reanimated");
+  reanimatedVersion =
+    // eslint-disable-next-line import/extensions
+    require("react-native-reanimated/package.json").version;
+  if (
+    reanimatedVersion &&
+    (reanimatedVersion >= "3.0.0" || reanimatedVersion.includes("3.0.0-"))
+  ) {
+    Reanimated3 = Reanimated2;
+  }
+} catch (e) {}

--- a/package/src/external/reanimated/import.web.ts
+++ b/package/src/external/reanimated/import.web.ts
@@ -1,0 +1,6 @@
+// Don't load reanimated on web
+
+export let Reanimated2: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export let Reanimated3: any;
+export let reanimatedVersion: string;

--- a/package/src/external/reanimated/moduleWrapper.ts
+++ b/package/src/external/reanimated/moduleWrapper.ts
@@ -1,27 +1,11 @@
 import { useMemo } from "react";
 
 import type { SharedValueType } from "../../renderer/processors/Animations";
+import { Reanimated2, Reanimated3, reanimatedVersion } from "./import";
 
 // This one is needed for the deprecated useSharedValue function
 // We can remove it once we remove the deprecation
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-let Reanimated2: any;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let Reanimated3: any;
-let reanimatedVersion: string;
-
-try {
-  Reanimated2 = require("react-native-reanimated");
-  reanimatedVersion =
-    // eslint-disable-next-line import/extensions
-    require("react-native-reanimated/package.json").version;
-  if (
-    reanimatedVersion &&
-    (reanimatedVersion >= "3.0.0" || reanimatedVersion.includes("3.0.0-"))
-  ) {
-    Reanimated3 = Reanimated2;
-  }
-} catch (e) {}
 
 export const HAS_REANIMATED2 = !!Reanimated2;
 export const HAS_REANIMATED3 = !!Reanimated3;
@@ -30,7 +14,7 @@ function throwOnMissingReanimated2() {
   if (!HAS_REANIMATED2) {
     throw new Error(
       "Reanimated was not found, make sure react-native-reanimated package is installed if you want to use \
-      react-naitve-skia's integration layer API."
+      react-native-skia's integration layer API."
     );
   }
 }


### PR DESCRIPTION
Before merging, we need to ask ourselves:
Do people use Reanimated in React Native Skia Web?

This PR will never load Reanimated on the Web and therefore fewer Webpack hacks are needed. However, if this is a feature you would like to support, then this PR is invalid.