### PR TITLE
Update size identity in onSize

### DIFF
--- a/package/cpp/rnskia/RNSkView.h
+++ b/package/cpp/rnskia/RNSkView.h
@@ -379,9 +379,10 @@ private:
 
                 if (w != width || h != height) {
                   // Update
-                  onSizeObj.setProperty(*runtime, "width", width);
-                  onSizeObj.setProperty(*runtime, "height", height);
-                  self->_onSize->set_current(*runtime, onSize);
+                  auto newValue = jsi::Object(*runtime);
+                  newValue.setProperty(*runtime, "width", width);
+                  newValue.setProperty(*runtime, "height", height);
+                  self->_onSize->set_current(*runtime, newValue);
                 }
               }
             }

--- a/package/cpp/rnskia/RNSkView.h
+++ b/package/cpp/rnskia/RNSkView.h
@@ -382,7 +382,7 @@ private:
                   auto newValue = jsi::Object(*runtime);
                   newValue.setProperty(*runtime, "width", width);
                   newValue.setProperty(*runtime, "height", height);
-                  self->_onSize->set_current(*runtime, newValue);
+                  self->_onSize->set_current(*runtime, jsi::Value(*runtime, newValue));
                 }
               }
             }

--- a/package/cpp/rnskia/RNSkView.h
+++ b/package/cpp/rnskia/RNSkView.h
@@ -382,7 +382,8 @@ private:
                   auto newValue = jsi::Object(*runtime);
                   newValue.setProperty(*runtime, "width", width);
                   newValue.setProperty(*runtime, "height", height);
-                  self->_onSize->set_current(*runtime, jsi::Value(*runtime, newValue));
+                  self->_onSize->set_current(*runtime,
+                                             jsi::Value(*runtime, newValue));
                 }
               }
             }


### PR DESCRIPTION
This issue was found by @XantreGodlike at #1654 where adding a listener to the size value would always return the same object identity.

@chrfalch Should this be caught in the Skia animation system? That it shouldn't be possible to trigger an update with the same object identity?