### PR TITLE
fix typo in Shapes/Path docs

### DIFF
--- a/docs/docs/shapes/path.md
+++ b/docs/docs/shapes/path.md
@@ -94,8 +94,8 @@ const SVGNotation = () => {
 
 ## Fill Type
 
-The `fillType`` property defines the algorithm to use to determine the inside part of a shape.
-Possible values are: `"winding`, `evenOdd`, `inverseWinding`, `inverseEvenOdd`. Default value is `winding`.
+The `fillType` property defines the algorithm to use to determine the inside part of a shape.
+Possible values are: `winding`, `evenOdd`, `inverseWinding`, `inverseEvenOdd`. Default value is `winding`.
 
 ```tsx twoslash
 import {Canvas, Group, TextPath, Skia, useFont, vec, Fill, Path} from "@shopify/react-native-skia";


### PR DESCRIPTION
When I was going through the docs I found a typo in documentation of `Path`. PR fix it. 