### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Get NPM Package name
         id: get_npm_package_name
-        run: echo "::set-output name=npm_package_name::$(yarn get-filename-npm| grep ^'shopify')"
+        run: echo "npm_package_name=$(yarn get-filename-npm| grep ^'shopify')" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifacts - NPM Package
         uses: actions/upload-artifact@v2
@@ -60,7 +60,7 @@ jobs:
 
       - name: Get NPM Package version
         id: get_npm_package_version
-        run: echo "::set-output name=npm_package_version::$(yarn get-version-npm| tail -2)"
+        run: echo "npm_package_version=$(yarn get-version-npm| tail -2)" >> "$GITHUB_OUTPUT"
 
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter