### PR TITLE
#1658: Removed inclusion of TurboModuleUtils.h

### DIFF
--- a/package/android/CMakeLists.txt
+++ b/package/android/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(
         "${PROJECT_SOURCE_DIR}/cpp/jsi/JsiValue.cpp"
         "${PROJECT_SOURCE_DIR}/cpp/jsi/RuntimeLifecycleMonitor.cpp"
         "${PROJECT_SOURCE_DIR}/cpp/jsi/RuntimeAwareCache.cpp"        
+        "${PROJECT_SOURCE_DIR}/cpp/jsi/JsiPromises.cpp"
 
         "${PROJECT_SOURCE_DIR}/cpp/rnskia/RNSkManager.cpp"
         "${PROJECT_SOURCE_DIR}/cpp/rnskia/RNSkJsView.cpp"

--- a/package/cpp/api/JsiSkDataFactory.h
+++ b/package/cpp/api/JsiSkDataFactory.h
@@ -3,17 +3,15 @@
 #include <memory>
 #include <utility>
 
-#include <ReactCommon/TurboModuleUtils.h>
 #include <jsi/jsi.h>
 
-#include "SkBase64.h"
-
+#include "JsiPromises.h"
 #include "JsiSkData.h"
+#include "SkBase64.h"
 
 namespace RNSkia {
 
 namespace jsi = facebook::jsi;
-namespace react = facebook::react;
 
 class JsiSkDataFactory : public JsiSkHostObject {
 public:
@@ -21,11 +19,11 @@ public:
     auto jsiLocalUri = arguments[0].asString(runtime);
     auto localUri = jsiLocalUri.utf8(runtime);
     auto context = getContext();
-    return react::createPromiseAsJSIValue(
+    return RNJsi::JsiPromises::createPromiseAsJSIValue(
         runtime,
         [context = std::move(context), localUri = std::move(localUri)](
             jsi::Runtime &runtime,
-            std::shared_ptr<react::Promise> promise) -> void {
+            std::shared_ptr<RNJsi::JsiPromises::Promise> promise) -> void {
           // Create a stream operation - this will be run in a
           // separate thread
           context->performStreamOperation(

--- a/package/cpp/api/JsiSkImageFactory.h
+++ b/package/cpp/api/JsiSkImageFactory.h
@@ -5,6 +5,7 @@
 
 #include <jsi/jsi.h>
 
+#include "JsiPromises.h"
 #include "JsiSkData.h"
 #include "JsiSkHostObjects.h"
 #include "JsiSkImage.h"
@@ -41,11 +42,11 @@ public:
   JSI_HOST_FUNCTION(MakeImageFromViewTag) {
     auto viewTag = arguments[0].asNumber();
     auto context = getContext();
-    return react::createPromiseAsJSIValue(
+    return RNJsi::JsiPromises::createPromiseAsJSIValue(
         runtime,
-        [context = std::move(context),
-         viewTag](jsi::Runtime &runtime,
-                  std::shared_ptr<react::Promise> promise) -> void {
+        [context = std::move(context), viewTag](
+            jsi::Runtime &runtime,
+            std::shared_ptr<RNJsi::JsiPromises::Promise> promise) -> void {
           // Create a stream operation - this will be run on the main thread
           context->makeViewScreenshot(
               viewTag, [&runtime, context = std::move(context),

--- a/package/cpp/jsi/JsiPromises.cpp
+++ b/package/cpp/jsi/JsiPromises.cpp
@@ -1,0 +1,39 @@
+#include "JsiPromises.h"
+
+namespace RNJsi {
+
+JsiPromises::Promise::Promise(jsi::Runtime &rt, jsi::Function resolve,
+                              jsi::Function reject)
+    : runtime_(rt), resolve_(std::move(resolve)), reject_(std::move(reject)) {}
+
+void JsiPromises::Promise::resolve(const jsi::Value &result) {
+  resolve_.call(runtime_, result);
+}
+
+void JsiPromises::Promise::reject(const std::string &message) {
+  jsi::Object error(runtime_);
+  error.setProperty(runtime_, "message",
+                    jsi::String::createFromUtf8(runtime_, message));
+  reject_.call(runtime_, error);
+}
+
+jsi::Value
+JsiPromises::createPromiseAsJSIValue(jsi::Runtime &rt,
+                                     PromiseSetupFunctionType &&func) {
+  jsi::Function JSPromise = rt.global().getPropertyAsFunction(rt, "Promise");
+  jsi::Function fn = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "fn"), 2,
+      [func = std::move(func)](jsi::Runtime &rt2, const jsi::Value &thisVal,
+                               const jsi::Value *args, size_t count) {
+        jsi::Function resolve = args[0].getObject(rt2).getFunction(rt2);
+        jsi::Function reject = args[1].getObject(rt2).getFunction(rt2);
+        auto wrapper = std::make_shared<Promise>(rt2, std::move(resolve),
+                                                 std::move(reject));
+        func(rt2, wrapper);
+        return jsi::Value::undefined();
+      });
+
+  return JSPromise.callAsConstructor(rt, fn);
+}
+
+} // namespace RNJsi

--- a/package/cpp/jsi/JsiPromises.h
+++ b/package/cpp/jsi/JsiPromises.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <memory>
-#include <utility>
 #include <string>
+#include <utility>
 
 #include <jsi/jsi.h>
 

--- a/package/cpp/jsi/JsiPromises.h
+++ b/package/cpp/jsi/JsiPromises.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <string>
+
+#include <jsi/jsi.h>
+
+#include "SkBase64.h"
+
+namespace RNJsi {
+namespace jsi = facebook::jsi;
+
+/**
+ These classes are taken from ReactCommon TurboModuleUtils. It is no longer (RN
+ 0.72) possible to include and uses TurboModulesUtils without a lot of trouble
+ when use_frameworks are true in POD file. Instead we're now just including the
+ implementations ourselves.
+ */
+
+class LongLivedObject {
+public:
+  void allowRelease();
+
+protected:
+  LongLivedObject() = default;
+  virtual ~LongLivedObject() = default;
+};
+
+class JsiPromises {
+public:
+  struct Promise : public LongLivedObject {
+    Promise(jsi::Runtime &rt, jsi::Function resolve, jsi::Function reject);
+
+    void resolve(const jsi::Value &result);
+    void reject(const std::string &error);
+
+    jsi::Runtime &runtime_;
+    jsi::Function resolve_;
+    jsi::Function reject_;
+  };
+
+  using PromiseSetupFunctionType =
+      std::function<void(jsi::Runtime &rt, std::shared_ptr<Promise>)>;
+
+  static jsi::Value createPromiseAsJSIValue(jsi::Runtime &rt,
+                                            PromiseSetupFunctionType &&func);
+};
+
+} // namespace RNJsi


### PR DESCRIPTION
It is no longer (from RN 0.72) possible to include and uses TurboModulesUtils without a lot of trouble when use_frameworks are true in POD file. 

Instead we're now just including the implementations ourselves. TurboModuleUtils contains simple wrappers for JSI Promises that we're using when loading data like images etc.

This problem only occurs when use_frameworks is set in the POD file - so testing must be done using this setting. (this causes all include files to be flattened)

Fixes #1658 