### PR TITLE
Fix bridgeless support on iOS

### DIFF
--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
@@ -2,7 +2,6 @@
 
 #import <React/RCTBridge+Private.h>
 #import <React/RCTBridge.h>
-#import <ReactCommon/RCTTurboModule.h>
 
 #include <functional>
 #include <memory>
@@ -30,8 +29,8 @@ static void handleNotification(CFNotificationCenterRef center, void *observer,
 
 class RNSkiOSPlatformContext : public RNSkPlatformContext {
 public:
-  RNSkiOSPlatformContext(jsi::Runtime *runtime, RCTBridge *bridge)
-      : RNSkPlatformContext(runtime, bridge.jsCallInvoker,
+  RNSkiOSPlatformContext(jsi::Runtime *runtime, RCTBridge *bridge, std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker)
+      : RNSkPlatformContext(runtime, jsCallInvoker,
                             [[UIScreen mainScreen] scale]) {
 
     // We need to make sure we invalidate when modules are freed

--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
@@ -29,7 +29,9 @@ static void handleNotification(CFNotificationCenterRef center, void *observer,
 
 class RNSkiOSPlatformContext : public RNSkPlatformContext {
 public:
-  RNSkiOSPlatformContext(jsi::Runtime *runtime, RCTBridge *bridge, std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker)
+  RNSkiOSPlatformContext(
+      jsi::Runtime *runtime, RCTBridge *bridge,
+      std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker)
       : RNSkPlatformContext(runtime, jsCallInvoker,
                             [[UIScreen mainScreen] scale]) {
 

--- a/package/ios/RNSkia-iOS/SkiaManager.h
+++ b/package/ios/RNSkia-iOS/SkiaManager.h
@@ -12,6 +12,8 @@
 
 - (void)invalidate;
 
-- (instancetype)initWithBridge:(RCTBridge *)bridge jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker;
+- (instancetype)initWithBridge:(RCTBridge *)bridge
+                     jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)
+                                   jsInvoker;
 
 @end

--- a/package/ios/RNSkia-iOS/SkiaManager.h
+++ b/package/ios/RNSkia-iOS/SkiaManager.h
@@ -12,6 +12,6 @@
 
 - (void)invalidate;
 
-- (instancetype)initWithBridge:(RCTBridge *)bridge;
+- (instancetype)initWithBridge:(RCTBridge *)bridge jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker;
 
 @end

--- a/package/ios/RNSkia-iOS/SkiaManager.mm
+++ b/package/ios/RNSkia-iOS/SkiaManager.mm
@@ -24,7 +24,9 @@
   _skManager = nullptr;
 }
 
-- (instancetype)initWithBridge:(RCTBridge *)bridge jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker {
+- (instancetype)initWithBridge:(RCTBridge *)bridge
+                     jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)
+                                   jsInvoker {
   self = [super init];
   if (self) {
     RCTCxxBridge *cxxBridge = (RCTCxxBridge *)bridge;
@@ -36,7 +38,8 @@
       // Create the RNSkiaManager (cross platform)
       _skManager = std::make_shared<RNSkia::RNSkManager>(
           jsRuntime, jsInvoker,
-          std::make_shared<RNSkia::RNSkiOSPlatformContext>(jsRuntime, bridge, jsInvoker));
+          std::make_shared<RNSkia::RNSkiOSPlatformContext>(jsRuntime, bridge,
+                                                           jsInvoker));
     }
   }
   return self;

--- a/package/ios/RNSkia-iOS/SkiaManager.mm
+++ b/package/ios/RNSkia-iOS/SkiaManager.mm
@@ -6,8 +6,6 @@
 #import <React/RCTBridge.h>
 #import <React/RCTUIManager.h>
 
-#import <ReactCommon/RCTTurboModule.h>
-
 #import "RNSkiOSPlatformContext.h"
 
 @implementation SkiaManager {
@@ -26,7 +24,7 @@
   _skManager = nullptr;
 }
 
-- (instancetype)initWithBridge:(RCTBridge *)bridge {
+- (instancetype)initWithBridge:(RCTBridge *)bridge jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker {
   self = [super init];
   if (self) {
     RCTCxxBridge *cxxBridge = (RCTCxxBridge *)bridge;
@@ -37,8 +35,8 @@
 
       // Create the RNSkiaManager (cross platform)
       _skManager = std::make_shared<RNSkia::RNSkManager>(
-          jsRuntime, bridge.jsCallInvoker,
-          std::make_shared<RNSkia::RNSkiOSPlatformContext>(jsRuntime, bridge));
+          jsRuntime, jsInvoker,
+          std::make_shared<RNSkia::RNSkiOSPlatformContext>(jsRuntime, bridge, jsInvoker));
     }
   }
   return self;

--- a/package/ios/RNSkiaModule.mm
+++ b/package/ios/RNSkiaModule.mm
@@ -1,9 +1,11 @@
 
 #import "RNSkiaModule.h"
 #import <React/RCTBridge+Private.h>
+#import <ReactCommon/RCTTurboModule.h>
 
 @implementation RNSkiaModule {
   SkiaManager *skiaManager;
+  std::shared_ptr<facebook::react::CallInvoker> jsInvoker;
 }
 
 RCT_EXPORT_MODULE()
@@ -33,13 +35,17 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
     return @true;
   }
   RCTBridge *bridge = [RCTBridge currentBridge];
-  skiaManager = [[SkiaManager alloc] initWithBridge:bridge];
+  if (!jsInvoker) {
+    jsInvoker = bridge.jsCallInvoker;
+  }
+  skiaManager = [[SkiaManager alloc] initWithBridge:bridge jsInvoker:jsInvoker];
   return @true;
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params {
+  jsInvoker = params.jsInvoker;
   return std::make_shared<facebook::react::NativeSkiaModuleSpecJSI>(params);
 }
 #endif


### PR DESCRIPTION
# Why

solving crash when running with react-native new architecture mode with bridgeless mode

# How

in bridgeless mode, react-native does not support fallback for jsCallInvoker and the `bridge.jsCallInvoker` is nil. the app will crash when accessing null pointer. the pr tries to get jsCallInvoker from turbo module setup in new architecture mode.

# Test Plan

```sh
$ npx react-native@latest init RN074 --version nightly
$ yarn add @shopify/react-native-skia
$ cd ios
$ RCT_NEW_ARCH_ENABLED=1 pod install
# running app in xcode
```