### PR TITLE
iOS: Removed bitcode generation for skia build

### DIFF
--- a/docs/docs/getting-started/bundle-size.md
+++ b/docs/docs/getting-started/bundle-size.md
@@ -7,12 +7,11 @@ slug: /getting-started/bundle-size
 
 Below is the app size increase to be expected when adding React Native Skia to your project.
 
-| iOS  | Android | Web    |
-| ---- | ------- | ------ |
-| 6 MB | 4 MB    | 2.9 MB* |
+| iOS  | Android | Web      |
+| ---- | ------- | -------- |
+| 6 MB | 4 MB    | 2.9 MB\* |
 
-
-*This figure is the size of the gzipped file served through a CDN ([learn more](web)).
+\*This figure is the size of the gzipped file served through a CDN ([learn more](web)).
 
 React Native Skia includes both prebuilt library files and C++ files that are compiled and linked with your app when being built - adding to the size of your app.
 
@@ -41,5 +40,4 @@ Meaning that we’ve increased the size of our app by around 5,8 MB after adding
 
 ### NPM Package
 
-The NPM download is much bigger than these numbers indicate because we need to distribute Skia for all target platforms.
-On iOS, it is also required to distribute the bitcode (intermediate representation of a compiled program that can be used to recompile the program). This requirement will be removed in the future.
+The NPM download is bigger than these numbers indicate because we need to distribute Skia for all target platforms on both iOS and Android.

--- a/scripts/skia-configuration.ts
+++ b/scripts/skia-configuration.ts
@@ -133,15 +133,9 @@ export const configurations: Configuration = {
         cpu: "arm64",
         args: [
           ["ios_min_target", '"13.0"'],
-          ["extra_cflags", '["-target", "arm64-apple-ios", "-fembed-bitcode"]'],
-          [
-            "extra_asmflags",
-            '["-target", "arm64-apple-ios", "-fembed-bitcode"]',
-          ],
-          [
-            "extra_ldflags",
-            '["-target", "arm64-apple-ios", "-fembed-bitcode"]',
-          ],
+          ["extra_cflags", '["-target", "arm64-apple-ios"]'],
+          ["extra_asmflags", '["-target", "arm64-apple-ios"]'],
+          ["extra_ldflags", '["-target", "arm64-apple-ios"]'],
         ],
       },
       "arm64-iphonesimulator": {


### PR DESCRIPTION
It is no longer necessary to upload binaries built with bitcode on XCode 14 and later on iOS.

https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes

This commit removes bitcode flags for the device targets when building Skia and updates the documentation.

**NOTE: Needs an updated Skia Build after merging.**

Fixes [Request]: reduce size of package #1745