### PR TITLE
Add ellipsisText method

### DIFF
--- a/package/src/skia/types/Font/Font.ts
+++ b/package/src/skia/types/Font/Font.ts
@@ -11,7 +11,21 @@ export interface FontMetrics {
   bounds?: SkRect; // smallest rect containing all glyphs (relative to 0,0)
 }
 
+export type EllipsizeMode = "clip" | "head" | "middle" | "tail";
+export type EllipsisParams = {
+  text: string;
+  width: number;
+  mode: EllipsizeMode;
+};
+
 export interface SkFont extends SkJSIInstance<"Font"> {
+  /**
+   * Returns ellipsize text.
+   * @param args
+   * @param paint
+   */
+  ellipsisText(args: EllipsisParams, paint?: SkPaint): string;
+
   /**
    * Returns the advance width of text.
    * The advance is the normal distance to move before drawing additional text.


### PR DESCRIPTION
```tsx
const font = useFont(require('Roboto.ttf'), 14);
const clip = font.ellipsisText({ text: "Hello World", type: 'clip', width: 60 });
const head = font.ellipsisText({ text: "Hello World", type: 'head', width: 60 });
const middle = font.ellipsisText({ text: "Hello World", type: 'middle', width: 60 });
const tail = font.ellipsisText({ text: "Hello World", type: 'tail', width: 60 });
```
Result:
<img width="183" alt="image" src="https://github.com/Shopify/react-native-skia/assets/43195241/fc908af9-89e5-48b3-ae1e-cf52828a2230">
