### PR TITLE
#1625: Relaxed renderer bail-out when iOS is inactive

### DIFF
--- a/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
+++ b/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
@@ -77,8 +77,7 @@ void RNSkMetalCanvasProvider::renderToCanvas(
   // accessed from the main thread so we need to check here.
   if ([[NSThread currentThread] isMainThread]) {
     auto state = UIApplication.sharedApplication.applicationState;
-    if (state == UIApplicationStateBackground ||
-        state == UIApplicationStateInactive) {
+    if (state == UIApplicationStateBackground) {
       // Request a redraw in the next run loop callback
       _requestRedraw();
       // and don't draw now since it might cause errors in the metal renderer if


### PR DESCRIPTION
On iOS we need to be careful about using the Metal primitives when the app is backgrounded.

We have a test that bails out from rendering when the app is in the background / inactive, but we believe that this is a bit to strict (see #1625 and originally #1257).

This commit fixes this by removing bailing out when the app is inactive - Metal can still render, and the original error message was showing errors when the app was backgrounded.

**Verification:** 
Open animation example and pull down control center - the animation should continue when this PR is applied.
You can also test that the [example](https://github.com/Shopify/react-native-skia/issues/1257#issuecomment-1373524606) in #1257 works as expected.

Fixes #1625 