### PR TITLE
Fix example on web

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -33,7 +33,7 @@
     "react-native-reanimated": "3.1.0",
     "react-native-safe-area-context": "4.3.4",
     "react-native-screens": "3.17.0",
-    "react-native-svg": "^13.9.0",
+    "react-native-svg": "13.8.0",
     "react-native-web": "^0.18.0",
     "simplex-noise": "^3.0.1"
   },

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2103,10 +2103,8 @@
     nanoid "^3.1.23"
 
 "@shopify/react-native-skia@link:../package":
-  version "0.1.0-development"
-  dependencies:
-    canvaskit-wasm "0.38.0"
-    react-reconciler "^0.27.0"
+  version "0.0.0"
+  uid ""
 
 "@sideway/address@^4.1.3":
   version "4.1.4"
@@ -7871,10 +7869,10 @@ react-native-screens@3.17.0:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
-react-native-svg@^13.9.0:
-  version "13.9.0"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-13.9.0.tgz#8df8a690dd00362601f074dec5d3a86dd0f99c7f"
-  integrity sha512-Ey18POH0dA0ob/QiwCBVrxIiwflhYuw0P0hBlOHeY4J5cdbs8ngdKHeWC/Kt9+ryP6fNoEQ1PUgPYw2Bs/rp5Q==
+react-native-svg@13.8.0:
+  version "13.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-13.8.0.tgz#b6a22cf77f8098f910490a13aeb160a37e182f97"
+  integrity sha512-G8Mx6W86da+vFimZBJvA93POw8yz0fgDS5biy6oIjMWVJVQSDzCyzwO/zY0yuZmCDhKSZzogl5m0wXXvW2OcTA==
   dependencies:
     css-select "^5.1.0"
     css-tree "^1.1.3"


### PR DESCRIPTION
downgrade RN SVG module to `13.8.0` due to the following bug: https://github.com/software-mansion/react-native-svg/issues/2020