### PR TITLE
Update download artifact step

### DIFF
--- a/.github/workflows/android-ubuntu.yml
+++ b/.github/workflows/android-ubuntu.yml
@@ -43,6 +43,7 @@ jobs:
           workflow: "build-skia.yml"
           repo: shopify/react-native-skia
           path: artifacts
+          branch: main
 
       - name: Copy Artifacts to libs folder
         run: yarn workflow-copy-libs

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -46,6 +46,7 @@ jobs:
           workflow: "build-skia.yml"
           repo: shopify/react-native-skia
           path: artifacts
+          branch: main
 
       - name: Copy Artifacts to libs folder
         run: yarn workflow-copy-libs

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           workflow: "build-skia.yml"
           path: artifacts
+          branch: main
 
       - name: Copy Artifacts to libs folder
         run: yarn workflow-copy-libs

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -39,6 +39,7 @@ jobs:
           workflow: "build-skia.yml"
           repo: shopify/react-native-skia
           path: artifacts
+          branch: main
 
       - name: Copy Artifacts to libs folder
         run: yarn workflow-copy-libs


### PR DESCRIPTION
Now that we run the build skia step outside the main branch, we need to download only the successful artifacts from the main branch. Running the build-skia outside the main branch, won't upload any artifacts.