### PR TITLE
#1960: Fixing Android render jank

### DIFF
--- a/package/android/src/main/java/com/shopify/reactnative/skia/PlatformContext.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/PlatformContext.java
@@ -1,7 +1,5 @@
 package com.shopify.reactnative.skia;
 
-import android.app.Application;
-import android.graphics.Bitmap;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
@@ -10,7 +8,6 @@ import android.view.Choreographer;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
@@ -21,14 +18,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 public class PlatformContext {
     @DoNotStrip
     private final HybridData mHybridData;
 
     private final ReactContext mContext;
+
+    private final Handler mHandler = new Handler(Looper.getMainLooper());
 
     private boolean _drawLoopActive = false;
     private boolean _isPaused = false;
@@ -68,7 +65,7 @@ public class PlatformContext {
 
     @DoNotStrip
     public void notifyTaskReadyOnMainThread() {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
+        mHandler.post(new Runnable() {
             @Override
             public void run() {
                 notifyTaskReady();
@@ -83,7 +80,7 @@ public class PlatformContext {
 
     @DoNotStrip
     public void raise(final String message) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
+        mHandler.post(new Runnable() {
             @Override
             public void run() {
                 mContext.handleException(new Exception(message));
@@ -97,7 +94,7 @@ public class PlatformContext {
             return;
         }
         _drawLoopActive = true;
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
+        mHandler.post(new Runnable() {
             @Override
             public void run() {
                 postFrameLoop();
@@ -169,7 +166,7 @@ public class PlatformContext {
         Log.i(TAG, "Resume");
         if(_drawLoopActive) {
             // Restart draw loop
-            new Handler(Looper.getMainLooper()).post(new Runnable() {
+            mHandler.post(new Runnable() {
                 @Override
                 public void run() {
                     postFrameLoop();


### PR DESCRIPTION
## Background

We've got reports showing that Skia on Android seems to only render at half speed. It doesn't seem like it is a cpu issue as the cpu load is low when we observe the problem.

Some measurement was done by printing out timing info in the `onSurfaceTextureUpdated` callback in RNSkia's `SkiaBaseView.java` file that showed this behavior.

## Reproduction:

To reproduce the problem we need to make a small example that will change something visible on screen like the background-color on every frame. This can be done in Javascript like in the following reproduction where we drive rendering through a REA shared value that toggles between two colors on every frame.

_Swap out the Breathe.txt file in the RNSkia Example project with the following code:_

```ts
import React, { useEffect } from "react";
import { Canvas, Fill } from "@shopify/react-native-skia";
import {
  useSharedValue,
  withRepeat,
  withTiming,
  useDerivedValue,
} from "react-native-reanimated";

const c1 = "#61bea2";
const c2 = "#529ca0";

export const Breathe = () => {
  const loop = useSharedValue(0);
  const temp = useSharedValue("#FFF");
  const color = useDerivedValue(() => {
    console.log("color:", temp.value);
    temp.value = temp.value === c1 ? c2 : c1;
    return temp.value;
  }, [loop]);

  useEffect(() => {
    loop.value = withRepeat(withTiming(1, { duration: 1000 }), undefined, true);
  }, []);

  return (
    <Canvas style={{ flex: 1 }}>
      <Fill color={color} />
    </Canvas>
  );
};
```

## Finding the problem

The first path taken was to look into why `onSurfaceTextureUpdated` was called in our setup. The callback is used in the file [TextureView.java]( https://android.googlesource.com/platform/frameworks/base/+/master/core/java/ android/view/TextureView.java) in the Android source code in a method call `applyUpdated()`.

The [documentation](https://developer.android.com/reference/android/view/TextureView.SurfaceTexture Listener) states that `onSurfaceTextureUpdated` is called as a result of calling `SurfaceTexture#updateTexImage()`. After doing some investigation setting breakpoints in the `onSurfaceTextureUpdated` callback it was clear that the callstack showed that this came from the draw method in `TextureView.java` as a result of the Android view system calling the `draw` method on the `TextureView`.

After some additional peeking into the source code it is clear that the TextureView will be re-rendered when we swap OpenGL buffers from within Skia to push the rendered contents to the screen calling `eglSwapBuffers`.

> **NOTE:** This is the main difference between using the `TextureView` and
> then `SurfaceView` - the `TextureView` will be rendered as part of the view
> hierarcy in Android to be able to use features like transforms, opacity and
> zindex. This is why the draw method is called for every frame when we update
> the underlying surcace by calling `eglSwapBuffers`.

## Solution

The solution to this problem was due to a small detail in the `SkiaBaseView.java` file which @wcandillon also found in his suggested fix.

In RN Skia on Android we'd like to be notified on every new frame that is rendered to the screen - something that we use the `Coreographer` interface to post these update requests (almost like `requestAnimationFrame` in JS). We're posting these requests on the main thread to make sure we do our rendering on the main thread.

To post a task on the main thread we ask the Looper interface for the main looper like this:

```java
new Handler(Looper.getMainLooper()).post(... our request)
```

The problem with this is that the `getMainLooper` function needs to be synchronized (ie. block the thread) to make sure that the main looper is initialized before we can get a reference to it. This is done in the `Looper.java` file in the Android source code:

```java
public static @NonNull Looper getMainLooper() {
    synchronized (Looper.class) {
        return sMainLooper;
    }
}
```

So when we call `getMainLooper()` every frame we also perform synchronization on the main thread which will block the thread for a short while. This is the reason why we see the `onSurfaceTextureUpdated` callback being called so many times - the main thread is blocked and the TextureView is rendered as a result of the `eglSwapBuffers` call.

The solution - and also the suggested way to handle using the main looper - is to cache the main looper in a class variable and then use that cached variable instead of calling `getMainLooper` every frame.

## Regression

This bug was introduced when we moved away from rendering on a separate thread to get more instant drawing to screen for our Skia components.

Fixes #1960
Superseds #1965