### PR TITLE
Fix translation in makeViewScreenshotFromTag

### DIFF
--- a/example/src/Examples/API/Snapshot.tsx
+++ b/example/src/Examples/API/Snapshot.tsx
@@ -65,10 +65,10 @@ export const Snapshot = () => {
             <ImageShader
               image={image}
               fit="contain"
-              x={20}
-              y={20}
-              width={width - 40}
-              height={width - 120}
+              x={0}
+              y={0}
+              width={width}
+              height={width}
             />
           </Shader>
         </Fill>
@@ -81,6 +81,37 @@ const Component = () => {
   const [counter, setCounter] = useState(0);
   return (
     <ScrollView style={styles.scrollview}>
+      <View
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: 200,
+          height: 200,
+        }}
+      >
+        <View
+          style={{
+            position: "absolute",
+            transform: [{ translateX: 20 }, { translateY: 100 }],
+            top: 0,
+            left: 0,
+            width: 80,
+            height: 80,
+            backgroundColor: "red",
+          }}
+        />
+        <View
+          style={{
+            position: "absolute",
+            top: 100,
+            left: 100,
+            width: 80,
+            height: 80,
+            backgroundColor: "blue",
+          }}
+        />
+      </View>
       <Text>Hello World!</Text>
       <View style={{ flexDirection: "row" }}>
         <View

--- a/package/android/src/main/java/com/shopify/reactnative/skia/ViewScreenshotService.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/ViewScreenshotService.java
@@ -174,8 +174,8 @@ public class ViewScreenshotService {
 
         // Create a new matrix for translation
         final Matrix translateMatrix = new Matrix();
-        final float dx = view.getLeft() + view.getPaddingLeft() + view.getTranslationX();
-        final float dy = view.getTop() + view.getPaddingTop() + view.getTranslationY();
+        final float dx = view.getLeft() + view.getPaddingLeft();
+        final float dy = view.getTop() + view.getPaddingTop();
         translateMatrix.setTranslate(dx, dy);
 
         // Pre-concatenate the current matrix of the canvas with the translation and transformation matrices of the view

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -755,7 +755,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-syntax-jsx@^7.22.5":
+"@babel/plugin-syntax-jsx@^7.22.5", "@babel/plugin-syntax-jsx@^7.7.2":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz#a6b68e84fb76e759fc3b93e901876ffabbe1d918"
   integrity sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==


### PR DESCRIPTION
When we added support for the transformation matrix (#1649), we forgot to remove it from `dx` and `dy`.
Thanks @august-byrne for catching this.

fixes #1958