### PR TITLE
Minor update to the headless API

### DIFF
--- a/docs/docs/getting-started/headless.md
+++ b/docs/docs/getting-started/headless.md
@@ -22,18 +22,21 @@ import { Fill, draw } from "@shopify/react-native-skia/lib/commonjs/headless";
   const height = 256;
   const r = size * 0.33;
   await LoadSkiaWeb();
-  const image = draw(
+  const {image, surface} = draw(
     <Group blendMode="multiply">
-        <Circle cx={r} cy={r} r={r} color="cyan" />
-        <Circle cx={size - r} cy={r} r={r} color="magenta" />
-        <Circle
-          cx={size/2}
-          cy={size - r}
-          r={r}
-          color="yellow"
-        />
+      <Circle cx={r} cy={r} r={r} color="cyan" />
+      <Circle cx={size - r} cy={r} r={r} color="magenta" />
+      <Circle
+        cx={size/2}
+        cy={size - r}
+        r={r}
+        color="yellow"
+      />
     </Group>, width, height);
   console.log(image.encodeToBase64());
+  // Cleaning up CanvasKit resources
+  image.dispose();
+  surface.dispose();
 })();
 ```
 

--- a/docs/docs/getting-started/headless.md
+++ b/docs/docs/getting-started/headless.md
@@ -15,14 +15,15 @@ You will notice in the example below that the import URL looks different than th
 
 ```tsx
 import { LoadSkiaWeb } from "@shopify/react-native-skia/lib/commonjs/web/LoadSkiaWeb";
-import { Fill, draw } from "@shopify/react-native-skia/lib/commonjs/headless";
+import { Fill, makeOffscreenSurface, drawOffscreen } from "@shopify/react-native-skia/lib/commonjs/headless";
 
 (async () => {
   const width = 256;
   const height = 256;
   const r = size * 0.33;
   await LoadSkiaWeb();
-  const {image, surface} = draw(
+  const surface = makeOffscreenSurface(width, height);
+  const image = draw(surface,
     <Group blendMode="multiply">
       <Circle cx={r} cy={r} r={r} color="cyan" />
       <Circle cx={size - r} cy={r} r={r} color="magenta" />
@@ -32,7 +33,7 @@ import { Fill, draw } from "@shopify/react-native-skia/lib/commonjs/headless";
         r={r}
         color="yellow"
       />
-    </Group>, width, height);
+    </Group>);
   console.log(image.encodeToBase64());
   // Cleaning up CanvasKit resources
   image.dispose();

--- a/package/src/headless/index.ts
+++ b/package/src/headless/index.ts
@@ -27,5 +27,5 @@ export const draw = (element: ReactNode, width: number, height: number) => {
   root.dom.render(ctx);
   surface.flush();
   const image = surface.makeImageSnapshot();
-  return image;
+  return { image, surface };
 };

--- a/package/src/headless/index.ts
+++ b/package/src/headless/index.ts
@@ -6,13 +6,14 @@ import type { ReactNode } from "react";
 import { JsiSkApi } from "../skia/web";
 import { SkiaRoot } from "../renderer/Reconciler";
 import { JsiDrawingContext } from "../dom/types";
+import type { SkSurface } from "../skia";
 
 export * from "../renderer/components";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let Skia: any;
 
-export const draw = (element: ReactNode, width: number, height: number) => {
+export const makeOffscreenSurface = (width: number, height: number) => {
   if (!Skia) {
     Skia = JsiSkApi(CanvasKit);
   }
@@ -20,12 +21,15 @@ export const draw = (element: ReactNode, width: number, height: number) => {
   if (surface === null) {
     throw new Error("Couldn't create surface!");
   }
+  return surface;
+};
+
+export const drawOffscreen = (surface: SkSurface, element: ReactNode) => {
   const root = new SkiaRoot(Skia);
   root.render(element);
   const canvas = surface.getCanvas();
   const ctx = new JsiDrawingContext(Skia, canvas);
   root.dom.render(ctx);
   surface.flush();
-  const image = surface.makeImageSnapshot();
-  return { image, surface };
+  return surface.makeImageSnapshot();
 };


### PR DESCRIPTION
fixes #2079
The goal of this PR is to decouple the surface creation from the drawing of the image allowing to 1) reuse the surface for multiple drawings and 2) have more explicit resource management.

Thank you @JKring for bringing this to our attention.