### PR TITLE
Deprecates Skia values

### DIFF
--- a/package/src/animation/spring/runSpring.ts
+++ b/package/src/animation/spring/runSpring.ts
@@ -10,6 +10,9 @@ import { Spring } from "./Spring";
 import { createSpringEasing } from "./functions/spring";
 
 /**
+ * @deprecated Use Reanimated 3 for animations:
+ * https://shopify.github.io/react-native-skia/docs/animations/animations
+ *
  * Creates a new animation on an existing value that will be driven by
  * an animation value. The value will be run from / to the value in
  * params and modified by the provided easing curve for the length of

--- a/package/src/animation/spring/useSpring.ts
+++ b/package/src/animation/spring/useSpring.ts
@@ -10,6 +10,9 @@ import { Spring } from "./Spring";
 import { createSpringEasing } from "./functions/spring";
 
 /**
+ * @deprecated Use Reanimated 3 for animations:
+ * https://shopify.github.io/react-native-skia/docs/animations/animations
+ *
  * Creats a spring based animation value that will run whenever
  * the animation parameters change.
  * @param toOrParams

--- a/package/src/animation/timing/runTiming.ts
+++ b/package/src/animation/timing/runTiming.ts
@@ -8,6 +8,9 @@ import type {
 import { getResolvedParams } from "./functions";
 import { createTiming } from "./createTiming";
 /**
+ * @deprecated Use Reanimated 3 for animations:
+ * https://shopify.github.io/react-native-skia/docs/animations/animations
+ *
  * Creates a new animation on an existing value that will be driven by
  * an animation value. The value will be run from / to the value in
  * params and modified by the provided easing curve for the length of

--- a/package/src/animation/timing/useLoop.ts
+++ b/package/src/animation/timing/useLoop.ts
@@ -3,6 +3,9 @@ import type { TimingConfig } from "../types";
 import { useTiming } from "./useTiming";
 
 /**
+ * @deprecated Use Reanimated 3 for animations:
+ * https://shopify.github.io/react-native-skia/docs/animations/animations
+ *
  * Configures a looped timing value. The value will go back and forth
  * between 0 and 1 and back.
  * @param config Timing configuration for easing and duration

--- a/package/src/animation/timing/useTiming.ts
+++ b/package/src/animation/timing/useTiming.ts
@@ -12,6 +12,9 @@ import { getResolvedParams } from "./functions";
 import { createTiming } from "./createTiming";
 
 /**
+ * @deprecated Use Reanimated 3 for animations:
+ * https://shopify.github.io/react-native-skia/docs/animations/animations
+ *
  * Creats an animation value that will run whenever
  * the animation parameters change. The animation start immediately.
  * @param toOrParams

--- a/package/src/values/api.ts
+++ b/package/src/values/api.ts
@@ -21,10 +21,18 @@ Please use Reanimated instead: https://shopify.github.io/react-native-skia/docs/
 };
 
 export const ValueApi = {
+  /**
+   * @deprecated Use Reanimated 3
+   * for animating Skia: https://shopify.github.io/react-native-skia/docs/animations/animations
+   */
   createValue<T>(initialValue: T): SkiaMutableValue<T> {
     deprecatedWarning();
     return SkiaValueApi.createValue(initialValue);
   },
