### PR TITLE
Build Skia with freetype on iOS

### DIFF
--- a/scripts/skia-configuration.ts
+++ b/scripts/skia-configuration.ts
@@ -165,6 +165,8 @@ export const configurations: Configuration = {
     },
     args: [
       ["skia_use_metal", true],
+      ['skia_use_freetype', true],
+      ["skia_use_system_freetype2", false],
       ["cc", '"clang"'],
       ["cxx", '"clang++"'],
     ],


### PR DESCRIPTION
To get metadata from a font file, Skia needs freetype. Not sure why the option doesn't need to be specified on Android. By setting `skia_use_system_freetype2=false` Skia will compile the third-party provided freetype. This options was already set to false on Android.