### PR TITLE
Removed duplicateStrategy = include to avoid duplicating files

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -274,7 +274,6 @@ if (ENABLE_PREFAB) {
         into "${project.buildDir}/headers/rnskia/"
         includeEmptyDirs = false
         include "**/*.h"
-        duplicatesStrategy = 'include'
         eachFile {
             String path = it.path
 


### PR DESCRIPTION
When packaging in Android (prefab) we've now removed the duplicateStrategy=include since we've added scripts that removes duplicate header files (related to [iOS] "Multiple commands produce" #1619) on iOS.