### PR TITLE
Make font property mandatory in Text

### DIFF
--- a/docs/docs/text/text.md
+++ b/docs/docs/text/text.md
@@ -11,7 +11,7 @@ Please note that the y origin of the Text is the bottom of the text, not the top
 | Name        | Type       |  Description                                                    |
 |:------------|:-----------|:----------------------------------------------------------------|
 | text        | `string`   | Text to draw                                                    |
-| font        | `SkFont`   | Font to use (optional)                                          |
+| font        | `SkFont`   | Font to use                                                     |
 | x           | `number`   | Left position of the text (default is 0)                        |
 | y           | `number`   | Bottom position the text (default is 0, the )                   |
 
@@ -30,7 +30,6 @@ export const HelloWorld = () => {
         x={0}
         y={fontSize}
         text="Hello World"
-        // Font is optional
         font={font}
       />
     </Canvas>

--- a/package/cpp/rnskia/dom/props/FontProp.h
+++ b/package/cpp/rnskia/dom/props/FontProp.h
@@ -31,12 +31,7 @@ public:
             "Expected SkFont object or null/undefined for the Font property.");
       }
     } else {
-      auto fm = SkFontMgr::RefDefault();
-      sk_sp<SkTypeface> typeface =
-          fm->legacyMakeTypeface(nullptr, SkFontStyle());
-      auto font = std::make_shared<SkFont>(SkFont(typeface));
-      font->setSize(14);
-      setDerivedValue(font);
+      setDerivedValue(nullptr);
     }
   }
 

--- a/package/src/dom/nodes/drawings/Text.ts
+++ b/package/src/dom/nodes/drawings/Text.ts
@@ -23,21 +23,8 @@ export class TextNode extends JsiDrawingNode<TextProps, SkFont | null> {
 
   protected deriveProps() {
     const { font } = this.props;
-    if (font === null) {
+    if (!font) {
       return null;
-    } else if (font === undefined) {
-      console.warn(
-        "<Text />: the font property is mandatory on React Native Web"
-      );
-      return null;
-      // return this.Skia.Font(
-      //   this.Skia.FontMgr.System().matchFamilyStyle("System", {
-      //     width: 5,
-      //     weight: 400,
-      //     slant: 0,
-      //   }),
-      //   14
-      // );
     }
     return font;
   }

--- a/package/src/dom/types/Drawings.ts
+++ b/package/src/dom/types/Drawings.ts
@@ -109,7 +109,7 @@ export interface DiffRectProps extends DrawingNodeProps {
 }
 
 export interface TextProps extends DrawingNodeProps {
-  font?: SkFont | null;
+  font: SkFont | null;
   text: string;
   x: number;
   y: number;

--- a/package/src/renderer/__tests__/e2e/Text.spec.tsx
+++ b/package/src/renderer/__tests__/e2e/Text.spec.tsx
@@ -69,19 +69,6 @@ describe("Text", () => {
     checkImage(image, `snapshots/text/text-bounds-${surface.OS}.png`);
   });
 
-  // We test it only on Android and iOS now because there might be no default font on Web
-  itRunsE2eOnly("The font property is optional", async () => {
-    const image = await surface.draw(
-      <>
-        <Fill color="white" />
-        <Group>
-          <Text x={32} y={64} text="Hello World!" />
-        </Group>
-      </>
-    );
-    checkImage(image, `snapshots/text/text-default-font-${surface.OS}.png`);
-  });
-
   it("Should draw text along a circle", async () => {
     const font = fonts.RobotoMedium;
     const { Skia } = importSkia();


### PR DESCRIPTION
Currently the optional font property wasn't supported on web and relies on a to be deprecated API.
Now that we support the paragraph API which does use default system font, it seems fair to make this property mandatory again in `<Text />`