### PR TITLE
Fix substancial performance bottleneck fon ParagraphBuilderFactory

### DIFF
--- a/package/cpp/api/JsiSkApi.h
+++ b/package/cpp/api/JsiSkApi.h
@@ -24,6 +24,7 @@
 #include "JsiSkMaskFilterFactory.h"
 #include "JsiSkMatrix.h"
 #include "JsiSkPaint.h"
+#include "JsiSkParagraphBuilderFactory.h"   
 #include "JsiSkParagraphBuilder.h"
 #include "JsiSkPath.h"
 #include "JsiSkPathEffect.h"

--- a/package/cpp/api/JsiSkApi.h
+++ b/package/cpp/api/JsiSkApi.h
@@ -63,7 +63,9 @@ public:
    */
   JsiSkApi(jsi::Runtime &runtime, std::shared_ptr<RNSkPlatformContext> context)
       : JsiSkHostObject(context) {
-
+    // We create the system font manager eagerly since it has proven to be too slow 
+    // to do it on demand
+    JsiSkFontMgrFactory::getFontMgr(getContext());
     installFunction("Font", JsiSkFont::createCtor(context));
     installFunction("Paint", JsiSkPaint::createCtor(context));
     installFunction("RSXform", JsiSkRSXform::createCtor(context));

--- a/package/cpp/api/JsiSkApi.h
+++ b/package/cpp/api/JsiSkApi.h
@@ -24,8 +24,8 @@
 #include "JsiSkMaskFilterFactory.h"
 #include "JsiSkMatrix.h"
 #include "JsiSkPaint.h"
-#include "JsiSkParagraphBuilderFactory.h"   
 #include "JsiSkParagraphBuilder.h"
+#include "JsiSkParagraphBuilderFactory.h"
 #include "JsiSkPath.h"
 #include "JsiSkPathEffect.h"
 #include "JsiSkPathEffectFactory.h"
@@ -63,8 +63,8 @@ public:
    */
   JsiSkApi(jsi::Runtime &runtime, std::shared_ptr<RNSkPlatformContext> context)
       : JsiSkHostObject(context) {
-    // We create the system font manager eagerly since it has proven to be too slow 
-    // to do it on demand
+    // We create the system font manager eagerly since it has proven to be too
+    // slow to do it on demand
     JsiSkFontMgrFactory::getFontMgr(getContext());
     installFunction("Font", JsiSkFont::createCtor(context));
     installFunction("Paint", JsiSkPaint::createCtor(context));

--- a/package/cpp/api/JsiSkParagraphBuilder.h
+++ b/package/cpp/api/JsiSkParagraphBuilder.h
@@ -7,12 +7,12 @@
 
 #include <JsiSkFont.h>
 #include <JsiSkFontMgr.h>
+#include <JsiSkFontMgrFactory.h>
 #include <JsiSkHostObjects.h>
 #include <JsiSkParagraph.h>
 #include <JsiSkParagraphStyle.h>
 #include <JsiSkTextStyle.h>
 #include <JsiSkTypefaceFontProvider.h>
-#include <JsiSkFontMgrFactory.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"

--- a/package/cpp/api/JsiSkParagraphBuilder.h
+++ b/package/cpp/api/JsiSkParagraphBuilder.h
@@ -12,6 +12,7 @@
 #include <JsiSkParagraphStyle.h>
 #include <JsiSkTextStyle.h>
 #include <JsiSkTypefaceFontProvider.h>
+#include <JsiSkFontMgrFactory.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
@@ -113,7 +114,8 @@ public:
                                  sk_sp<SkFontMgr> fontManager)
       : JsiSkHostObject(std::move(context)) {
     _fontCollection = sk_make_sp<para::FontCollection>();
-    _fontCollection->setDefaultFontManager(JsiSkFontMgrFactory::getFontMgr(context));
+    auto fontMgr = JsiSkFontMgrFactory::getFontMgr(getContext());
+    _fontCollection->setDefaultFontManager(fontMgr);
     if (fontManager != nullptr) {
       _fontCollection->setAssetFontManager(fontManager);
     }

--- a/package/cpp/api/JsiSkParagraphBuilder.h
+++ b/package/cpp/api/JsiSkParagraphBuilder.h
@@ -113,7 +113,7 @@ public:
                                  sk_sp<SkFontMgr> fontManager)
       : JsiSkHostObject(std::move(context)) {
     _fontCollection = sk_make_sp<para::FontCollection>();
-    _fontCollection->setDefaultFontManager(getContext()->createFontMgr());
+    _fontCollection->setDefaultFontManager(JsiSkFontMgrFactory::getFontMgr(context));
     if (fontManager != nullptr) {
       _fontCollection->setAssetFontManager(fontManager);
     }
@@ -125,35 +125,4 @@ private:
   std::unique_ptr<para::ParagraphBuilder> _builder;
   sk_sp<para::FontCollection> _fontCollection;
 };
-
-/**
- Implementation of the ParagraphBuilderFactory for making ParagraphBuilder JSI
- object
- */
-class JsiSkParagraphBuilderFactory : public JsiSkHostObject {
-public:
-  JSI_HOST_FUNCTION(Make) {
-    // Get paragraph style from params
-    auto paragraphStyle =
-        count > 0 ? JsiSkParagraphStyle::fromValue(runtime, arguments[0])
-                  : para::ParagraphStyle();
-
-    // get font manager
-    auto fontMgr =
-        count > 1 ? JsiSkTypefaceFontProvider::fromValue(runtime, arguments[1])
-                  : nullptr;
-
-    // Create the paragraph builder
-    return jsi::Object::createFromHostObject(
-        runtime, std::make_shared<JsiSkParagraphBuilder>(
-                     getContext(), paragraphStyle, fontMgr));
-  }
-
-  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkParagraphBuilderFactory, Make))
-
-  explicit JsiSkParagraphBuilderFactory(
-      std::shared_ptr<RNSkPlatformContext> context)
-      : JsiSkHostObject(std::move(context)) {}
-};
-
 } // namespace RNSkia

