### PR TITLE
Fix regression

### DIFF
--- a/package/src/renderer/Canvas.tsx
+++ b/package/src/renderer/Canvas.tsx
@@ -84,6 +84,12 @@ export const Canvas = forwardRef<SkiaDomView, CanvasProps>(
       root.render(children);
     }, [children, root, redraw]);
 
+    useEffect(() => {
+      return () => {
+        root.unmount();
+      };
+    }, [root]);
+
     if (NATIVE_DOM) {
       return (
         <SkiaDomView

--- a/package/src/renderer/HostConfig.ts
+++ b/package/src/renderer/HostConfig.ts
@@ -82,7 +82,7 @@ export const skHostConfig: SkiaHostConfig = {
   noTimeout: -1,
 
   appendChildToContainer(container, child) {
-    debug("appendChildToContainer", container, child);
+    debug("appendChildToContainer");
     appendNode(container.root, child);
   },
 

--- a/package/src/renderer/Reconciler.tsx
+++ b/package/src/renderer/Reconciler.tsx
@@ -44,6 +44,10 @@ export class SkiaRoot {
     });
   }
 
+  unmount() {
+    skiaReconciler.updateContainer(null, this.root, null, () => {});
+  }
+
   get dom() {
     return this.container.root;
   }


### PR DESCRIPTION
When removing the dependency manager, we removed the unmounting of the reconciler by mistake:
https://github.com/Shopify/react-native-skia/commit/a34ff73af5bc56bafb33fe7912cdfa85d5b81892#diff-84330b05bbd892e5eacb478c69e714bc2e5f9a39dac3947a5eed1158cbe97230L59

fixes #2095