### PR TITLE
Remove last occurence of SkFontMgr::RefDefault()

### DIFF
--- a/package/cpp/api/JsiSkTypefaceFactory.h
+++ b/package/cpp/api/JsiSkTypefaceFactory.h
@@ -17,7 +17,8 @@ class JsiSkTypefaceFactory : public JsiSkHostObject {
 public:
   JSI_HOST_FUNCTION(MakeFreeTypeFaceFromData) {
     auto data = JsiSkData::fromValue(runtime, arguments[0]);
-    auto typeface = SkFontMgr::RefDefault()->makeFromData(std::move(data));
+    auto fontMgr = JsiSkFontMgrFactory::getFontMgr(getContext());
+    auto typeface = fontMgr->makeFromData(std::move(data));
     if (typeface == nullptr) {
       return jsi::Value::null();
     }


### PR DESCRIPTION
SkFontMgr::RefDefault() has been completely removed from Skia and this was the last occurence of this API in this repo.