--- a/package/cpp/api/JsiSkParagraphBuilderFactory.h
+++ b/package/cpp/api/JsiSkParagraphBuilderFactory.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <jsi/jsi.h>
+
+#include <JsiSkParagraphBuilder.h>
+#include <JsiSkParagraphStyle.h>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
+
+#include "ParagraphBuilder.h"
+
+#pragma clang diagnostic pop
+
+
+namespace RNSkia {
+
+namespace jsi = facebook::jsi;
+
+namespace para = skia::textlayout;
+
+/**
+ Implementation of the ParagraphBuilderFactory for making ParagraphBuilder JSI
+ object
+ */
+class JsiSkParagraphBuilderFactory : public JsiSkHostObject {
+public:
+  JSI_HOST_FUNCTION(Make) {
+    // Get paragraph style from params
+    auto paragraphStyle =
+        count > 0 ? JsiSkParagraphStyle::fromValue(runtime, arguments[0])
+                  : para::ParagraphStyle();
+
+    // get font manager
+    auto fontMgr =
+        count > 1 ? JsiSkTypefaceFontProvider::fromValue(runtime, arguments[1])
+                  : nullptr;
+
+    // Create the paragraph builder
+    return jsi::Object::createFromHostObject(
+        runtime, std::make_shared<JsiSkParagraphBuilder>(
+                     getContext(), paragraphStyle, fontMgr));
+  }
+
+  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkParagraphBuilderFactory, Make))
+
+  explicit JsiSkParagraphBuilderFactory(
+      std::shared_ptr<RNSkPlatformContext> context)
+      : JsiSkHostObject(std::move(context)) {}
+};
+
+} // namespace RNSkia

--- a/package/cpp/api/JsiSkParagraphBuilderFactory.h
+++ b/package/cpp/api/JsiSkParagraphBuilderFactory.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <utility>
+
 #include <jsi/jsi.h>
 
 #include <JsiSkParagraphBuilder.h>

--- a/package/cpp/api/JsiSkParagraphBuilderFactory.h
+++ b/package/cpp/api/JsiSkParagraphBuilderFactory.h
@@ -12,7 +12,6 @@
 
 #pragma clang diagnostic pop
 
-
 namespace RNSkia {
 
 namespace jsi = facebook::jsi;


### PR DESCRIPTION
fixes #2073 

This issue was nicely caught by @Nodonisko.

On every call to the paragraphbuilder factory, we would recreate an instance of the Android FontMgr, which can do a lot of work parsing all the fonts. This PR fixes the issues by doing this work only once.
We took advantage of this PR to move the ParagraphBuilderFactory in its own file, it was causing too much trouble and was also asymetric.
