### PR TITLE
Update react-native-skia.podspec to match documentation

### DIFF
--- a/package/react-native-skia.podspec
+++ b/package/react-native-skia.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   # optional - use expanded license entry instead:
   # s.license    = { :type => "MIT", :file => "LICENSE" }
   s.authors      = { "Your Name" => "yourname@email.com" }
-  s.platforms    = { :ios => "12.0" }
+  s.platforms    = { :ios => "13.0" }
   s.source       = { :git => "https://github.com/shopify/react-native-skia/react-native-skia.git", :tag => "#{s.version}" }
 
   s.requires_arc = true


### PR DESCRIPTION
We actually do not support iOS 12. This change reflects that.