### PR TITLE
Android: Render first frame to bitmap

### DIFF
--- a/example/src/Examples/API/Icons/index.tsx
+++ b/example/src/Examples/API/Icons/index.tsx
@@ -77,7 +77,8 @@ const Icon = ({ icon }: IconProps) => {
   return <SkiaPictureView picture={icon} style={style} />;
 };
 
-const Screen = () => {
+type Props = { color: string };
+const Screen: React.FC<Props> = ({ color }) => {
   const { github, octocat, stackExchange, overflow } = useSVGs();
   return (
     <View
@@ -96,10 +97,8 @@ const Screen = () => {
         <Icon icon={overflow} />
         <Text>React Native Skia Canvas</Text>
         <Canvas style={{ width: 50, height: 50 }}>
-          <Rect x={0} y={0} width={50} height={50} color="red" />
+          <Rect x={0} y={0} width={50} height={50} color={color} />
         </Canvas>
-        <Text>React Native View</Text>
-        <View style={{ backgroundColor: "orange", width: 50, height: 50 }} />
       </View>
       <View style={{ flex: 1, alignItems: "center" }}>
         <Text>React Native SVG</Text>
@@ -114,9 +113,9 @@ const Screen = () => {
   );
 };
 
-const HomeScreen = () => <Screen />;
+const HomeScreen = () => <Screen color="red" />;
 
-const SettingsScreen = () => <Screen />;
+const SettingsScreen = () => <Screen color="green" />;
 
 const Tab = createBottomTabNavigator();
 

--- a/package/android/cpp/jni/include/JniSkiaBaseView.h
+++ b/package/android/cpp/jni/include/JniSkiaBaseView.h
@@ -10,6 +10,8 @@
 #include <JniSkiaManager.h>
 #include <RNSkAndroidView.h>
 
+#include <android/bitmap.h>
+
 namespace RNSkia {
 
 namespace jsi = facebook::jsi;
@@ -55,6 +57,61 @@ protected:
     getSkiaManager()->unregisterSkiaView(
         _skiaView->getSkiaView()->getNativeId());
     _skiaView->viewDidUnmount();
+  }
+
+  /**
+   * Android specific method for rendering an offscreen GPU buffer to an Android
+   * bitmap. The result can be used to render the first frame of the Skia render
+   * to avoid flickering on android.
+   */
+  virtual jobject renderToBitmap(jobject bitmapIn, int width, int height) {
+    auto platformContext = getSkiaManager()->getPlatformContext();
+    auto provider = std::make_shared<RNSkImageCanvasProvider>(
+        platformContext,
+        std::bind(&RNSkView::requestRedraw, _skiaView->getSkiaView()), width,
+        height);
+
+    // Render into a gpu backed buffer
+    _skiaView->getSkiaView()->getRenderer()->renderImmediate(provider);
+    auto rect = SkRect::MakeXYWH(0, 0, width, height);
+    auto image = provider->makeSnapshot(&rect);
+
+    AndroidBitmapInfo infoIn;
+    auto env = facebook::jni::Environment::current();
+    void *pixels;
+
+    // Get image info
+    if (AndroidBitmap_getInfo(env, bitmapIn, &infoIn) !=
+        ANDROID_BITMAP_RESULT_SUCCESS) {
+      return env->NewStringUTF("failed");
+    }
+
+    // Check image
+    if (infoIn.format != ANDROID_BITMAP_FORMAT_RGBA_8888 &&
+        infoIn.format != ANDROID_BITMAP_FORMAT_RGB_565) {
+      return env->NewStringUTF("Only support ANDROID_BITMAP_FORMAT_RGBA_8888 "
+                               "and ANDROID_BITMAP_FORMAT_RGB_565");
+    }
+
+    auto imageInfo = SkImageInfo::Make(image->width(), image->height(),
+                                       image->colorType(), image->alphaType());
+
+    // Lock all images
+    if (AndroidBitmap_lockPixels(env, bitmapIn, &pixels) !=
+        ANDROID_BITMAP_RESULT_SUCCESS) {
+      return env->NewStringUTF("AndroidBitmap_lockPixels failed!");
+    }
+
+    // Set pixels from SkImage
+    image->readPixels(imageInfo, pixels, imageInfo.minRowBytes(), 0, 0);
+
+    // Unlocks everything
+    AndroidBitmap_unlockPixels(env, bitmapIn);
+
+    image = nullptr;
+    provider = nullptr;
+
+    return bitmapIn;
   }
 
 private:

--- a/package/android/cpp/jni/include/JniSkiaDomView.h
+++ b/package/android/cpp/jni/include/JniSkiaDomView.h
@@ -45,7 +45,8 @@ public:
          makeNativeMethod("updateTouchPoints",
                           JniSkiaDomView::updateTouchPoints),
          makeNativeMethod("registerView", JniSkiaDomView::registerView),
-         makeNativeMethod("unregisterView", JniSkiaDomView::unregisterView)});
+         makeNativeMethod("unregisterView", JniSkiaDomView::unregisterView),
+         makeNativeMethod("renderToBitmap", JniSkiaDomView::renderToBitmap)});
   }
 
 protected:
