### PR TITLE
Fix reset of useClock value on component re-rendering

### DIFF
--- a/package/src/external/reanimated/interpolators.ts
+++ b/package/src/external/reanimated/interpolators.ts
@@ -1,5 +1,9 @@
-import type { ExtrapolationType, SharedValue } from "react-native-reanimated";
-import { useMemo } from "react";
+import type {
+  ExtrapolationType,
+  FrameInfo,
+  SharedValue,
+} from "react-native-reanimated";
+import { useMemo, useRef } from "react";
 
 import type { SkPath, SkPoint } from "../../skia/types";
 import { interpolatePaths, interpolateVector } from "../../animation";
@@ -19,9 +23,11 @@ export const notifyChange = (value: SharedValue<unknown>) => {
 
 export const useClock = () => {
   const clock = useSharedValue(0);
-  useFrameCallback((info) => {
+  const callback = useRef((info: FrameInfo) => {
+    "worklet";
     clock.value = info.timeSinceFirstFrame;
-  });
+  }).current;
+  useFrameCallback(callback);
   return clock;
 };
 


### PR DESCRIPTION
I encountered the clock.value being reset to 0 when the component was re-rendered.

Sample code:
```TS
function App() {
  const [state, setState] = useState(0);
  const clock = useClock();

  // rerender every 2 seconds
  useEffect(() => {
    setInterval(() => {
      setState((v) => v + 1);
    }, 2000);
  }, []);

  // read clock.value on each re-render(React state changes)
  useEffect(() => {
    console.log({
      clockValue: clock.value,
      elapsedTime: `${state * 2}seconds`,
    });
  }, [clock, state]);

  return null;
}
```

Current behaviour result, reset clock.value on each re-render:
<img width="500" alt="Screenshot 2023-12-09 at 15 42 08" src="https://github.com/Shopify/react-native-skia/assets/25579397/78e38754-f0e7-42ce-b290-a684bd0e2429">

Expected behavior, component re-renders no affect on clock.value:
<img width="500" alt="Screenshot 2023-12-09 at 15 44 43" src="https://github.com/Shopify/react-native-skia/assets/25579397/1683e020-d6a9-452e-9425-c583466c091c">


