### PR TITLE
Remove makeNonTextureImage in makeImageSnapshot

### DIFF
--- a/package/cpp/rnskia/RNSkView.h
+++ b/package/cpp/rnskia/RNSkView.h
@@ -109,7 +109,7 @@ public:
     } else {
       image = _surface->makeImageSnapshot();
     }
-    return image->makeNonTextureImage();
+    return image;
   }
 
   /**


### PR DESCRIPTION
Now that all API calls on the same thread share the same Skia context, there is no need anymore to use `makeNonTextureImage` in makeImageSnapshot.

This change will make `on screen canvas makeImageSnapshot() to draw to Canvas` faster and does that the non-backward compatible change that `on screen makeImageSnapshot() to draw to offscreen on JS thread` will result in a blank. We may be able to simply warn about these since we can access the skia context from an image and check if it is equal to the one on the current thread.

This also raise the possibility to create an offscreen drawing on the UI thread to be draw on multiple onscreen canvases.