### PR TITLE
Update documentation on bundle size

### DIFF
--- a/docs/docs/getting-started/bundle-size.md
+++ b/docs/docs/getting-started/bundle-size.md
@@ -9,13 +9,14 @@ Below is the app size increase to be expected when adding React Native Skia to y
 
 | iOS  | Android | Web    |
 | ---- | ------- | ------ |
-| 6 MB | 4 MB    | 7,2 MB |
+| 6 MB | 4 MB    | 2.9 MB* |
+
+
+*This figure is the size of the gzipped file served through a CDN ([learn more](web)).
 
 React Native Skia includes both prebuilt library files and C++ files that are compiled and linked with your app when being built - adding to the size of your app.
 
 For a regular arm 64-bit **Android** device, the increased download size will be around **4 MB** added after adding React Native Skia - on **iOS**, the increased download size will be around **6 MB**.
-
-On **Web**, the increase will be around **7,2 MB**, which can be reduced by distributing the included CanvasKit Web Assembly file through a CDN ([learn more](web)).
 
 Below is an explanation of how these numbers were found - using a bare-bones React Native app created with `npx react-native init` before and after adding React Native Skia.
 

--- a/docs/docs/getting-started/web.mdx
+++ b/docs/docs/getting-started/web.mdx
@@ -11,9 +11,6 @@ React Native Skia runs in a web browser thanks to [CanvasKit](https://skia.org/d
 The WebAssembly file is loaded asynchronously and has a size of 2.9MB gzipped.
 While this is a substantial file size, you have control over the user experience: you can decide when to load Skia and how the loading experience should be.
 
-We are exploring the possibility of providing alternative versions of CanvasKit with smaller file sizes.
-If this interests you, let us know on GitHub, and we will look if we can help with your use case.
-
 We provide direct integrations with [Expo](#Expo) and [Remotion](#Remotion).
 Below you will also find the manual installation steps to run the module on any React Native Web projects.
 

--- a/docs/docs/getting-started/web.mdx
+++ b/docs/docs/getting-started/web.mdx
@@ -8,8 +8,11 @@ slug: /getting-started/web
 import {Snack} from '@site/src/components/Snack';
 
 React Native Skia runs in a web browser thanks to [CanvasKit](https://skia.org/docs/user/modules/canvaskit/), a WebAssembly build of Skia.
-The WebAssembly file is loaded asynchronously and has a size of 7.2MB.
+The WebAssembly file is loaded asynchronously and has a size of 2.9MB gzipped.
 While this is a substantial file size, you have control over the user experience: you can decide when to load Skia and how the loading experience should be.
+
+We are exploring the possibility of providing alternative versions of CanvasKit with smaller file sizes.
+If this interests you, let us know on GitHub, and we will look if we can help with your use case.
 
 We provide direct integrations with [Expo](#Expo) and [Remotion](#Remotion).
 Below you will also find the manual installation steps to run the module on any React Native Web projects.


### PR DESCRIPTION
The old figure was misleading because the size sent over the wire is almost always gzipped.
Since we might be able to provide smaller build of canvaskit (without sksl -300kb, without paragraph =?), I wanted to elude to it in the documentation so we can collect feedback.