@@ -72,6 +73,10 @@ protected:
   }
 
   void unregisterView() override { JniSkiaBaseView::unregisterView(); }
+
+  jobject renderToBitmap(jobject bitmap, int width, int height) override {
+    return JniSkiaBaseView::renderToBitmap(bitmap, width, height);
+  }
 
 private:
   friend HybridBase;

--- a/package/android/cpp/jni/include/JniSkiaDrawView.h
+++ b/package/android/cpp/jni/include/JniSkiaDrawView.h
@@ -46,7 +46,8 @@ public:
          makeNativeMethod("updateTouchPoints",
                           JniSkiaDrawView::updateTouchPoints),
          makeNativeMethod("registerView", JniSkiaDrawView::registerView),
-         makeNativeMethod("unregisterView", JniSkiaDrawView::unregisterView)});
+         makeNativeMethod("unregisterView", JniSkiaDrawView::unregisterView),
+         makeNativeMethod("renderToBitmap", JniSkiaDrawView::renderToBitmap)});
   }
 
 protected:
@@ -73,6 +74,10 @@ protected:
   }
 
   void unregisterView() override { JniSkiaBaseView::unregisterView(); }
+
+  jobject renderToBitmap(jobject bitmap, int width, int height) override {
+    return JniSkiaBaseView::renderToBitmap(bitmap, width, height);
+  }
 
 private:
   friend HybridBase;

--- a/package/android/cpp/jni/include/JniSkiaPictureView.h
+++ b/package/android/cpp/jni/include/JniSkiaPictureView.h
@@ -46,8 +46,9 @@ public:
          makeNativeMethod("updateTouchPoints",
                           JniSkiaPictureView::updateTouchPoints),
          makeNativeMethod("registerView", JniSkiaPictureView::registerView),
-         makeNativeMethod("unregisterView",
-                          JniSkiaPictureView::unregisterView)});
+         makeNativeMethod("unregisterView", JniSkiaPictureView::unregisterView),
+         makeNativeMethod("renderToBitmap",
+                          JniSkiaPictureView::renderToBitmap)});
   }
 
 protected:
@@ -74,6 +75,10 @@ protected:
   }
 
   void unregisterView() override { JniSkiaBaseView::unregisterView(); }
+
+  jobject renderToBitmap(jobject bitmap, int width, int height) override {
+    return JniSkiaBaseView::renderToBitmap(bitmap, width, height);
+  }
 
 private:
   friend HybridBase;

