### PR TITLE
Make LoadSkiaWeb() load the CanvasKit wasm only once

### DIFF
--- a/package/src/web/LoadSkiaWeb.tsx
+++ b/package/src/web/LoadSkiaWeb.tsx
@@ -10,11 +10,14 @@ declare global {
   var CanvasKit: CanvasKitType;
 }
 
+let ckSharedPromise: Promise<CanvasKitType>;
+
 export const LoadSkiaWeb = async (opts?: CanvasKitInitOptions) => {
   if (global.CanvasKit !== undefined) {
     return;
   }
-  const CanvasKit = await CanvasKitInit(opts);
+  ckSharedPromise = ckSharedPromise ?? CanvasKitInit(opts);
+  const CanvasKit = await ckSharedPromise;
   // The CanvasKit API is stored on the global object and used
   // to create the JsiSKApi in the Skia.web.ts file.
   global.CanvasKit = CanvasKit;


### PR DESCRIPTION
Solution for #2121: "Using the WithSkiaWeb component multiple times (or rerender the same) while the CanvasKit wasn't loaded yet, produces a wasm download/parsing for each LoadSkiaWeb() call. This behavior overrides the global.CanvasKit variable, producing BindingError when CanvasKit needs to validate that an object is an instanceof something, such as "Paint"."

Instead of calling CanvasKitInit() for each LoadSkiaWeb(), a single promise is stored locally and reused (or created if it is the first call)