### PR TITLE
Fix invalid .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,14 +30,14 @@ DerivedData
 project.xcworkspace
 
 # Android/IntelliJ
-#
 build/
 .idea
 .gradle
 local.properties
 *.iml
 .cxx
-*.settings**
+# Legacy Eclipse Settings
+.settings/
 
 # Externals
 libs


### PR DESCRIPTION
This pattern for `.gitignore` is invalid and is causing an error when passed over to other tools