--- a/package/android/cpp/rnskia-android/RNSkAndroidPlatformContext.h
+++ b/package/android/cpp/rnskia-android/RNSkAndroidPlatformContext.h
@@ -38,7 +38,7 @@ public:
   }
 
   sk_sp<SkSurface> makeOffscreenSurface(int width, int height) override {
-    return MakeOffscreenGLSurface(width, height);
+    return SkiaOpenGLRenderer::MakeOffscreenGLSurface(width, height);
   }
 
   void runOnMainThread(std::function<void()> task) override {

--- a/package/android/cpp/rnskia-android/RNSkOpenGLCanvasProvider.cpp
+++ b/package/android/cpp/rnskia-android/RNSkOpenGLCanvasProvider.cpp
@@ -48,29 +48,7 @@ void RNSkOpenGLCanvasProvider::surfaceDestroyed() {
   if (_renderer != nullptr) {
     // teardown
     _renderer->teardown();
-
-    // Teardown renderer on the render thread since OpenGL demands
-    // same thread access for OpenGL contexts.
-    std::condition_variable cv;
-    std::mutex m;
-    std::unique_lock<std::mutex> lock(m);
-
-    _context->runOnRenderThread([&cv, &m, weakSelf = weak_from_this()]() {
-      // Lock
-      std::unique_lock<std::mutex> lock(m);
-
-      auto self = weakSelf.lock();
-      if (self) {
-        if (self->_renderer != nullptr) {
-          self->_renderer->run(nullptr, 0, 0);
-        }
-        // Remove renderer
-        self->_renderer = nullptr;
-      }
-      cv.notify_one();
-    });
-
-    cv.wait(lock);
+    _renderer = nullptr;
   }
 }
 

--- a/package/android/cpp/rnskia-android/SkiaOpenGLHelper.h
+++ b/package/android/cpp/rnskia-android/SkiaOpenGLHelper.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <RNSkLog.h>
+
+#include "EGL/egl.h"
+#include "GLES2/gl2.h"
+#include "android/native_window.h"
+#include <fbjni/fbjni.h>
+#include <jni.h>
+
+#include <condition_variable>
+#include <memory>
+#include <thread>
+#include <unordered_map>
+
+#define STENCIL_BUFFER_SIZE 8
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
+
+#include "include/gpu/GrDirectContext.h"
+#include "include/gpu/gl/GrGLInterface.h"
+
+#pragma clang diagnostic pop
+
+namespace RNSkia {
+
+class SkiaOpenGLHelper {
+public:
+  struct ThreadRenderContext {
+    ThreadRenderContext() {
+      glConfig = 0;
+      glContext = EGL_NO_CONTEXT;
+      glDisplay = EGL_NO_DISPLAY;
+      skContext = nullptr;
+    }
+    EGLContext glContext;
+    EGLDisplay glDisplay;
+    EGLConfig glConfig;
+    sk_sp<GrDirectContext> skContext;
+  };
+
+  static bool initializeSkiaContext(ThreadRenderContext *context) {
+    // Create the Skia Context
+    auto backendInterface = GrGLMakeNativeInterface();
+    context->skContext = GrDirectContext::MakeGL(backendInterface);
+
+    if (context->skContext == nullptr) {
+      RNSkLogger::logToConsole("GrDirectContext::MakeGL failed");
+      return false;
+    }
+
+    return true;
+  }
+
+  static bool initializeOpenGL(ThreadRenderContext *context,
+                               int surfaceType = EGL_WINDOW_BIT,
+                               EGLContext parent = EGL_NO_CONTEXT) {
+    // Get default context
+    context->glDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+    if (context->glDisplay == EGL_NO_DISPLAY) {
+      RNSkLogger::logToConsole("eglGetdisplay failed : %i", glGetError());
+      return false;
+    }
+
+    EGLint major;
+    EGLint minor;
+
+    if (!eglInitialize(context->glDisplay, &major, &minor)) {
+      RNSkLogger::logToConsole("eglInitialize failed : %i", glGetError());
+      return false;
+    }
+
+    EGLint att[] = {EGL_RENDERABLE_TYPE,
+                    EGL_OPENGL_ES2_BIT,
+                    EGL_SURFACE_TYPE,
+                    surfaceType,
+                    EGL_ALPHA_SIZE,
+                    8,
+                    EGL_BLUE_SIZE,
+                    8,
+                    EGL_GREEN_SIZE,
+                    8,
+                    EGL_RED_SIZE,
+                    8,
+                    EGL_DEPTH_SIZE,
+                    0,
+                    EGL_STENCIL_SIZE,
+                    0,
+                    EGL_NONE};
+
+    EGLint numConfigs;
+    context->glConfig = 0;
+    if (!eglChooseConfig(context->glDisplay, att, &context->glConfig, 1,
+                         &numConfigs) ||
+        numConfigs == 0) {
+      RNSkLogger::logToConsole("Failed to choose a config %d\n", eglGetError());
+      return false;
+    }
+
+    EGLint contextAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
+
+    context->glContext = eglCreateContext(context->glDisplay, context->glConfig,
+                                          parent, contextAttribs);
+
+    if (context->glContext == EGL_NO_CONTEXT) {
+      RNSkLogger::logToConsole("eglCreateContext failed: %d\n", eglGetError());
+      return false;
+    }
+
+    return true;
+  }
+};
+} // namespace RNSkia

--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDomView.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDomView.java
@@ -1,6 +1,7 @@
 package com.shopify.reactnative.skia;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 
 import com.facebook.jni.HybridData;
 import com.facebook.jni.annotations.DoNotStrip;
@@ -42,4 +43,5 @@ public class SkiaDomView extends SkiaBaseView {
 
     protected native void unregisterView();
 
+    protected native Object renderToBitmap(Object bitmap, int width, int height);
 }

--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDrawView.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDrawView.java
@@ -1,6 +1,7 @@
 package com.shopify.reactnative.skia;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 
 import com.facebook.jni.HybridData;
 import com.facebook.jni.annotations.DoNotStrip;
@@ -20,6 +21,13 @@ public class SkiaDrawView extends SkiaBaseView {
     protected void finalize() throws Throwable {
         super.finalize();
         mHybridData.resetNative();
+    }
+
+    @Override
+    protected boolean isMainThreadRendererSupported() {
+        // Since we're rendering on the JS thread we'll never
+        // be able to deliver first frame rendering
+        return false;
     }
 
     private native HybridData initHybrid(SkiaManager skiaManager);
@@ -42,4 +50,5 @@ public class SkiaDrawView extends SkiaBaseView {
 
     protected native void unregisterView();
 
+    protected native Object renderToBitmap(Object bitmap, int width, int height);
 }

--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaPictureView.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaPictureView.java
@@ -1,6 +1,7 @@
 package com.shopify.reactnative.skia;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 
 import com.facebook.jni.HybridData;
 import com.facebook.jni.annotations.DoNotStrip;
@@ -41,5 +42,7 @@ public class SkiaPictureView extends SkiaBaseView {
     protected native void registerView(int nativeId);
 
     protected native void unregisterView();
+
+    protected native Object renderToBitmap(Object bitmap, int width, int height);
 
 }

--- a/package/cpp/rnskia/RNSkJsiViewApi.h
+++ b/package/cpp/rnskia/RNSkJsiViewApi.h
@@ -162,7 +162,7 @@ public:
     if (info->view != nullptr) {
       if (count > 1 && !arguments[1].isUndefined() && !arguments[1].isNull()) {
         auto rect = JsiSkRect::fromValue(runtime, arguments[1]);
-        image = info->view->makeImageSnapshot(rect);
+        image = info->view->makeImageSnapshot(rect.get());
       } else {
         image = info->view->makeImageSnapshot(nullptr);
       }

--- a/package/cpp/rnskia/RNSkView.h
+++ b/package/cpp/rnskia/RNSkView.h
@@ -98,7 +98,7 @@ public:
   /**
    Returns a snapshot of the current surface/canvas
    */
-  sk_sp<SkImage> makeSnapshot(std::shared_ptr<SkRect> bounds) {
+  sk_sp<SkImage> makeSnapshot(SkRect *bounds) {
     sk_sp<SkImage> image;
     if (bounds != nullptr) {
       SkIRect b = SkIRect::MakeXYWH(bounds->x(), bounds->y(), bounds->width(),
@@ -273,7 +273,7 @@ public:
   /**
    Renders the view into an SkImage instead of the screen.
    */
-  sk_sp<SkImage> makeImageSnapshot(std::shared_ptr<SkRect> bounds) {
+  sk_sp<SkImage> makeImageSnapshot(SkRect *bounds) {
 
     auto provider = std::make_shared<RNSkImageCanvasProvider>(
         getPlatformContext(), std::bind(&RNSkView::requestRedraw, this),
@@ -283,6 +283,8 @@ public:
     return provider->makeSnapshot(bounds);
   }
 
+  std::shared_ptr<RNSkRenderer> getRenderer() { return _renderer; }
+
 protected:
   std::shared_ptr<RNSkPlatformContext> getPlatformContext() {
     return _platformContext;
@@ -290,7 +292,6 @@ protected:
   std::shared_ptr<RNSkCanvasProvider> getCanvasProvider() {
     return _canvasProvider;
   }
-  std::shared_ptr<RNSkRenderer> getRenderer() { return _renderer; }
 
   /**
    Ends an ongoing beginDrawCallback loop for this view. This method is made
@@ -419,7 +420,6 @@ private:
 
   size_t _drawingLoopId = 0;
   std::atomic<int> _redrawRequestCounter = {1};
-  bool _initialDrawingDone = false;
 };
 
 } // namespace RNSkia


### PR DESCRIPTION
## Descriptions
Added support for first-frame-render using a bitmap.


## Background
The problem we're trying to solve is to ensure that the first frame of a newly mounted view is displayed directly without having to wait 1-2 frames before rendering is done. This has been addressed here previously: #1614. 

The issue on Android is basically that we need to use a TextureView to render OpenGL content. This is so that we can get support for combining our OpenGL rendering in Skia with regular views with transparency and view hierarchies. 

The problem is that the TextureView uses a threaded render to render its content using OpenGL queues and buffers - this causes a typical 1-frame glitch that is visible also outside React Native (example here: https://github.com/chrfalch/AndroidTextureViewTesterBareBones/blob/feature/without-threading/app/src/main/java/com/falch/textureview/TestView.java). We've tested this using QuickTime recording, and it gives unreliable results - sometimes rendering on first frame, sometimes not - pointing to the fact that this is thread related.

By looking at the source code for the TextureView.java in Android, we also see that there is a thread involved in rendering - also pointing us to the fact that we'll not be able to render first frame reliably (https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/TextureView.java).

## Solution 
To really ensure that we have something to render the first time the view is displayed, we utilise the offscreen render method of our views to create a rendering of the first frame when the Android view is about to draw (overriding the `onDraw` method of the view - the TextureView doesn't initially use the onDraw method - but we can override this setting shouldDraw to true in the constructor). 

When we have an offscreen texture of the first frame we can convert and render that into a bitmap that we can blit directly to the screen in the onDraw method. This makes sure that the view is not empty in the first frame.