### PR TITLE
Bug fixes in the FontMgr

### DIFF
--- a/docs/docs/text/fonts.md
+++ b/docs/docs/text/fonts.md
@@ -8,6 +8,19 @@ slug: /text/fonts
 In Skia, the `FontMgr` object manages a collection of font families.
 It allows you to access fonts from the system and manage custom fonts.
 
+The `matchFont()` function will always return a font.
+So a fast way to display text in React Native Skia would be the following:
+
+```tsx twoslash
+import {Text, matchFont} from "@shopify/react-native-skia";
+
+const Demo = () => {
+  return (
+    <Text text="Hello World" y={32} x={32} font={matchFont()} />
+  );
+};
+```
+
 ## Custom Fonts
 
 The `useFonts` hooks allows you to load custom fonts to be used for your Skia drawing.

--- a/docs/docs/text/fonts.md
+++ b/docs/docs/text/fonts.md
@@ -121,11 +121,15 @@ The `fontStyle` object can have the following list of optional attributes:
 
 By default, `matchFont` uses the system font manager to match the font style. However, if you want to use your custom font manager, you can pass it as the second parameter to the `matchFont` function:
 
-```jsx
-const fontMgr = useFonts([
-  require("../../Tests/assets/Roboto-Medium.ttf"),
-  require("../../Tests/assets/Roboto-Bold.ttf"),
-]);
+```jsx twoslash
+import {matchFont, useFonts} from "@shopify/react-native-skia";
+
+const fontMgr = useFonts({
+  Roboto: [
+    require("../../Tests/assets/Roboto-Medium.ttf"),
+    require("../../Tests/assets/Roboto-Bold.ttf"),
+  ]
+});
 
 const font = matchFont(fontStyle, fontMgr);
 ```

--- a/example/src/Examples/API/FontMgr.tsx
+++ b/example/src/Examples/API/FontMgr.tsx
@@ -70,7 +70,7 @@ export const FontMgr = () => {
         })}
         <Text font={titleFont} text="Custom Fonts" x={PADDING} y={title2Y} />
         {customfamilyNames.map((fontFamily, i) => {
-          const font = matchFont({ fontFamily }, customFontMgr);
+          const font = matchFont({ fontFamily, fontSize: 24 }, customFontMgr);
 
           const resolvedFont =
             font.getGlyphIDs(fontFamily)[0] === 0 ? subtitleFont : font;
@@ -79,7 +79,7 @@ export const FontMgr = () => {
               key={fontFamily}
               font={resolvedFont}
               x={PADDING}
-              y={title2Y + 16 * (i + 1)}
+              y={title2Y + 24 * (i + 1)}
               text={fontFamily}
             />
           );

--- a/example/src/Examples/API/FontMgr.tsx
+++ b/example/src/Examples/API/FontMgr.tsx
@@ -71,7 +71,6 @@ export const FontMgr = () => {
         <Text font={titleFont} text="Custom Fonts" x={PADDING} y={title2Y} />
         {customfamilyNames.map((fontFamily, i) => {
           const font = matchFont({ fontFamily, fontSize: 16 }, customFontMgr);
-
           const resolvedFont =
             font.getGlyphIDs(fontFamily)[0] === 0 ? subtitleFont : font;
           return (
@@ -84,6 +83,12 @@ export const FontMgr = () => {
             />
           );
         })}
+        <Text
+          font={matchFont()}
+          x={PADDING}
+          y={title2Y + 16 * (customfamilyNames.length + 1)}
+          text="Default font"
+        />
       </Canvas>
     </ScrollView>
   );

--- a/example/src/Examples/API/FontMgr.tsx
+++ b/example/src/Examples/API/FontMgr.tsx
@@ -70,7 +70,7 @@ export const FontMgr = () => {
         })}
         <Text font={titleFont} text="Custom Fonts" x={PADDING} y={title2Y} />
         {customfamilyNames.map((fontFamily, i) => {
-          const font = matchFont({ fontFamily, fontSize: 24 }, customFontMgr);
+          const font = matchFont({ fontFamily, fontSize: 16 }, customFontMgr);
 
           const resolvedFont =
             font.getGlyphIDs(fontFamily)[0] === 0 ? subtitleFont : font;
@@ -79,7 +79,7 @@ export const FontMgr = () => {
               key={fontFamily}
               font={resolvedFont}
               x={PADDING}
-              y={title2Y + 24 * (i + 1)}
+              y={title2Y + 16 * (i + 1)}
               text={fontFamily}
             />
           );

--- a/package/cpp/api/JsiSkFontMgr.h
+++ b/package/cpp/api/JsiSkFontMgr.h
@@ -14,6 +14,7 @@
 #pragma clang diagnostic ignored "-Wdocumentation"
 
 #include "SkFontMgr.h"
+//#include "SkString.h"
 
 #pragma clang diagnostic pop
 
@@ -45,6 +46,36 @@ public:
     return jsi::Object::createFromHostObject(
         runtime, std::make_shared<JsiSkTypeface>(getContext(), typeface));
   }
+
+  // JSI_HOST_FUNCTION(matchFamily) {
+  //   auto name = arguments[0].asString(runtime).utf8(runtime);
+  //   auto fontStyleSet = getObject()->matchFamily(name.c_str());
+  //   int setSize = fontStyleSet->count();
+  //   jsi::Array resultArray = jsi::Array(runtime, setSize);
+
+  //   for (int i = 0; i < setSize; i++) {
+  //     SkFontStyle skStyle;
+  //     SkString skStringStyle;
+
+  //     fontStyleSet->getStyle(i, &skStyle, &skStringStyle);
+
+  //     // Convert SkFontStyle and SkString to jsi::Object.
+  //     jsi::Object jsStyleObj(runtime);
+  //     jsStyleObj.setProperty(runtime, "weight",
+  //                            jsi::Value(static_cast<int>(skStyle.weight())));
+  //     jsStyleObj.setProperty(runtime, "width",
+  //                            jsi::Value(static_cast<int>(skStyle.width())));
+  //     jsStyleObj.setProperty(runtime, "slant",
+  //                            jsi::Value(static_cast<int>(skStyle.slant())));
+  //     jsStyleObj.setProperty(
+  //         runtime, "name",
+  //         jsi::String::createFromUtf8(runtime, skStringStyle.c_str()));
+
+  //     resultArray.setValueAtIndex(runtime, i, jsStyleObj);
+  //   }
+
+  //   return resultArray;
+  // }
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkFontMgr, countFamilies),
                        JSI_EXPORT_FUNC(JsiSkFontMgr, getFamilyName),

--- a/package/cpp/api/JsiSkFontMgr.h
+++ b/package/cpp/api/JsiSkFontMgr.h
@@ -14,7 +14,6 @@
 #pragma clang diagnostic ignored "-Wdocumentation"
 
 #include "SkFontMgr.h"
-//#include "SkString.h"
 
 #pragma clang diagnostic pop
 
@@ -46,36 +45,6 @@ public:
     return jsi::Object::createFromHostObject(
         runtime, std::make_shared<JsiSkTypeface>(getContext(), typeface));
   }
-
-  // JSI_HOST_FUNCTION(matchFamily) {
-  //   auto name = arguments[0].asString(runtime).utf8(runtime);
-  //   auto fontStyleSet = getObject()->matchFamily(name.c_str());
-  //   int setSize = fontStyleSet->count();
-  //   jsi::Array resultArray = jsi::Array(runtime, setSize);
-
-  //   for (int i = 0; i < setSize; i++) {
-  //     SkFontStyle skStyle;
-  //     SkString skStringStyle;
-
-  //     fontStyleSet->getStyle(i, &skStyle, &skStringStyle);
-
-  //     // Convert SkFontStyle and SkString to jsi::Object.
-  //     jsi::Object jsStyleObj(runtime);
-  //     jsStyleObj.setProperty(runtime, "weight",
-  //                            jsi::Value(static_cast<int>(skStyle.weight())));
-  //     jsStyleObj.setProperty(runtime, "width",
-  //                            jsi::Value(static_cast<int>(skStyle.width())));
-  //     jsStyleObj.setProperty(runtime, "slant",
-  //                            jsi::Value(static_cast<int>(skStyle.slant())));
-  //     jsStyleObj.setProperty(
-  //         runtime, "name",
-  //         jsi::String::createFromUtf8(runtime, skStringStyle.c_str()));
-
-  //     resultArray.setValueAtIndex(runtime, i, jsStyleObj);
-  //   }
-
-  //   return resultArray;
-  // }
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkFontMgr, countFamilies),
                        JSI_EXPORT_FUNC(JsiSkFontMgr, getFamilyName),

--- a/package/cpp/api/JsiSkFontStyle.h
+++ b/package/cpp/api/JsiSkFontStyle.h
@@ -36,12 +36,20 @@ public:
     if (object.isHostObject(runtime)) {
       return object.asHostObject<JsiSkFontStyle>(runtime)->getObject();
     } else {
-      auto weight =
-          static_cast<int>(object.getProperty(runtime, "weight").asNumber());
-      auto width =
-          static_cast<int>(object.getProperty(runtime, "width").asNumber());
+      //     constexpr SkFontStyle() : SkFontStyle{kNormal_Weight,
+      //     kNormal_Width, kUpright_Slant} { }
+      auto weightProp = object.getProperty(runtime, "weight");
+      auto weight = static_cast<int>(weightProp.isUndefined()
+                                         ? SkFontStyle::Weight::kNormal_Weight
+                                         : weightProp.asNumber());
+      auto widthProp = object.getProperty(runtime, "width");
+      auto width = static_cast<int>(widthProp.isUndefined()
+                                        ? SkFontStyle::Width::kNormal_Width
+                                        : widthProp.asNumber());
+      auto slantProp = object.getProperty(runtime, "slant");
       auto slant = static_cast<SkFontStyle::Slant>(
-          object.getProperty(runtime, "slant").asNumber());
+          slantProp.isUndefined() ? SkFontStyle::Slant::kUpright_Slant
+                                  : slantProp.asNumber());
       SkFontStyle style(weight, width, slant);
       return std::make_shared<SkFontStyle>(style);
     }

--- a/package/cpp/api/JsiSkFontStyle.h
+++ b/package/cpp/api/JsiSkFontStyle.h
@@ -36,8 +36,6 @@ public:
     if (object.isHostObject(runtime)) {
       return object.asHostObject<JsiSkFontStyle>(runtime)->getObject();
     } else {
-      //     constexpr SkFontStyle() : SkFontStyle{kNormal_Weight,
-      //     kNormal_Width, kUpright_Slant} { }
       auto weightProp = object.getProperty(runtime, "weight");
       auto weight = static_cast<int>(weightProp.isUndefined()
                                          ? SkFontStyle::Weight::kNormal_Weight

--- a/package/cpp/api/JsiSkTypeFaceFontProvider.h
+++ b/package/cpp/api/JsiSkTypeFaceFontProvider.h
@@ -31,7 +31,6 @@ public:
   JSI_EXPORT_FUNCTIONS(
       JSI_EXPORT_FUNC(JsiSkTypefaceFontProvider, dispose),
       JSI_EXPORT_FUNC(JsiSkTypefaceFontProvider, registerFont),
-      JSI_EXPORT_FUNC(JsiSkTypefaceFontProvider, matchFamily),
       JSI_EXPORT_FUNC(JsiSkTypefaceFontProvider, matchFamilyStyle),
       JSI_EXPORT_FUNC(JsiSkTypefaceFontProvider, countFamilies),
       JSI_EXPORT_FUNC(JsiSkTypefaceFontProvider, getFamilyName))
@@ -51,36 +50,6 @@ public:
     sk_sp<SkTypeface> typeface(set->matchStyle(*fontStyle));
     return jsi::Object::createFromHostObject(
         runtime, std::make_shared<JsiSkTypeface>(getContext(), typeface));
-  }
-
-  JSI_HOST_FUNCTION(matchFamily) {
-    auto name = arguments[0].asString(runtime).utf8(runtime);
-    auto fontStyleSet = getObject()->matchFamily(name.c_str());
-    int setSize = fontStyleSet->count();
-    jsi::Array resultArray = jsi::Array(runtime, setSize);
-
-    for (int i = 0; i < setSize; i++) {
-      SkFontStyle skStyle;
-      SkString skStringStyle;
-
-      fontStyleSet->getStyle(i, &skStyle, &skStringStyle);
-
-      // Convert SkFontStyle and SkString to jsi::Object.
-      jsi::Object jsStyleObj(runtime);
-      jsStyleObj.setProperty(runtime, "weight",
-                             jsi::Value(static_cast<int>(skStyle.weight())));
-      jsStyleObj.setProperty(runtime, "width",
-                             jsi::Value(static_cast<int>(skStyle.width())));
-      jsStyleObj.setProperty(runtime, "slant",
-                             jsi::Value(static_cast<int>(skStyle.slant())));
-      jsStyleObj.setProperty(
-          runtime, "name",
-          jsi::String::createFromUtf8(runtime, skStringStyle.c_str()));
-
-      resultArray.setValueAtIndex(runtime, i, jsStyleObj);
-    }
-
-    return resultArray;
   }
 
   JSI_HOST_FUNCTION(countFamilies) { return getObject()->countFamilies(); }

--- a/package/cpp/api/JsiSkTypeFaceFontProviderFactory.h
+++ b/package/cpp/api/JsiSkTypeFaceFontProviderFactory.h
@@ -7,7 +7,7 @@
 
 #include "JsiSkData.h"
 #include "JsiSkHostObjects.h"
-#include "JsiSkTypefaceFontProvider.h"
+#include "JsiSkTypeFaceFontProvider.h"
 
 namespace RNSkia {
 

--- a/package/cpp/api/JsiSkTypeface.h
+++ b/package/cpp/api/JsiSkTypeface.h
@@ -23,11 +23,35 @@ namespace jsi = facebook::jsi;
 class JsiSkTypeface : public JsiSkWrappingSkPtrHostObject<SkTypeface> {
 public:
   EXPORT_JSI_API_TYPENAME(JsiSkTypeface, "Typeface")
-  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkTypeface, dispose))
+  JSI_EXPORT_FUNCTIONS(
+    JSI_EXPORT_FUNC(JsiSkTypeface, getGlyphIDs),
+    JSI_EXPORT_FUNC(JsiSkTypeface, dispose)
+  )
 
   JsiSkTypeface(std::shared_ptr<RNSkPlatformContext> context,
                 sk_sp<SkTypeface> typeface)
       : JsiSkWrappingSkPtrHostObject(std::move(context), std::move(typeface)) {}
+
+
+  JSI_HOST_FUNCTION(getGlyphIDs) {
+    auto str = arguments[0].asString(runtime).utf8(runtime);
+    int numGlyphIDs =
+        count > 1 && !arguments[1].isNull() && !arguments[1].isUndefined()
+            ? static_cast<int>(arguments[1].asNumber())
+            : getObject()->textToGlyphs(str.c_str(), str.length(),
+                                     SkTextEncoding::kUTF8, nullptr, 0);
+    std::vector<SkGlyphID> glyphIDs;
+    glyphIDs.resize(numGlyphIDs);
+    getObject()->textToGlyphs(str.c_str(), str.length(), SkTextEncoding::kUTF8,
+                              static_cast<SkGlyphID *>(glyphIDs.data()),
+                              numGlyphIDs);
+    auto jsiGlyphIDs = jsi::Array(runtime, numGlyphIDs);
+    for (int i = 0; i < numGlyphIDs; i++) {
+      jsiGlyphIDs.setValueAtIndex(runtime, i,
+                                  jsi::Value(static_cast<int>(glyphIDs[i])));
+    }
+    return jsiGlyphIDs;
+  }
 
   /**
    Returns the jsi object from a host object of this type

--- a/package/cpp/api/JsiSkTypeface.h
+++ b/package/cpp/api/JsiSkTypeface.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include <jsi/jsi.h>
 
@@ -23,15 +24,12 @@ namespace jsi = facebook::jsi;
 class JsiSkTypeface : public JsiSkWrappingSkPtrHostObject<SkTypeface> {
 public:
   EXPORT_JSI_API_TYPENAME(JsiSkTypeface, "Typeface")
-  JSI_EXPORT_FUNCTIONS(
-    JSI_EXPORT_FUNC(JsiSkTypeface, getGlyphIDs),
-    JSI_EXPORT_FUNC(JsiSkTypeface, dispose)
-  )
+  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkTypeface, getGlyphIDs),
+                       JSI_EXPORT_FUNC(JsiSkTypeface, dispose))
 
   JsiSkTypeface(std::shared_ptr<RNSkPlatformContext> context,
                 sk_sp<SkTypeface> typeface)
       : JsiSkWrappingSkPtrHostObject(std::move(context), std::move(typeface)) {}
-
 
   JSI_HOST_FUNCTION(getGlyphIDs) {
     auto str = arguments[0].asString(runtime).utf8(runtime);
@@ -39,7 +37,7 @@ public:
         count > 1 && !arguments[1].isNull() && !arguments[1].isUndefined()
             ? static_cast<int>(arguments[1].asNumber())
             : getObject()->textToGlyphs(str.c_str(), str.length(),
-                                     SkTextEncoding::kUTF8, nullptr, 0);
+                                        SkTextEncoding::kUTF8, nullptr, 0);
     std::vector<SkGlyphID> glyphIDs;
     glyphIDs.resize(numGlyphIDs);
     getObject()->textToGlyphs(str.c_str(), str.length(), SkTextEncoding::kUTF8,

--- a/package/src/renderer/__tests__/e2e/FontMgr.spec.tsx
+++ b/package/src/renderer/__tests__/e2e/FontMgr.spec.tsx
@@ -36,7 +36,7 @@ describe("FontMgr", () => {
       },
       { fonts: testingFonts }
     );
-    expect(result.identities).toEqual([false, false]);
+    expect(result.identities).toEqual([true]);
     expect(result.familyNames.length).toBeGreaterThan(0);
     expect(result.familyNames.indexOf("Helvetica")).toBe(-1);
     expect(result.familyNames.indexOf("Roboto")).not.toBe(-1);
@@ -93,4 +93,7 @@ describe("FontMgr", () => {
       expect(width).not.toEqual([0, 0]);
     }
   });
+  // Add test
+  //     *  Passing |nullptr| as the parameter for |familyName| will return the
+  // *  default system font.
 });

--- a/package/src/skia/types/Font/FontMgr.ts
+++ b/package/src/skia/types/Font/FontMgr.ts
@@ -6,5 +6,7 @@ import type { FontStyle } from "./Font";
 export interface SkFontMgr extends SkJSIInstance<"FontMgr"> {
   countFamilies(): number;
   getFamilyName(index: number): string;
+  // TODO: name could be null
   matchFamilyStyle(name: string, style: FontStyle): SkTypeface;
+  matchFamily(name: string): FontStyle[];
 }

--- a/package/src/skia/types/Font/FontMgr.ts
+++ b/package/src/skia/types/Font/FontMgr.ts
@@ -6,6 +6,5 @@ import type { FontStyle } from "./Font";
 export interface SkFontMgr extends SkJSIInstance<"FontMgr"> {
   countFamilies(): number;
   getFamilyName(index: number): string;
-  // TODO: name could be null
-  matchFamilyStyle(name: string, style: FontStyle): SkTypeface;
+  matchFamilyStyle(name?: string, style?: FontStyle): SkTypeface;
 }

--- a/package/src/skia/types/Font/FontMgr.ts
+++ b/package/src/skia/types/Font/FontMgr.ts
@@ -8,5 +8,4 @@ export interface SkFontMgr extends SkJSIInstance<"FontMgr"> {
   getFamilyName(index: number): string;
   // TODO: name could be null
   matchFamilyStyle(name: string, style: FontStyle): SkTypeface;
-  matchFamily(name: string): FontStyle[];
 }

--- a/package/src/skia/types/Typeface/Typeface.ts
+++ b/package/src/skia/types/Typeface/Typeface.ts
@@ -1,3 +1,12 @@
 import type { SkJSIInstance } from "../JsiInstance";
 
-export type SkTypeface = SkJSIInstance<"Typeface">;
+export interface SkTypeface extends SkJSIInstance<"Typeface"> {
+  /**
+   * Retrieves the glyph ids for each code point in the provided string. This call is passed to
+   * the typeface of this font. Note that glyph IDs are typeface-dependent; different faces
+   * may have different ids for the same code point.
+   * @param str
+   * @param numCodePoints - the number of code points in the string. Defaults to str.length.
+   */
+  getGlyphIDs(str: string, numCodePoints?: number): number[];
+}

--- a/package/src/skia/web/JsiSkTypeface.ts
+++ b/package/src/skia/web/JsiSkTypeface.ts
@@ -26,6 +26,10 @@ export class JsiSkTypeface
     return false;
   }
 
+  getGlyphIDs(str: string, numCodePoints?: number) {
+    return Array.from(this.ref.getGlyphIDs(str, numCodePoints));
+  }
+
   dispose = () => {
     this.ref.delete();
   };


### PR DESCRIPTION
* Fix documentation typos
* Fix bug in TypefaceFontProvider which overrides matchFamilyStyle as nullptr (which is sensible due to the typeface font provider name alising).
* FontStyle object constructor