### PR TITLE
Remove BaseSkJSIInstance

### DIFF
--- a/package/src/skia/core/Data.ts
+++ b/package/src/skia/core/Data.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { Skia } from "../Skia";
-import type { SkData, DataSourceParam, BaseSkJSIInstance } from "../types";
+import type { SkData, DataSourceParam, SkJSIInstance } from "../types";
 import { Platform } from "../../Platform";
 
 const factoryWrapper = <T>(
@@ -37,7 +37,7 @@ const loadData = <T>(
     );
   }
 };
-const useLoading = <T extends BaseSkJSIInstance>(
+const useLoading = <T extends SkJSIInstance<string>>(
   source: DataSourceParam,
   loader: () => Promise<T | null>
 ) => {
@@ -61,7 +61,7 @@ const useLoading = <T extends BaseSkJSIInstance>(
   return data;
 };
 
-export const useRawData = <T extends BaseSkJSIInstance>(
+export const useRawData = <T extends SkJSIInstance<string>>(
   source: DataSourceParam,
   factory: (data: SkData) => T | null,
   onError?: (err: Error) => void

--- a/package/src/skia/types/JsiInstance.ts
+++ b/package/src/skia/types/JsiInstance.ts
@@ -1,7 +1,4 @@
-export interface BaseSkJSIInstance {
-  dispose: () => void;
-}
-
-export interface SkJSIInstance<T extends string> extends BaseSkJSIInstance {
+export interface SkJSIInstance<T extends string> {
   __typename__: T;
+  dispose: () => void;
 }


### PR DESCRIPTION
This is part 1 of 3 of a small refactoring/clean up of our host object interfaces.
Here we remove BaseSkJSIInstance. In a separate PR, we contributed the following patch to canvaskit: https://github.com/google/skia/commit/c474dc0aec7fdf8c9e17dd528ed8a4095932f3f2 (part 2 of 3).
 
Once this version of CanvasKit is released, this will allow us to define the three following host types for the Web:
* `StaticHostObject` (for factories, just holds a reference to CanvasKit)
* `JSHostObject<T, N extends string>` extends StaticHostObject (host a JS value, e.g ArrayBuffer)
* `CanvasKitHostObject<N extends string, T extends EmbindObject<N>> extends JSHostObject<T, N>` holds a CanvasKit (emscripten) instance.

I tried this refactoring by patching the CanvasKit types and it works like a charm and that allow us to factorize all declarations of `dipose()` and the naming and type definition adds clarity (right now it is slightly entangled). This is how the new types will looks like: https://gist.github.com/wcandillon/1ec901364d95acd3a1d43af3f7978ada

I wanted to first contribute this patch to keep the HostObject refactoring on Web nicely isolated.