### PR TITLE
Update Dox Code Snippet typo at web.mdx

### DIFF
--- a/docs/docs/getting-started/web.mdx
+++ b/docs/docs/getting-started/web.mdx
@@ -134,7 +134,7 @@ export default function App() {
   return (
     <WithSkiaWeb
       getComponent={() => import("./MySkiaComponent")}
-      fallback={<Text>Loading Skia...</Text>} />}
+      fallback={<Text>Loading Skia...</Text>}
     />
   );
 }


### PR DESCRIPTION
A miss-type with the code snippet

This :
```
 <WithSkiaWeb
      getComponent={() => import("./MySkiaComponent")}
      fallback={<Text>Loading Skia...</Text>} />}   <<-----
    />
```
To:
```
<WithSkiaWeb
      getComponent={() => import("./MySkiaComponent")}
      fallback={<Text>Loading Skia...</Text>} />}    <<-----
    />
```
😇