+  /**
+   * @deprecated Use Reanimated 3
+   * for animating Skia: https://shopify.github.io/react-native-skia/docs/animations/animations
+   */
   createComputedValue<R>(
     cb: () => R,
     values: SkiaValue<unknown>[]
@@ -32,10 +40,18 @@ export const ValueApi = {
     deprecatedWarning();
     return SkiaValueApi.createComputedValue(cb, values);
   },
+  /**
+   * @deprecated Use Reanimated 3
+   * for animating Skia: https://shopify.github.io/react-native-skia/docs/animations/animations
+   */
   createClockValue(): SkiaClockValue {
     deprecatedWarning();
     return SkiaValueApi.createClockValue();
   },
+  /**
+   * @deprecated Use Reanimated 3
+   * for animating Skia: https://shopify.github.io/react-native-skia/docs/animations/animations
+   */
   createAnimation<S extends AnimationState = AnimationState>(
     cb: (t: number, state: S | undefined) => S
   ): SkiaAnimation {

--- a/package/src/values/api.ts
+++ b/package/src/values/api.ts
@@ -1,8 +1,45 @@
-import type { ISkiaValueApi } from "./types";
+import type {
+  AnimationState,
+  ISkiaValueApi,
+  SkiaAnimation,
+  SkiaClockValue,
+  SkiaMutableValue,
+  SkiaValue,
+} from "./types";
 
 declare global {
   var SkiaValueApi: ISkiaValueApi;
 }
 
 const { SkiaValueApi } = global;
-export const ValueApi = SkiaValueApi;
+
+const deprecatedWarning = () => {
+  console.warn(
+    `Skia values are deprecated and will be removed in the next Skia release.
+Please use Reanimated instead: https://shopify.github.io/react-native-skia/docs/animations/animations`
+  );
+};
+
+export const ValueApi = {
+  createValue<T>(initialValue: T): SkiaMutableValue<T> {
+    deprecatedWarning();
+    return SkiaValueApi.createValue(initialValue);
+  },
+  createComputedValue<R>(
+    cb: () => R,
+    values: SkiaValue<unknown>[]
+  ): SkiaValue<R> {
+    deprecatedWarning();
+    return SkiaValueApi.createComputedValue(cb, values);
+  },
+  createClockValue(): SkiaClockValue {
+    deprecatedWarning();
+    return SkiaValueApi.createClockValue();
+  },
+  createAnimation<S extends AnimationState = AnimationState>(
+    cb: (t: number, state: S | undefined) => S
+  ): SkiaAnimation {
+    deprecatedWarning();
+    return SkiaValueApi.createAnimation(cb);
+  },
+};

--- a/package/src/values/hooks/useClockValue.ts
+++ b/package/src/values/hooks/useClockValue.ts
@@ -3,6 +3,9 @@ import { useEffect, useMemo } from "react";
 import { ValueApi } from "../api";
 
 /**
+ * @deprecated Use Reanimated 3
+ * for animating Skia: https://shopify.github.io/react-native-skia/docs/animations/animations
+ *
  * @returns A new value that will be updated on every frame redraw with the
  * number of milliseconds elapsed since the value was started.
  * The clock is created in the stopped state.

--- a/package/src/values/hooks/useComputedValue.ts
+++ b/package/src/values/hooks/useComputedValue.ts
@@ -4,6 +4,9 @@ import { ValueApi } from "../api";
 import { isValue } from "../../renderer/processors/Animations";
 
 /**
+ * @deprecated Use Reanimated 3
+ * for animating Skia: https://shopify.github.io/react-native-skia/docs/animations/animations
+ *
  * Creates a new computed value - a value that will calculate its value depending
  * on other values.
  * @param cb Callback to calculate new value

--- a/package/src/values/hooks/useValue.ts
+++ b/package/src/values/hooks/useValue.ts
@@ -4,6 +4,9 @@ import { ValueApi } from "../api";
 import type { SkiaMutableValue } from "../types";
 
 /**
+ * @deprecated Use Reanimated 3
+ * for animating Skia: https://shopify.github.io/react-native-skia/docs/animations/animations
+ *
  * Creates a new value that holds some data.
  * @param v Value to hold
  * @returns A Value of type of v

--- a/package/src/values/hooks/useValueEffect.ts
+++ b/package/src/values/hooks/useValueEffect.ts
@@ -3,6 +3,9 @@ import { useEffect } from "react";
 import type { SkiaValue } from "../types";
 
 /**
+ * @deprecated Use Reanimated 3
+ * for animating Skia: https://shopify.github.io/react-native-skia/docs/animations/animations
+ *
  * Sets up an effect that will be run whenever the value changes
  * @param value Value to subscribe to changes on
  * @param cb Callback to run when value changes

--- a/package/src/values/types.ts
+++ b/package/src/values/types.ts
@@ -48,26 +48,26 @@ export interface ISkiaValueApi {
    * Creates a new value that holds the initial value and that
    * can be changed.
    */
-  createValue: <T>(initialValue: T) => SkiaMutableValue<T>;
+  createValue<T>(initialValue: T): SkiaMutableValue<T>;
   /**
    * Creates a computed value. This is a calculated value that returns the result of
    * a function that is called with the values of the dependencies.
    */
-  createComputedValue: <R>(
+  createComputedValue<R>(
     cb: () => R,
     values: Array<SkiaValue<unknown>>
-  ) => SkiaValue<R>;
+  ): SkiaValue<R>;
   /**
    * Creates a clock value where the value is the number of milliseconds elapsed
    * since the clock was created
    */
-  createClockValue: () => SkiaClockValue;
+  createClockValue(): SkiaClockValue;
   /**
    * Creates an animation that is driven from a clock and updated every frame.
    * @param cb Callback to calculate next value from time.
    * @returns An animation object that can control a value.
    */
-  createAnimation: <S extends AnimationState = AnimationState>(
+  createAnimation<S extends AnimationState = AnimationState>(
     cb: (t: number, state: S | undefined) => S
-  ) => SkiaAnimation;
+  ): SkiaAnimation;
 }


### PR DESCRIPTION
Skia values as been soft deprecated in favor of Reanimated since a while now.
So goal of this PR is throw a deprecation warning so we can remove them completely.
The removal of this API is expected to be a substantial clean up in the code base as well as enable future work on performance improvement.

* [ ] Add @deprecate jsdoc