### PR TITLE
Remove Box from the documentation

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -53,7 +53,6 @@ const sidebars = {
         "shapes/ellipses",
         "shapes/vertices",
         "shapes/patch",
-        "shapes/box",
         "shapes/custom-drawing",
       ],
     },


### PR DESCRIPTION
Since we moved to the native renderer, the Box element hasn't been very well tested.
We originally built it for fast inner shadows on rounded rectangle (using rect-diff) but it doesn't look like we have the resources at the moment to support it part of the core.