### PR TITLE
Remove bogus quotes in typenames

### DIFF
--- a/package/cpp/api/JsiSkColorFilter.h
+++ b/package/cpp/api/JsiSkColorFilter.h
@@ -23,7 +23,7 @@ public:
       : JsiSkWrappingSkPtrHostObject<SkColorFilter>(std::move(context),
                                                     std::move(colorFilter)) {}
 
-  EXPORT_JSI_API_TYPENAME(JsiSkColorFilter, "ColorFilter")
+  EXPORT_JSI_API_TYPENAME(JsiSkColorFilter, ColorFilter)
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkColorFilter, dispose))
 };
 

--- a/package/cpp/api/JsiSkContourMeasure.h
+++ b/package/cpp/api/JsiSkContourMeasure.h
@@ -68,7 +68,7 @@ public:
     return JsiSkPath::toValue(runtime, getContext(), std::move(path));
   }
 
-  EXPORT_JSI_API_TYPENAME(JsiSkContourMeasure, "ContourMeasure")
+  EXPORT_JSI_API_TYPENAME(JsiSkContourMeasure, ContourMeasure)
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkContourMeasure, getPosTan),
                        JSI_EXPORT_FUNC(JsiSkContourMeasure, length),

--- a/package/cpp/api/JsiSkContourMeasureIter.h
+++ b/package/cpp/api/JsiSkContourMeasureIter.h
@@ -40,7 +40,7 @@ public:
     return jsi::Object::createFromHostObject(runtime, std::move(nextObject));
   }
 
-  EXPORT_JSI_API_TYPENAME(JsiSkContourMeasureIter, "ContourMeasureIter")
+  EXPORT_JSI_API_TYPENAME(JsiSkContourMeasureIter, ContourMeasureIter)
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkContourMeasureIter, next),
                        JSI_EXPORT_FUNC(JsiSkContourMeasureIter, dispose))

--- a/package/cpp/api/JsiSkData.h
+++ b/package/cpp/api/JsiSkData.h
@@ -24,7 +24,7 @@ public:
   JsiSkData(std::shared_ptr<RNSkPlatformContext> context, sk_sp<SkData> asset)
       : JsiSkWrappingSkPtrHostObject(std::move(context), std::move(asset)) {}
 
-  EXPORT_JSI_API_TYPENAME(JsiSkData, "Data")
+  EXPORT_JSI_API_TYPENAME(JsiSkData, Data)
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkData, dispose))
 };
 } // namespace RNSkia

--- a/package/cpp/api/JsiSkFont.h
+++ b/package/cpp/api/JsiSkFont.h
@@ -239,7 +239,7 @@ public:
     return jsi::Value::undefined();
   }
 
-  EXPORT_JSI_API_TYPENAME(JsiSkFont, "Font")
+  EXPORT_JSI_API_TYPENAME(JsiSkFont, Font)
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkFont, getSize),
                        JSI_EXPORT_FUNC(JsiSkFont, getMetrics),

--- a/package/cpp/api/JsiSkFontMgr.h
+++ b/package/cpp/api/JsiSkFontMgr.h
@@ -23,7 +23,7 @@ namespace jsi = facebook::jsi;
 
 class JsiSkFontMgr : public JsiSkWrappingSkPtrHostObject<SkFontMgr> {
 public:
-  EXPORT_JSI_API_TYPENAME(JsiSkFontMgr, "FontMgr")
+  EXPORT_JSI_API_TYPENAME(JsiSkFontMgr, FontMgr)
 
   JsiSkFontMgr(std::shared_ptr<RNSkPlatformContext> context,
                sk_sp<SkFontMgr> fontMgr)

--- a/package/cpp/api/JsiSkImage.h
+++ b/package/cpp/api/JsiSkImage.h
@@ -131,7 +131,7 @@ public:
         runtime, std::make_shared<JsiSkImage>(getContext(), std::move(image)));
   }
 
-  EXPORT_JSI_API_TYPENAME(JsiSkImage, "Image")
+  EXPORT_JSI_API_TYPENAME(JsiSkImage, Image)
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkImage, width),
                        JSI_EXPORT_FUNC(JsiSkImage, height),

--- a/package/cpp/api/JsiSkImageFilter.h
+++ b/package/cpp/api/JsiSkImageFilter.h
@@ -25,7 +25,7 @@ public:
       : JsiSkWrappingSkPtrHostObject<SkImageFilter>(std::move(context),
                                                     std::move(imageFilter)) {}
 
-  EXPORT_JSI_API_TYPENAME(JsiSkImageFilter, "ImageFilter")
+  EXPORT_JSI_API_TYPENAME(JsiSkImageFilter, ImageFilter)
 };
 
 } // namespace RNSkia

