### PR TITLE
Fix bug in reanimated buffers

### DIFF
--- a/package/src/external/reanimated/buffers.ts
+++ b/package/src/external/reanimated/buffers.ts
@@ -1,15 +1,19 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 import type { SkColor, SkHostRect, SkPoint, SkRSXform } from "../../skia/types";
 import { Skia } from "../../skia";
 
-import { useDerivedValue, useSharedValue } from "./moduleWrapper";
+import { useSharedValue } from "./moduleWrapper";
 import { notifyChange } from "./interpolators";
+import { startMapper, stopMapper } from "react-native-reanimated";
+import { WorkletFunction } from "react-native-reanimated/lib/typescript/reanimated2/commonTypes";
+
+type Modifier<T> = (input: T, index: number) => void;
 
 const useBuffer = <T>(
   size: number,
   bufferInitializer: () => T,
-  modifier: (input: T, index: number) => void
+  modifier: Modifier<T>
 ) => {
   const buffer = useMemo(
     () => new Array(size).fill(0).map(bufferInitializer),
@@ -17,37 +21,44 @@ const useBuffer = <T>(
     [size]
   );
   const transforms = useSharedValue(buffer);
-
-  useDerivedValue(() => {
+  const mod = modifier as WorkletFunction;
+  const deps = Object.values(mod.__closure ?? {});
+  const mapperId = startMapper(() => {
+    "worklet";
     buffer.forEach((val, index) => {
       modifier(val, index);
     });
-    // Assuming notifyChange is a function that notifies about the change in transforms.
-    notifyChange(transforms);
-  });
+   notifyChange(transforms);
+  }, deps);
+
+  useEffect(() => {
+    return () => {
+      stopMapper(mapperId);
+    }
+  }, [mapperId]);
 
   return transforms;
 };
 
 export const useRectBuffer = (
   size: number,
-  modifier: (input: SkHostRect, index: number) => void
+  modifier: Modifier<SkHostRect>
 ) => useBuffer(size, () => Skia.XYWHRect(0, 0, 0, 0), modifier);
 
 // Usage for RSXform Buffer
 export const useRSXformBuffer = (
   size: number,
-  modifier: (input: SkRSXform, index: number) => void
+  modifier: Modifier<SkRSXform>,
 ) => useBuffer(size, () => Skia.RSXform(1, 0, 0, 0), modifier);
 
 // Usage for Point Buffer
 export const usePointBuffer = (
   size: number,
-  modifier: (input: SkPoint, index: number) => void
+  modifier: Modifier<SkPoint>,
 ) => useBuffer(size, () => Skia.Point(0, 0), modifier);
 
 // Usage for Color Buffer
 export const useColorBuffer = (
   size: number,
-  modifier: (input: SkColor, index: number) => void
+  modifier: Modifier<SkColor>,
 ) => useBuffer(size, () => Skia.Color("black"), modifier);

--- a/package/src/external/reanimated/buffers.ts
+++ b/package/src/external/reanimated/buffers.ts
@@ -1,12 +1,12 @@
 import { useEffect, useMemo } from "react";
+import { startMapper, stopMapper } from "react-native-reanimated";
+import type { WorkletFunction } from "react-native-reanimated/lib/typescript/reanimated2/commonTypes";
 
 import type { SkColor, SkHostRect, SkPoint, SkRSXform } from "../../skia/types";
 import { Skia } from "../../skia";
 
 import { useSharedValue } from "./moduleWrapper";
 import { notifyChange } from "./interpolators";
-import { startMapper, stopMapper } from "react-native-reanimated";
-import { WorkletFunction } from "react-native-reanimated/lib/typescript/reanimated2/commonTypes";
 
 type Modifier<T> = (input: T, index: number) => void;
 
@@ -28,37 +28,29 @@ const useBuffer = <T>(
     buffer.forEach((val, index) => {
       modifier(val, index);
     });
-   notifyChange(values);
+    notifyChange(values);
   }, deps);
 
   useEffect(() => {
     return () => {
       stopMapper(mapperId);
-    }
+    };
   }, [mapperId]);
 
   return values;
 };
 
-export const useRectBuffer = (
-  size: number,
-  modifier: Modifier<SkHostRect>
-) => useBuffer(size, () => Skia.XYWHRect(0, 0, 0, 0), modifier);
+export const useRectBuffer = (size: number, modifier: Modifier<SkHostRect>) =>
+  useBuffer(size, () => Skia.XYWHRect(0, 0, 0, 0), modifier);
 
 // Usage for RSXform Buffer
-export const useRSXformBuffer = (
-  size: number,
-  modifier: Modifier<SkRSXform>,
-) => useBuffer(size, () => Skia.RSXform(1, 0, 0, 0), modifier);
+export const useRSXformBuffer = (size: number, modifier: Modifier<SkRSXform>) =>
+  useBuffer(size, () => Skia.RSXform(1, 0, 0, 0), modifier);
 
 // Usage for Point Buffer
-export const usePointBuffer = (
-  size: number,
-  modifier: Modifier<SkPoint>,
-) => useBuffer(size, () => Skia.Point(0, 0), modifier);
+export const usePointBuffer = (size: number, modifier: Modifier<SkPoint>) =>
+  useBuffer(size, () => Skia.Point(0, 0), modifier);
 
 // Usage for Color Buffer
-export const useColorBuffer = (
-  size: number,
-  modifier: Modifier<SkColor>,
-) => useBuffer(size, () => Skia.Color("black"), modifier);
+export const useColorBuffer = (size: number, modifier: Modifier<SkColor>) =>
+  useBuffer(size, () => Skia.Color("black"), modifier);

--- a/package/src/external/reanimated/buffers.ts
+++ b/package/src/external/reanimated/buffers.ts
@@ -20,7 +20,7 @@ const useBuffer = <T>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [size]
   );
-  const transforms = useSharedValue(buffer);
+  const values = useSharedValue(buffer);
   const mod = modifier as WorkletFunction;
   const deps = Object.values(mod.__closure ?? {});
   const mapperId = startMapper(() => {
@@ -28,7 +28,7 @@ const useBuffer = <T>(
     buffer.forEach((val, index) => {
       modifier(val, index);
     });
-   notifyChange(transforms);
+   notifyChange(values);
   }, deps);
 
   useEffect(() => {
@@ -37,7 +37,7 @@ const useBuffer = <T>(
     }
   }, [mapperId]);
 
-  return transforms;
+  return values;
 };
 
 export const useRectBuffer = (


### PR DESCRIPTION
Currently dependencies to a buffer weren't being used and any buffer used would trigger a redraw on every frame.
Now we only render if the buffer has changed.