### PR TITLE
move pixelmatch, pngjs, ws and their types to devdependencies

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -81,28 +81,28 @@
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
     "@types/jest": "^28.1.6",
+    "@types/pixelmatch": "^5.2.4",
+    "@types/pngjs": "^6.0.1",
     "@types/react-native": "0.70.6",
     "@types/react-reconciler": "^0.26.7",
+    "@types/ws": "^8.5.3",
     "eslint": "8.21.0",
     "eslint-config-react-native-wcandillon": "3.9.0",
     "eslint-plugin-reanimated": "2.0.0",
     "jest": "28.1.3",
     "merge-dirs": "^0.2.1",
+    "pixelmatch": "^5.3.0",
+    "pngjs": "^6.0.0",
     "react": "18.1.0",
     "react-native": "0.71.7",
     "react-native-builder-bob": "^0.18.2",
     "ts-jest": "^28.0.7",
-    "typescript": "4.8.3"
+    "typescript": "4.8.3",
+    "ws": "^8.11.0"
   },
   "dependencies": {
-    "@types/pixelmatch": "^5.2.4",
-    "@types/pngjs": "^6.0.1",
-    "@types/ws": "^8.5.3",
     "canvaskit-wasm": "0.38.0",
-    "pixelmatch": "^5.3.0",
-    "pngjs": "^6.0.0",
-    "react-reconciler": "^0.27.0",
-    "ws": "^8.11.0"
+    "react-reconciler": "^0.27.0"
   },
   "eslintIgnore": [
     "node_modules/",


### PR DESCRIPTION
These seem only to be used for testing, so people should not have to install it