### PR TITLE
docs: expo installation command

### DIFF
--- a/docs/docs/getting-started/web.mdx
+++ b/docs/docs/getting-started/web.mdx
@@ -21,7 +21,7 @@ You can use React Native Skia without React Native Web.
 Using React Native Skia on Expo web is reasonably straightforward.
 We provide a script that will work well with the setup:
 ```bash
-$ expo install @shopify/react-native-skia
+$ npx expo install @shopify/react-native-skia
 $ yarn setup-skia-web
 ```
 


### PR DESCRIPTION
### Docs changes

Changed expo installation command.

Old:
```bash
 expo install @shopify/react-native-skia
```

Above command will break if user has not installed expo globally.

Updated: 
```bash
npx expo install @shopify/react-native-skia
```