--- a/package/cpp/api/JsiSkMaskFilter.h
+++ b/package/cpp/api/JsiSkMaskFilter.h
@@ -25,7 +25,7 @@ public:
       : JsiSkWrappingSkPtrHostObject<SkMaskFilter>(std::move(context),
                                                    std::move(maskFilter)) {}
 
-  EXPORT_JSI_API_TYPENAME(JsiSkMaskFilter, "MaskFilter")
+  EXPORT_JSI_API_TYPENAME(JsiSkMaskFilter, MaskFilter)
 };
 
 } // namespace RNSkia

--- a/package/cpp/api/JsiSkMatrix.h
+++ b/package/cpp/api/JsiSkMatrix.h
@@ -86,7 +86,7 @@ public:
     return values;
   }
 
-  EXPORT_JSI_API_TYPENAME(JsiSkMatrix, "Matrix")
+  EXPORT_JSI_API_TYPENAME(JsiSkMatrix, Matrix)
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkMatrix, concat),
                        JSI_EXPORT_FUNC(JsiSkMatrix, translate),

--- a/package/cpp/api/JsiSkPaint.h
+++ b/package/cpp/api/JsiSkPaint.h
@@ -25,7 +25,7 @@ namespace jsi = facebook::jsi;
 
 class JsiSkPaint : public JsiSkWrappingSharedPtrHostObject<SkPaint> {
 public:
-  EXPORT_JSI_API_TYPENAME(JsiSkPaint, "Paint")
+  EXPORT_JSI_API_TYPENAME(JsiSkPaint, Paint)
 
   JSI_HOST_FUNCTION(copy) {
     const auto *paint = getObject().get();

--- a/package/cpp/api/JsiSkPath.h
+++ b/package/cpp/api/JsiSkPath.h
@@ -523,7 +523,7 @@ public:
     return cmds;
   }
 
-  EXPORT_JSI_API_TYPENAME(JsiSkPath, "Path")
+  EXPORT_JSI_API_TYPENAME(JsiSkPath, Path)
 
   JSI_EXPORT_FUNCTIONS(
       JSI_EXPORT_FUNC(JsiSkPath, addPath), JSI_EXPORT_FUNC(JsiSkPath, addArc),

--- a/package/cpp/api/JsiSkPathEffect.h
+++ b/package/cpp/api/JsiSkPathEffect.h
@@ -25,7 +25,7 @@ public:
       : JsiSkWrappingSkPtrHostObject<SkPathEffect>(std::move(context),
                                                    std::move(pathEffect)) {}
 
-  EXPORT_JSI_API_TYPENAME(JsiSkPathEffect, "PathEffect")
+  EXPORT_JSI_API_TYPENAME(JsiSkPathEffect, PathEffect)
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkColorFilter, dispose))
 };
 

--- a/package/cpp/api/JsiSkPicture.h
+++ b/package/cpp/api/JsiSkPicture.h
@@ -60,7 +60,7 @@ public:
     return array;
   }
 
-  EXPORT_JSI_API_TYPENAME(JsiSkPicture, "Picture")
+  EXPORT_JSI_API_TYPENAME(JsiSkPicture, Picture)
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkPicture, makeShader),
                        JSI_EXPORT_FUNC(JsiSkPicture, serialize),

--- a/package/cpp/api/JsiSkPictureRecorder.h
+++ b/package/cpp/api/JsiSkPictureRecorder.h
@@ -40,7 +40,7 @@ public:
         runtime, std::make_shared<JsiSkPicture>(getContext(), picture));
   }
 
-  EXPORT_JSI_API_TYPENAME(JsiSkPictureRecorder, "PictureRecorder")
+  EXPORT_JSI_API_TYPENAME(JsiSkPictureRecorder, PictureRecorder)
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkPictureRecorder, beginRecording),
                        JSI_EXPORT_FUNC(JsiSkPictureRecorder,

--- a/package/cpp/api/JsiSkRuntimeEffect.h
+++ b/package/cpp/api/JsiSkRuntimeEffect.h
@@ -115,7 +115,7 @@ public:
     return jsi::String::createFromAscii(runtime, getObject()->source());
   }
 
