### PR TITLE
Add android namespace to support react-native 0.73

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -113,6 +113,11 @@ buildscript {
 }
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+      namespace "com.shopify.reactnative.skia"
+    }
+
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
     defaultConfig {


### PR DESCRIPTION
As stated here https://github.com/react-native-community/discussions-and-proposals/issues/671 React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x and this will require all the libraries to specify a namespace in their build.gradle file.
 