### PR TITLE
useTextureValue

### DIFF
--- a/example/src/Examples/Performance/PerformanceRects.tsx
+++ b/example/src/Examples/Performance/PerformanceRects.tsx
@@ -1,5 +1,13 @@
-import { Canvas, Rect, Skia, Group } from "@shopify/react-native-skia";
-import type { SkRect } from "@shopify/react-native-skia";
+import {
+  Canvas,
+  Rect,
+  Skia,
+  Group,
+  useTextureValue,
+  Image,
+  rect,
+} from "@shopify/react-native-skia";
+import type { SkImage, SkRect } from "@shopify/react-native-skia";
 import React, { useMemo, useState } from "react";
 import {
   StyleSheet,
@@ -15,16 +23,21 @@ import Animated, {
   useSharedValue,
 } from "react-native-reanimated";
 
-const Size = 25;
 const Increaser = 50;
+const size = { width: 25, height: 25 * 0.45 };
+const rct = rect(0, 0, size.width, size.height);
 
 export const PerformanceDrawingTest: React.FC = () => {
+  const texture = useTextureValue(
+    <Group>
+      <Rect rect={rct} color="#00ff00" />
+      <Rect rect={rct} color="#4060A3" style="stroke" strokeWidth={2} />
+    </Group>,
+    size
+  );
   const [numberOfBoxes, setNumberOfBoxes] = useState(150);
 
   const { width, height } = useWindowDimensions();
-
-  const SizeWidth = Size;
-  const SizeHeight = Size * 0.45;
 
   const pos = useSharedValue<{ x: number; y: number }>({
     x: width / 2,
@@ -37,13 +50,13 @@ export const PerformanceDrawingTest: React.FC = () => {
         .fill(0)
         .map((_, i) =>
           Skia.XYWHRect(
-            5 + ((i * Size) % width),
-            25 + Math.floor(i / (width / Size)) * Size,
-            SizeWidth,
-            SizeHeight
+            5 + ((i * size.width) % width),
+            25 + Math.floor(i / (width / size.width)) * size.width,
+            size.width,
+            size.height
           )
         ),
-    [numberOfBoxes, width, SizeWidth, SizeHeight]
+    [numberOfBoxes, width]
   );
 
   const gesture = Gesture.Pan().onChange((e) => (pos.value = e));
@@ -68,7 +81,7 @@ export const PerformanceDrawingTest: React.FC = () => {
       <View style={{ flex: 1 }}>
         <Canvas style={styles.container} mode="default">
           {rects.map((_, i) => (
-            <Rct pos={pos} key={i} rct={rects[i]} />
+            <Rct pos={pos} key={i} translation={rects[i]} texture={texture} />
           ))}
         </Canvas>
         <GestureDetector gesture={gesture}>
@@ -81,20 +94,28 @@ export const PerformanceDrawingTest: React.FC = () => {
 
 interface RctProps {
   pos: SharedValue<{ x: number; y: number }>;
-  rct: SkRect;
+  translation: SkRect;
+  texture: SharedValue<SkImage | null>;
 }
 
-const Rct = ({ pos, rct }: RctProps) => {
+const Rct = ({ pos, texture, translation }: RctProps) => {
   const transform = useDerivedValue(() => {
-    const p1 = { x: rct.x, y: rct.y };
+    const p1 = { x: translation.x, y: translation.y };
     const p2 = pos.value;
     const r = Math.atan2(p2.y - p1.y, p2.x - p1.x);
-    return [{ rotate: r }];
+    return [
+      { translateX: translation.x },
+      { translateY: translation.y },
+      { rotate: r },
+    ];
   });
   return (
-    <Group transform={transform} origin={rct}>
-      <Rect rect={rct} color="#00ff00" />
-      <Rect rect={rct} color="#4060A3" style="stroke" strokeWidth={2} />
+    <Group transform={transform}>
+      <Image
+        image={texture}
+        rect={rect(0, 0, size.width, size.height)}
+        fit="cover"
+      />
     </Group>
   );
 };

--- a/package/src/dom/nodes/JsiSkDOM.ts
+++ b/package/src/dom/nodes/JsiSkDOM.ts
@@ -55,7 +55,6 @@ import type {
   Path1DPathEffectProps,
   Path2DPathEffectProps,
 } from "../types/PathEffects";
-import { NATIVE_DOM } from "../../renderer/HostComponents";
 import type { ParagraphProps } from "../types/Paragraph";
 
 import {
@@ -125,200 +124,200 @@ import { LayerNode } from "./LayerNode";
 import { ParagraphNode } from "./drawings/ParagraphNode";
 
 export class JsiSkDOM implements SkDOM {
-  constructor(private ctx: NodeContext) {}
+  constructor(private ctx: NodeContext, private native: boolean) {}
 
   Layer(props?: ChildrenProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.LayerNode(props ?? {})
       : new LayerNode(this.ctx, props ?? {});
   }
 
   Group(props?: GroupProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.GroupNode(props ?? {})
       : new GroupNode(this.ctx, props ?? {});
   }
 
   Paint(props: PaintProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.PaintNode(props ?? {})
       : new PaintNode(this.ctx, props);
   }
 
   // Drawings
   Fill(props?: DrawingNodeProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.FillNode(props ?? {})
       : new FillNode(this.ctx, props);
   }
 
   Image(props: ImageProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.ImageNode(props ?? {})
       : new ImageNode(this.ctx, props);
   }
 
   Circle(props: CircleProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.CircleNode(props ?? {})
       : new CircleNode(this.ctx, props);
   }
 
   Path(props: PathProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.PathNode(props ?? {})
       : new PathNode(this.ctx, props);
   }
 
   Line(props: LineProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.LineNode(props ?? {})
       : new LineNode(this.ctx, props);
   }
 
   Oval(props: OvalProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.OvalNode(props ?? {})
       : new OvalNode(this.ctx, props);
   }
 
   Patch(props: PatchProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.PatchNode(props ?? {})
       : new PatchNode(this.ctx, props);
   }
 
   Points(props: PointsProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.PointsNode(props ?? {})
       : new PointsNode(this.ctx, props);
   }
 
   Rect(props: RectProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.RectNode(props)
       : new RectNode(this.ctx, props);
   }
 
   RRect(props: RoundedRectProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.RRectNode(props)
       : new RRectNode(this.ctx, props);
   }
 
   Vertices(props: VerticesProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.VerticesNode(props)
       : new VerticesNode(this.ctx, props);
   }
 
   Text(props: TextProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.TextNode(props)
       : new TextNode(this.ctx, props);
   }
 
   TextPath(props: TextPathProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.TextPathNode(props)
       : new TextPathNode(this.ctx, props);
   }
 
   TextBlob(props: TextBlobProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.TextBlobNode(props)
       : new TextBlobNode(this.ctx, props);
   }
 
   Glyphs(props: GlyphsProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.GlyphsNode(props)
       : new GlyphsNode(this.ctx, props);
   }
 
   DiffRect(props: DiffRectProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.DiffRectNode(props)
       : new DiffRectNode(this.ctx, props);
   }
 
   Picture(props: PictureProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.PictureNode(props)
       : new PictureNode(this.ctx, props);
   }
 
   ImageSVG(props: ImageSVGProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.ImageSVGNode(props)
       : new ImageSVGNode(this.ctx, props);
   }
 
   // BlurMaskFilters
   BlurMaskFilter(props: BlurMaskFilterProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.BlurMaskFilterNode(props)
       : new BlurMaskFilterNode(this.ctx, props);
   }
 
   // ImageFilters
   BlendImageFilter(props: BlendImageFilterProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.BlendImageFilterNode(props)
       : new BlendImageFilterNode(this.ctx, props);
   }
 
   DropShadowImageFilter(props: DropShadowImageFilterProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.DropShadowImageFilterNode(props)
       : new DropShadowImageFilterNode(this.ctx, props);
   }
 
   DisplacementMapImageFilter(props: DisplacementMapImageFilterProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.DisplacementMapImageFilterNode(props)
       : new DisplacementMapImageFilterNode(this.ctx, props);
   }
 
   BlurImageFilter(props: BlurImageFilterProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.BlurImageFilterNode(props)
       : new BlurImageFilterNode(this.ctx, props);
   }
 
   OffsetImageFilter(props: OffsetImageFilterProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.OffsetImageFilterNode(props)
       : new OffsetImageFilterNode(this.ctx, props);
   }
 
   MorphologyImageFilter(props: MorphologyImageFilterProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.MorphologyImageFilterNode(props)
       : new MorphologyImageFilterNode(this.ctx, props);
   }
 
   RuntimeShaderImageFilter(props: RuntimeShaderImageFilterProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.RuntimeShaderImageFilterNode(props)
       : new RuntimeShaderImageFilterNode(this.ctx, props);
   }
 
   // Color Filters
   MatrixColorFilter(props: MatrixColorFilterProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.MatrixColorFilterNode(props)
       : new MatrixColorFilterNode(this.ctx, props);
   }
 
   BlendColorFilter(props: BlendColorFilterProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.BlendColorFilterNode(props)
       : new BlendColorFilterNode(this.ctx, props);
   }
 
   LumaColorFilter() {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.LumaColorFilterNode()
       : new LumaColorFilterNode(this.ctx);
   }
@@ -338,136 +337,136 @@ export class JsiSkDOM implements SkDOM {
   }
 
   LerpColorFilter(props: LerpColorFilterProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.LerpColorFilterNode(props)
       : new LerpColorFilterNode(this.ctx, props);
   }
 
   // Shaders
   Shader(props: ShaderProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.ShaderNode(props)
       : new ShaderNode(this.ctx, props);
   }
 
   ImageShader(props: ImageShaderProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.ImageShaderNode(props)
       : new ImageShaderNode(this.ctx, props);
   }
 
   ColorShader(props: ColorProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.ColorShaderNode(props)
       : new ColorNode(this.ctx, props);
   }
 
   SweepGradient(props: SweepGradientProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.SweepGradientNode(props)
       : new SweepGradientNode(this.ctx, props);
   }
 
   Turbulence(props: TurbulenceProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.TurbulenceNode(props)
       : new TurbulenceNode(this.ctx, props);
   }
 
   FractalNoise(props: FractalNoiseProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.FractalNoiseNode(props)
       : new FractalNoiseNode(this.ctx, props);
   }
 
   LinearGradient(props: LinearGradientProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.LinearGradientNode(props)
       : new LinearGradientNode(this.ctx, props);
   }
 
   RadialGradient(props: RadialGradientProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.RadialGradientNode(props)
       : new RadialGradientNode(this.ctx, props);
   }
 
   TwoPointConicalGradient(props: TwoPointConicalGradientProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.TwoPointConicalGradientNode(props)
       : new TwoPointConicalGradientNode(this.ctx, props);
   }
 
   // Path Effects
   CornerPathEffect(props: CornerPathEffectProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.CornerPathEffectNode(props)
       : new CornerPathEffectNode(this.ctx, props);
   }
 
   DiscretePathEffect(props: DiscretePathEffectProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.DiscretePathEffectNode(props)
       : new DiscretePathEffectNode(this.ctx, props);
   }
 
   DashPathEffect(props: DashPathEffectProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.DashPathEffectNode(props)
       : new DashPathEffectNode(this.ctx, props);
   }
 
   Path1DPathEffect(props: Path1DPathEffectProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.Path1DPathEffectNode(props)
       : new Path1DPathEffectNode(this.ctx, props);
   }
 
   Path2DPathEffect(props: Path2DPathEffectProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.Path2DPathEffectNode(props)
       : new Path2DPathEffectNode(this.ctx, props);
   }
 
   SumPathEffect() {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.SumPathEffectNode()
       : new SumPathEffectNode(this.ctx);
   }
 
   Line2DPathEffect(props: Line2DPathEffectProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.Line2DPathEffectNode(props)
       : new Line2DPathEffectNode(this.ctx, props);
   }
 
   Blend(props: BlendProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.BlendNode(props)
       : new BlendNode(this.ctx, props);
   }
 
   BackdropFilter(props: ChildrenProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.BackdropFilterNode(props)
       : new BackdropFilterNode(this.ctx, props);
   }
 
   Box(props: BoxProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.BoxNode(props)
       : new BoxNode(this.ctx, props);
   }
 
   BoxShadow(props: BoxShadowProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.BoxShadowNode(props)
       : new BoxShadowNode(this.ctx, props);
   }
 
   // Paragraph
   Paragraph(props: ParagraphProps) {
-    return NATIVE_DOM
+    return this.native
       ? global.SkiaDomApi.ParagraphNode(props)
       : new ParagraphNode(this.ctx, props);
   }

--- a/package/src/external/reanimated/index.ts
+++ b/package/src/external/reanimated/index.ts
@@ -2,3 +2,4 @@ export * from "./useAnimatedImageValue";
 export * from "./useDerivedValueOnJS";
 export * from "./renderHelpers";
 export * from "./interpolators";
+export * from "./textures";

--- a/package/src/external/reanimated/moduleWrapper.ts
+++ b/package/src/external/reanimated/moduleWrapper.ts
@@ -63,6 +63,7 @@ export const stopMapper: (mapperID: number) => void =
   Reanimated2?.stopMapper || throwOnMissingReanimated;
 
 export const runOnJS = Reanimated2?.runOnJS || throwOnMissingReanimated;
+export const runOnUI = Reanimated2?.runOnUI || throwOnMissingReanimated;
 
 export const useAnimatedReaction: <T>(
   prepare: () => T,

--- a/package/src/external/reanimated/textures.ts
+++ b/package/src/external/reanimated/textures.ts
@@ -1,0 +1,33 @@
+import type { ReactElement } from "react";
+import { useEffect, useMemo } from "react";
+import type { SharedValue } from "react-native-reanimated";
+
+import { Skia } from "../../skia";
+import type { SkImage, SkPicture, SkSize } from "../../skia/types";
+import { drawAsPicture } from "../../renderer/Offscreen";
+
+import { runOnUI, useSharedValue } from "./moduleWrapper";
+
+const createTexture = (
+  texture: SharedValue<SkImage | null>,
+  picture: SkPicture,
+  size: SkSize
+) => {
+  "worklet";
+  const surface = Skia.Surface.MakeOffscreen(size.width, size.height)!;
+  const canvas = surface.getCanvas();
+  canvas.drawPicture(picture);
+  surface.flush();
+  texture.value = surface.makeImageSnapshot();
+};
+
+export const useTextureValue = (element: ReactElement, size: SkSize) => {
+  const picture = useMemo(() => {
+    return drawAsPicture(element);
+  }, [element]);
+  const texture = useSharedValue<SkImage | null>(null);
+  useEffect(() => {
+    runOnUI(createTexture)(texture, picture, size);
+  }, [texture, picture, size]);
+  return texture;
+};

--- a/package/src/headless/index.ts
+++ b/package/src/headless/index.ts
@@ -25,7 +25,7 @@ export const makeOffscreenSurface = (width: number, height: number) => {
 };
 
 export const drawOffscreen = (surface: SkSurface, element: ReactNode) => {
-  const root = new SkiaRoot(Skia);
+  const root = new SkiaRoot(Skia, false);
   root.render(element);
   const canvas = surface.getCanvas();
   const ctx = new JsiDrawingContext(Skia, canvas);

--- a/package/src/renderer/Canvas.tsx
+++ b/package/src/renderer/Canvas.tsx
@@ -75,7 +75,7 @@ export const Canvas = forwardRef<SkiaDomView, CanvasProps>(
     }, [innerRef]);
 
     const root = useMemo(
-      () => new SkiaRoot(Skia, redraw, getNativeId),
+      () => new SkiaRoot(Skia, NATIVE_DOM, redraw, getNativeId),
       [redraw, getNativeId]
     );
 

--- a/package/src/renderer/Container.tsx
+++ b/package/src/renderer/Container.tsx
@@ -13,9 +13,10 @@ export class Container {
   constructor(
     Skia: Skia,
     public redraw: () => void = () => {},
-    public getNativeId: () => number = () => 0
+    public getNativeId: () => number = () => 0,
+    native: boolean
   ) {
-    this.Sk = new JsiSkDOM({ Skia });
+    this.Sk = new JsiSkDOM({ Skia }, native);
     this._root = this.Sk.Group();
   }
 

--- a/package/src/renderer/Offscreen.tsx
+++ b/package/src/renderer/Offscreen.tsx
@@ -10,15 +10,24 @@ export const drawAsImage = (
   width: number,
   height: number
 ) => {
+  const picture = drawAsPicture(element);
   const surface = Skia.Surface.MakeOffscreen(width, height);
   if (!surface) {
     throw new Error("Could not create offscreen surface");
   }
   const canvas = surface.getCanvas();
-  const root = new SkiaRoot(Skia);
+  canvas.drawPicture(picture);
+  surface.flush();
+  return surface.makeImageSnapshot();
+};
+
+export const drawAsPicture = (element: ReactElement) => {
+  const recorder = Skia.PictureRecorder();
+  const canvas = recorder.beginRecording();
+  const root = new SkiaRoot(Skia, false);
   root.render(element);
   const ctx = new JsiDrawingContext(Skia, canvas);
   root.dom.render(ctx);
-  surface.flush();
-  return surface.makeImageSnapshot();
+  const picture = recorder.finishRecordingAsPicture();
+  return picture;
 };

--- a/package/src/renderer/Reconciler.tsx
+++ b/package/src/renderer/Reconciler.tsx
@@ -21,10 +21,11 @@ export class SkiaRoot {
 
   constructor(
     Skia: Skia,
+    native: boolean,
     redraw: () => void = () => {},
     getNativeId: () => number = () => 0
   ) {
-    this.container = new Container(Skia, redraw, getNativeId);
+    this.container = new Container(Skia, redraw, getNativeId, native);
     this.root = skiaReconciler.createContainer(
       this.container,
       0,
@@ -45,7 +46,9 @@ export class SkiaRoot {
   }
 
   unmount() {
-    skiaReconciler.updateContainer(null, this.root, null, () => {});
+    skiaReconciler.updateContainer(null, this.root, null, () => {
+      hostDebug("unmountContainer");
+    });
   }
 
   get dom() {

--- a/package/src/renderer/__tests__/setup.tsx
+++ b/package/src/renderer/__tests__/setup.tsx
@@ -175,7 +175,7 @@ export const importSkia = (): typeof SkiaExports => {
 
 export const getSkDOM = () => {
   const { Skia } = importSkia();
-  return new JsiSkDOM({ Skia });
+  return new JsiSkDOM({ Skia }, false);
 };
 
 export const PIXEL_RATIO = 3;
@@ -197,7 +197,7 @@ export const mountCanvas = (element: ReactNode) => {
   expect(ckSurface).toBeDefined();
   const canvas = ckSurface.getCanvas();
 
-  const root = new SkiaRoot(Skia);
+  const root = new SkiaRoot(Skia, false);
   root.render(element);
   return {
     surface: ckSurface,


### PR DESCRIPTION
The goal of this PR is to provide a zero-cost abstraction way to create a texture in React Native.
The current process of creating textures is documented at https://shopify.github.io/react-native-skia/docs/animations/textures/

First, we want to abstract the process of dealing with reanimated, just like we did for other animations hooks (https://shopify.github.io/react-native-skia/docs/animations/hooks).
From there, we also want to enable developers to use the declarative API to express offscreen drawing. To enable that, we needed to add an explicit switch between the JS and C++ SkiaDOM.