### PR TITLE
Address Memory Leak in Headless `draw`

### DIFF
--- a/docs/docs/getting-started/headless.md
+++ b/docs/docs/getting-started/headless.md
@@ -34,6 +34,8 @@ import { Fill, draw } from "@shopify/react-native-skia/lib/commonjs/headless";
         />
     </Group>, width, height);
   console.log(image.encodeToBase64());
+  // Dispose the image after use to prevent a memory leak.
+  image.dispose();
 })();
 ```
 

--- a/package/src/headless/index.ts
+++ b/package/src/headless/index.ts
@@ -27,5 +27,6 @@ export const draw = (element: ReactNode, width: number, height: number) => {
   root.dom.render(ctx);
   surface.flush();
   const image = surface.makeImageSnapshot();
+  surface.dispose();
   return image;
 };


### PR DESCRIPTION
This is my first time opening a PR on this project, so please let me know if you want me to provide more context!

I outlined the [issue here](https://github.com/Shopify/react-native-skia/issues/2079) and I _believe_ this fixes it. If you'd like me to write a test to prove it - I can presumably use the test I shared in the issue, but it will add real latency to your CI!