### PR TITLE
Fix doc typo

### DIFF
--- a/docs/docs/animated-images.md
+++ b/docs/docs/animated-images.md
@@ -50,10 +50,10 @@ export const AnimatedImages = () => {
 
 ## Manual API
 
-To load an image as a `SkAnimatedImage`` object, we offer a `useAnimatedImage` hook:
+To load an image as a `SkAnimatedImage` object, we offer a `useAnimatedImage` hook:
 
 ```tsx twoslash
-import {useAnimatedImageValue} from "@shopify/react-native-skia";
+import {useAnimatedImage} from "@shopify/react-native-skia";
 
 // bird is an SkAnimatedImage
 const bird = useAnimatedImage(

--- a/docs/docs/animated-images.md
+++ b/docs/docs/animated-images.md
@@ -58,7 +58,7 @@ import {useAnimatedImage} from "@shopify/react-native-skia";
 // bird is an SkAnimatedImage
 const bird = useAnimatedImage(
   require("../../assets/birdFlying.gif")
-);
+)!;
 // SkAnimatedImage offers 3 methods: decodeNextFrame(), getCurrentFrame(), and currentFrameDuration()
 // getCurrentFrame() returns a regular SkImage
 const image = bird.getCurrentFrame();

--- a/docs/docs/animated-images.md
+++ b/docs/docs/animated-images.md
@@ -56,7 +56,7 @@ To load an image as a `SkAnimatedImage`` object, we offer a `useAnimatedImage` h
 import {useAnimatedImageValue} from "@shopify/react-native-skia";
 
 // bird is an SkAnimatedImage
-const bird = useAnimatedImageValue(
+const bird = useAnimatedImage(
   require("../../assets/birdFlying.gif")
 );
 // SkAnimatedImage offers 3 methods: decodeNextFrame(), getCurrentFrame(), and currentFrameDuration()


### PR DESCRIPTION
@dcarubia the reason this typo didn't get caught statically is because our dependency with Reanimated is optional and they we dynamically link to it doesn't account for its types (yet). We could fix this in a separate PR to be on the safer side.