-  EXPORT_JSI_API_TYPENAME(JsiSkRuntimeEffect, "RuntimeEffect")
+  EXPORT_JSI_API_TYPENAME(JsiSkRuntimeEffect, RuntimeEffect)
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkRuntimeEffect, makeShader),
                        JSI_EXPORT_FUNC(JsiSkRuntimeEffect,

--- a/package/cpp/api/JsiSkSVG.h
+++ b/package/cpp/api/JsiSkSVG.h
@@ -24,7 +24,7 @@ public:
       : JsiSkWrappingSkPtrHostObject<SkSVGDOM>(std::move(context),
                                                std::move(svgdom)) {}
 
-  EXPORT_JSI_API_TYPENAME(JsiSkSVG, "SVG")
+  EXPORT_JSI_API_TYPENAME(JsiSkSVG, SVG)
 
   JSI_HOST_FUNCTION(width) {
     return static_cast<double>(getObject()->containerSize().width());

--- a/package/cpp/api/JsiSkShader.h
+++ b/package/cpp/api/JsiSkShader.h
@@ -26,7 +26,7 @@ public:
       : JsiSkWrappingSkPtrHostObject<SkShader>(std::move(context),
                                                std::move(shader)) {}
 
-  EXPORT_JSI_API_TYPENAME(JsiSkShader, "Shader")
+  EXPORT_JSI_API_TYPENAME(JsiSkShader, Shader)
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkShader, dispose))
 };
 } // namespace RNSkia

--- a/package/cpp/api/JsiSkSurface.h
+++ b/package/cpp/api/JsiSkSurface.h
@@ -28,7 +28,7 @@ public:
       : JsiSkWrappingSkPtrHostObject<SkSurface>(std::move(context),
                                                 std::move(surface)) {}
 
-  EXPORT_JSI_API_TYPENAME(JsiSkSurface, "Surface")
+  EXPORT_JSI_API_TYPENAME(JsiSkSurface, Surface)
 
   JSI_HOST_FUNCTION(getCanvas) {
     return jsi::Object::createFromHostObject(

--- a/package/cpp/api/JsiSkTextBlob.h
+++ b/package/cpp/api/JsiSkTextBlob.h
@@ -25,7 +25,7 @@ public:
       : JsiSkWrappingSkPtrHostObject<SkTextBlob>(std::move(context),
                                                  std::move(shader)) {}
 
-  EXPORT_JSI_API_TYPENAME(JsiSkTextBlob, "TextBlob")
+  EXPORT_JSI_API_TYPENAME(JsiSkTextBlob, TextBlob)
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkTextBlob, dispose))
 };
 } // namespace RNSkia

--- a/package/cpp/api/JsiSkTypeFaceFontProvider.h
+++ b/package/cpp/api/JsiSkTypeFaceFontProvider.h
@@ -27,7 +27,7 @@ namespace para = skia::textlayout;
 class JsiSkTypefaceFontProvider
     : public JsiSkWrappingSkPtrHostObject<para::TypefaceFontProvider> {
 public:
-  EXPORT_JSI_API_TYPENAME(JsiSkTypefaceFontProvider, "FontMgr")
+  EXPORT_JSI_API_TYPENAME(JsiSkTypefaceFontProvider, FontMgr)
   JSI_EXPORT_FUNCTIONS(
       JSI_EXPORT_FUNC(JsiSkTypefaceFontProvider, dispose),
       JSI_EXPORT_FUNC(JsiSkTypefaceFontProvider, registerFont),

--- a/package/cpp/api/JsiSkTypeface.h
+++ b/package/cpp/api/JsiSkTypeface.h
@@ -22,7 +22,7 @@ namespace jsi = facebook::jsi;
 
 class JsiSkTypeface : public JsiSkWrappingSkPtrHostObject<SkTypeface> {
 public:
-  EXPORT_JSI_API_TYPENAME(JsiSkTypeface, "Typeface")
+  EXPORT_JSI_API_TYPENAME(JsiSkTypeface, Typeface)
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkTypeface, dispose))
 
   JsiSkTypeface(std::shared_ptr<RNSkPlatformContext> context,

--- a/package/cpp/api/JsiSkVertices.h
+++ b/package/cpp/api/JsiSkVertices.h
@@ -25,7 +25,7 @@ public:
       : JsiSkWrappingSkPtrHostObject<SkVertices>(std::move(context),
                                                  std::move(vertices)) {}
 
-  EXPORT_JSI_API_TYPENAME(JsiSkVertices, "Vertices")
+  EXPORT_JSI_API_TYPENAME(JsiSkVertices, Vertices)
 
   JSI_HOST_FUNCTION(bounds) {
     const auto &result = getObject()->bounds();

--- a/package/src/renderer/__tests__/e2e/Paths.spec.tsx
+++ b/package/src/renderer/__tests__/e2e/Paths.spec.tsx
@@ -143,6 +143,13 @@ describe("Paths", () => {
     );
     checkImage(img, "snapshots/paths/pattern.png");
   });
+  it("typename should be correct", async () => {
+    const typename = await surface.eval((Skia) => {
+      const path = Skia.Path.Make();
+      return path.__typename__;
+    });
+    return expect(typename).toBe("Path");
+  });
   it("should be possible to call dispose on a path", async () => {
     await surface.eval((Skia) => {
       const path = Skia.Path.Make();


### PR DESCRIPTION
typenames had extra quotes. For instance `"Shader"` instead of `Shader`.