### PR TITLE
Fix snapshot opacity on Android

### DIFF
--- a/example/src/Examples/API/Snapshot.tsx
+++ b/example/src/Examples/API/Snapshot.tsx
@@ -82,14 +82,29 @@ const Component = () => {
   return (
     <ScrollView style={styles.scrollview}>
       <Text>Hello World!</Text>
-      <View
-        style={{ width: 80, height: 80, backgroundColor: "blue", opacity: 0.5 }}
-      >
+      <View style={{ flexDirection: "row" }}>
+        <View
+          style={{
+            width: 80,
+            height: 80,
+            backgroundColor: "blue",
+            opacity: 0.5,
+          }}
+        >
+          <View
+            style={{
+              width: 40,
+              height: 40,
+              backgroundColor: "green",
+              opacity: 0.5,
+            }}
+          />
+        </View>
         <View
           style={{
             width: 40,
             height: 40,
-            backgroundColor: "green",
+            backgroundColor: "red",
             opacity: 0.5,
           }}
         />

--- a/example/src/Examples/API/Snapshot.tsx
+++ b/example/src/Examples/API/Snapshot.tsx
@@ -82,6 +82,18 @@ const Component = () => {
   return (
     <ScrollView style={styles.scrollview}>
       <Text>Hello World!</Text>
+      <View
+        style={{ width: 80, height: 80, backgroundColor: "blue", opacity: 0.5 }}
+      >
+        <View
+          style={{
+            width: 40,
+            height: 40,
+            backgroundColor: "green",
+            opacity: 0.5,
+          }}
+        />
+      </View>
       <Button
         title={"Press me to increment (" + counter + ")"}
         onPress={() => setCounter((i) => i + 1)}

--- a/package/android/src/main/java/com/shopify/reactnative/skia/ViewScreenshotService.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/ViewScreenshotService.java
@@ -93,7 +93,9 @@ public class ViewScreenshotService {
             }
 
             // Draw ourselves
+            canvas.saveLayerAlpha(null, Math.round(view.getAlpha() * 255));
             view.draw(canvas);
+            canvas.restore();
 
             // Enable children again
             for (int i = 0; i < visibleChildren.size(); i++) {


### PR DESCRIPTION
The opacity of the view wasn't taken into account when drawing to Canvas. Since the View is responsible to draw onto the canvas, we use the opacity layer API to respect the opacity.