### PR TITLE
Export JsiSkImage

### DIFF
--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,4 +1,5 @@
 import "./skia/NativeSetup";
+export { JsiSkImage } from "./skia/web/JsiSkImage";
 export * from "./renderer";
 export * from "./renderer/Canvas";
 export * from "./renderer/Offscreen";


### PR DESCRIPTION
On the Web, there are many ways to decode images.
Skia uses synchronous decoded for both React Native and Web via `MakeImageFromEncoded`.
Now, on web it is also possible to use browser image decoding via `MakeImageFromCanvasImageSource`.
Image decoding on the browser is exclusively asynchronous.

Now, we are working on a polyfill of canvas-wasm that uses the browser APIs directly (https://www.youtube.com/watch?v=3p3NI1yIgcM).
In this environment, synchronous image decoding is not available at all (`MakeImageFromEncoded` doesn't exists).
The goal of this PR is to expose the JsiSkImage constructor so that users can create SkImage from any source they would like (as long as it implements the `Image` interface from CanvasKit).

Alternative solutions would be:
* Add support for `MakeImageFromEncodedAsync` in React Native Skia. I felt this many add entropy as other assets such as font wouldn't have such method.
* Add support for `MakeImageFromCanvasImageSource` (web only). Which I am not a big fan of as it would introduce a web only API to the project.

Exporting the JsiSkImage class feels like the best way to let CanvasKit implementations deal with Image decoding on their own.
