### PR TITLE
#1619: Fixed iOS issue when use_frameworks in Pod file

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "clean-skia": "yarn rimraf ./package/libs && yarn rimraf ./externals/skia/out",
     "copy-skia-include-headers": "yarn rimraf ./package/cpp/skia/include/ && cp -a ./externals/skia/include/. ./package/cpp/skia/include",
     "copy-skia-module-headers": "ts-node ./scripts/copy-skia-module-headers.ts",
-    "copy-skia-headers": "yarn copy-skia-module-headers && yarn copy-skia-include-headers",
+    "copy-skia-headers": "yarn copy-skia-include-headers && yarn copy-skia-module-headers",
     "build-npm": "yarn ts-node ./scripts/build-npm-package.ts",
     "get-filename-npm": "yarn ts-node ./scripts/get-npm-filename.ts",
     "get-version-npm": "yarn ts-node ./scripts/get-npm-version.ts",

--- a/scripts/copy-skia-module-headers.ts
+++ b/scripts/copy-skia-module-headers.ts
@@ -14,6 +14,8 @@ const copyModule = (module: string) => [
   `mkdir -p ./package/cpp/skia/src/`,
   `mkdir -p ./package/cpp/skia/src/core/`,
   `cp -a ./externals/skia/src/core/SkTHash.h ./package/cpp/skia/src/core/.`,
+  `rm ./package/cpp/skia/include/core/SkICC.h`, // Remove since there are now (Skia M108) two headers with the same name
+  `rm ./package/cpp/skia/include/core/SkEncodedImageFormat.h`, // Remove since there are now (Skia M108) two headers with the same name
 ].map((cmd) => {
   console.log(cmd);
   executeCmdSync(cmd);


### PR DESCRIPTION
When `use_frameworks!` is set in the pod file of the consuming app we get two errors saying RN Skia has multiple commands producing the same file. The two files are the following ones:

SkICC.h
SkEncodedImageFormat.h

These two files have been moved in the latest version of Skia, but kept in two separate locations in the source tree for backwards compatibility.

This causes use_frameworks-based POD files to get two files with the same names since headers are flattened.

This fix changes the order of the copy headers steps in our package.json file so that our js-script runs last.

The JS script has now gotten two steps that removes the old version of these two files.

Fixes [iOS] "Multiple commands produce" #1619