### PR TITLE
Make `react-native` an optional peer dependency

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -76,6 +76,9 @@
   "peerDependenciesMeta": {
     "react-native-reanimated": {
       "optional": true
+    },
+    "react-native": {
+      "optional": true
     }
   },
   "devDependencies": {


### PR DESCRIPTION
I saw that `react-native` still ends up in ones node modules, I assume it is because of this. 