### PR TITLE
fix undefined behavior of _drawingMode

### DIFF
--- a/package/cpp/rnskia/RNSkView.h
+++ b/package/cpp/rnskia/RNSkView.h
@@ -398,7 +398,7 @@ private:
 
   std::shared_ptr<RNSkValue> _onSize;
   std::function<void()> _onSizeUnsubscribe;
-  RNSkDrawingMode _drawingMode;
+  RNSkDrawingMode _drawingMode = RNSkDrawingMode::Default;
   size_t _nativeId;
 
   size_t _drawingLoopId = 0;


### PR DESCRIPTION
`RNSkDrawingMode _drawingMode` has no initialized value.

While in android, if user not specify `mode` prop, the `setMode` function will never be invoked and thus the `setDrawingMode` function will not be invoked. Causing `_drawingMode` remains uninitialized, which is an undefined behavior.

We noticed that in some runtime (testing on a Huawei device), `_drawingMode == RNSkDrawingMode::Continuous` will become true while not setting the `mode` prop, causing unnecessary render, which significantly increased battery consumption.