### PR TITLE
Skia Jest Environnement

### DIFF
--- a/example/globalJestSetup.js
+++ b/example/globalJestSetup.js
@@ -1,7 +1,0 @@
-const globalSetup = async () => {
-  const { LoadSkiaWeb } = require("../package/src/web/LoadSkiaWeb");
-  await LoadSkiaWeb();
-};
-
-// eslint-disable-next-line import/no-default-export
-export default globalSetup;

--- a/example/jestEnv.js
+++ b/example/jestEnv.js
@@ -1,4 +1,17 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
+import CanvasKitInit from "canvaskit-wasm/bin/full/canvaskit";
+
+const LoadSkiaWeb = async (opts) => {
+  if (global.CanvasKit !== undefined) {
+    return;
+  }
+  const CanvasKit = await CanvasKitInit(opts);
+  // The CanvasKit API is stored on the global object and used
+  // to create the JsiSKApi in the Skia.web.ts file.
+  return CanvasKit;
+};
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 const NodeEnvironment = require("jest-environment-node").TestEnvironment;
 
 class SkiaEnvironment extends NodeEnvironment {
@@ -8,9 +21,6 @@ class SkiaEnvironment extends NodeEnvironment {
 
   async setup() {
     await super.setup();
-    const {
-      LoadSkiaWeb,
-    } = require("@shopify/react-native-skia/lib/commonjs/web/LoadSkiaWeb");
     this.global.CanvasKit = await LoadSkiaWeb();
   }
 

--- a/example/package.json
+++ b/example/package.json
@@ -81,7 +81,6 @@
       "<rootDir>/lib/typescript",
       "setup.(ts|tsx)$"
     ],
-    "globalSetup": "<rootDir>/globalJestSetup.js",
     "setupFilesAfterEnv": [
       "<rootDir>/node_modules/react-native-gesture-handler/jestSetup.js",
       "<rootDir>/jestSetup.js"

--- a/example/src/App.spec.tsx
+++ b/example/src/App.spec.tsx
@@ -1,5 +1,5 @@
 /**
- * @jest-environment ../package/jestEnv.js
+ * @jest-environment ./jestEnv.js
  */
 import "react-native";
 import React from "react";

--- a/example/src/App.spec.tsx
+++ b/example/src/App.spec.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment ../package/jestEnv.js
+ */
 import "react-native";
 import React from "react";
 // Test renderer must be required after react-native.

--- a/example/src/Examples/Examples.test.tsx
+++ b/example/src/Examples/Examples.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment ./jestEnv.js
+ */
 import "react-native";
 import React from "react";
 // Test renderer must be required after react-native.

--- a/package/globalJestSetup.js
+++ b/package/globalJestSetup.js
@@ -1,6 +1,0 @@
-module.exports = async () => {
-  const {
-    LoadSkiaWeb,
-  } = require("@shopify/react-native-skia/lib/commonjs/web/LoadSkiaWeb");
-  await LoadSkiaWeb();
-};

--- a/package/jestEnv.js
+++ b/package/jestEnv.js
@@ -1,0 +1,24 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const NodeEnvironment = require("jest-environment-node").TestEnvironment;
+
+class SkiaEnvironment extends NodeEnvironment {
+  constructor(config, context) {
+    super(config, context);
+  }
+
+  async setup() {
+    await super.setup();
+    const {
+      LoadSkiaWeb,
+    } = require("@shopify/react-native-skia/lib/commonjs/web/LoadSkiaWeb");
+    await LoadSkiaWeb();
+  }
+
+  async teardown() {}
+
+  getVmContext() {
+    return super.getVmContext();
+  }
+}
+
+module.exports = SkiaEnvironment;

--- a/package/package.json
+++ b/package/package.json
@@ -83,7 +83,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
-    "@types/jest": "^28.1.6",
+    "@types/jest": "29.5.6",
     "@types/pixelmatch": "^5.2.4",
     "@types/pngjs": "^6.0.1",
     "@types/react-native": "0.70.6",
@@ -92,7 +92,7 @@
     "eslint": "8.21.0",
     "eslint-config-react-native-wcandillon": "3.9.0",
     "eslint-plugin-reanimated": "2.0.0",
-    "jest": "28.1.3",
+    "jest": "29.6.4",
     "merge-dirs": "^0.2.1",
     "pixelmatch": "^5.3.0",
     "pngjs": "^6.0.0",


### PR DESCRIPTION
Allow to run Skia tests in parallel. We might still offer the globalConfig option for people who are not planning to run their tests in parallel

fixes #1883 

* [ ] Document
* [ ] Put back the global env config?