### PR TITLE
Update Dox Typo at WithSkiaWeb Code Snippet web.mdx

### DIFF
--- a/docs/docs/getting-started/web.mdx
+++ b/docs/docs/getting-started/web.mdx
@@ -134,7 +134,7 @@ export default function App() {
   return (
     <WithSkiaWeb
       getComponent={() => import("./MySkiaComponent")}
-      fallback={<Text>Loading Skia...</Text>} />}
+      fallback={<Text>Loading Skia...</Text>}
     />
   );
 }


### PR DESCRIPTION
A small Typo in the Code Snippet `WithSkiaWeb`

 `/>}` was not needed at that line, since the WithSkiaWeb block gets closed in the next line
 
**THIS:**
```
<WithSkiaWeb
      getComponent={() => import("./MySkiaComponent")}
      fallback={<Text>Loading Skia...</Text>} />}   <<----
    />
```

**TO:**
```
<WithSkiaWeb
      getComponent={() => require('./MySkiaComponent')}
      fallback={<Text>Loading Skia...</Text>}    <<-----
    />
```