### PR TITLE
fix: typo in JsiSkParagraphBuilder.h that leads to build errors

### DIFF
--- a/package/cpp/api/JsiSkParagraphBuilder.h
+++ b/package/cpp/api/JsiSkParagraphBuilder.h
@@ -11,7 +11,7 @@
 #include <JsiSkParagraph.h>
 #include <JsiSkParagraphStyle.h>
 #include <JsiSkTextStyle.h>
-#include <JsiSkTypefaceFontProvider.h>
+#include <JsiSkTypeFaceFontProvider.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"


### PR DESCRIPTION
When building on EAS for Android, file names seem to be case sensitive, so the reference to `JsiSkTypefaceFontProvider.h` fails with `file not found` since the file has an uppercase `F` in `TypeFace`. Might be worth adding a smoke test that runs a build on an OS that's case sensitive.

```
/home/expo/workingdir/build/node_modules/@shopify/react-native-skia/android/../cpp/api/JsiSkParagraphBuilder.h:14:10: fatal error: 'JsiSkTypefaceFontProvider.h' file not found
  #include <JsiSkTypefaceFontProvider.h>
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  1 error generated.
```