### PR TITLE
Fix error handling for Image.MakeFromViewTag

### DIFF
--- a/package/ios/RNSkia-iOS/ViewScreenshotService.mm
+++ b/package/ios/RNSkia-iOS/ViewScreenshotService.mm
@@ -24,6 +24,7 @@
   auto view = [_uiManager viewForReactTag:viewTag];
   if (view == NULL) {
     RCTFatal(RCTErrorWithMessage(@"Could not find view with tag"));
+	return nullptr;
   }
 
   // Get size

--- a/package/src/renderer/__tests__/e2e/Image.spec.tsx
+++ b/package/src/renderer/__tests__/e2e/Image.spec.tsx
@@ -24,4 +24,11 @@ describe("Image loading from bundles", () => {
     );
     checkImage(image, `snapshots/images/bundle-${surface.OS}.png`);
   });
+  it("should not crash with an invalid viewTag", async () => {
+    const result = await surface.eval((Skia) => {
+      Skia.Image.MakeImageFromViewTag(-1);
+      return true;
+    });
+    expect(result).toBe(true);
+  });
 });


### PR DESCRIPTION
The goal of this PR is for the app to not crash if the viewTag is incorrect.

The scenario where you can end up with an invalid viewTag is somewhat marginal however: you would need to have extracted the viewTag manually and store it in a place (like a navigation parameter) where it can become stale on hot reload (the navigation stays unchanged but behind the scene the view has been remounted).