### PR TITLE
fix: Set `framebufferOnly` to true allowing the Metal Layer to be more optimized

### DIFF
--- a/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
+++ b/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
@@ -36,7 +36,7 @@ RNSkMetalCanvasProvider::RNSkMetalCanvasProvider(
 
   auto device = MTLCreateSystemDefaultDevice();
 
-  _layer.framebufferOnly = NO;
+  _layer.framebufferOnly = YES;
   _layer.device = device;
   _layer.opaque = false;
   _layer.contentsScale = _context->getPixelDensity();


### PR DESCRIPTION

From the documentation of that prop:

```
    /* This property controls whether or not the returned drawables'
     * MTLTextures may only be used for framebuffer attachments (YES) or
     * whether they may also be used for texture sampling and pixel
     * read/write operations (NO). A value of YES allows CAMetalLayer to
     * allocate the MTLTexture objects in ways that are optimized for display
     * purposes that makes them unsuitable for sampling. The recommended
     * value for most applications is YES. */
```

..it looks like setting this to YES might be more optimized. I tried to set it to yes for VisionCamera and everything still worked fine, not sure if there is anything breaking in RN Skia so I haven't thoroughly tested that yet tbh.