### PR TITLE
useImageAsTexture()

### DIFF
--- a/docs/docs/animations/textures.md
+++ b/docs/docs/animations/textures.md
@@ -6,21 +6,22 @@ slug: /animations/textures
 ---
 
 In React Native Skia, Skia resources are shared across threads.
-We can use Reanimated to create textures on the UI thread, thus ensuring that we can display them onscreen canvas without needing to perform unnecessary copies.
+We can use Reanimated to create textures on the UI thread, thus ensuring that we can display them on the onscreen canvas without needing to perform unnecessary copies.
 
-## `useTextureValue`
+## `useTexture`
 
-The `useTextureValue` hook allows you to create textures from React elements. It takes a React element and its size as arguments, and returns a shared value containing the texture.
+This hook allows you to allows you to create textures from React elements.
+It takes a React element and the dimensions of the texture as arguments and returns a Reanimated shared value that contains the texture.
 
 ```tsx twoslash
 import { useWindowDimensions } from "react-native";
-import { useTextureValue } from "@shopify/react-native-skia";
+import { useTexture } from "@shopify/react-native-skia";
 import { Image, Rect, rect, Canvas, Fill } from "@shopify/react-native-skia";
 import React from "react";
 
 const Demo = () => {
   const {width, height} = useWindowDimensions();
-  const texture = useTextureValue(
+  const texture = useTexture(
       <Fill color="cyan" />,
     { width, height }
   );
@@ -32,15 +33,39 @@ const Demo = () => {
 }
 ```
 
-## `useTextureValueFromPicture`
+## `useImageAsTexture`
 
-The `useTextureValueFromPicture` hook is identical to `useTextureValue` but accepts a `SkPicture` as first argument instead of a React element.
+This hook allows you to upload an image to the GPU.
+It accepts an image source as argument.
+It will first load the image from its source and then upload it to the GPU.
+
+```tsx twoslash
+import { useWindowDimensions } from "react-native";
+import { useImageAsTexture } from "@shopify/react-native-skia";
+import { Image, Rect, rect, Canvas, Fill } from "@shopify/react-native-skia";
+import React from "react";
+
+const Demo = () => {
+  const {width, height} = useWindowDimensions();
+  const texture = useImageAsTexture(
+    require("./assets/image.png")
+  );
+  return (
+    <Canvas style={{ flex: 1 }}>
+      <Image image={texture} rect={{ x: 0, y: 0, width, height }} />
+    </Canvas>
+  )
+}
+```
+
+## `usePictureAsTexture`
+
+The hook allows you to create a texture from an `SkPicture`.
 This is useful to either generate the drawing commands outside the React lifecycle or using the imperative API to build a texture.
-
 
 ```tsx twoslash
 import {useWindowDimensions} from "react-native";
-import { useTextureValueFromPicture } from "@shopify/react-native-skia";
+import { usePictureAsTexture } from "@shopify/react-native-skia";
 import { Image, Rect, rect, Canvas, Fill, Skia } from "@shopify/react-native-skia";
 import React from "react";
 
@@ -51,7 +76,7 @@ const picture = rec.finishRecordingAsPicture();
 
 const Demo = () => {
   const {width, height} = useWindowDimensions();
-  const texture = useTextureValueFromPicture(
+  const texture = usePictureAsTexture(
     picture,
     { width, height }
   );

--- a/example/src/Examples/Performance/Atlas.tsx
+++ b/example/src/Examples/Performance/Atlas.tsx
@@ -1,7 +1,7 @@
 import {
   Canvas,
   Atlas,
-  useTextureValue,
+  useTexture,
   Group,
   rect,
   Rect,
@@ -30,7 +30,7 @@ const textureSize = {
 export const PerformanceDrawingTest = () => {
   const [numberOfBoxes, setNumberOfBoxes] = useState(300);
 
-  const texture = useTextureValue(
+  const texture = useTexture(
     <Group>
       <Rect
         rect={rect(strokeWidth / 2, strokeWidth / 2, size.width, size.height)}

--- a/package/src/external/reanimated/textures.tsx
+++ b/package/src/external/reanimated/textures.tsx
@@ -2,15 +2,21 @@ import { useEffect, useMemo } from "react";
 import type { ReactElement } from "react";
 import type { SharedValue } from "react-native-reanimated";
 
-import type { SkImage, SkPicture, SkSize } from "../../skia/types";
+import type {
+  DataSourceParam,
+  SkImage,
+  SkPicture,
+  SkSize,
+} from "../../skia/types";
 import {
   drawAsImageFromPicture,
   drawAsPicture,
 } from "../../renderer/Offscreen";
+import { Skia, useImage } from "../../skia";
 
 import { runOnUI, useSharedValue } from "./moduleWrapper";
 
-const createTextureValue = (
+const createTexture = (
   texture: SharedValue<SkImage | null>,
   picture: SkPicture,
   size: SkSize
@@ -19,20 +25,63 @@ const createTextureValue = (
   texture.value = drawAsImageFromPicture(picture, size);
 };
 
-export const useTextureValue = (element: ReactElement, size: SkSize) => {
+export const useTexture = (element: ReactElement, size: SkSize) => {
   const picture = useMemo(() => {
     return drawAsPicture(element);
   }, [element]);
-  return useTextureValueFromPicture(picture, size);
+  return usePictureAsTexture(picture, size);
+};
+
+export const useTextureAsValue = (element: ReactElement, size: SkSize) => {
+  console.warn("useTextureAsValue has been renamed to use useTexture");
+  return useTexture(element, size);
 };
 
 export const useTextureValueFromPicture = (
-  picture: SkPicture,
+  picture: SkPicture | null,
+  size: SkSize
+) => {
+  console.warn(
+    "useTextureValueFromPicture has been renamed to use usePictureAsTexture"
+  );
+  return usePictureAsTexture(picture, size);
+};
+
+export const usePictureAsTexture = (
+  picture: SkPicture | null,
   size: SkSize
 ) => {
   const texture = useSharedValue<SkImage | null>(null);
   useEffect(() => {
-    runOnUI(createTextureValue)(texture, picture, size);
+    if (picture !== null) {
+      runOnUI(createTexture)(texture, picture, size);
+    }
   }, [texture, picture, size]);
   return texture;
+};
+
+export const useImageAsTexture = (source: DataSourceParam) => {
+  const image = useImage(source);
+  const size = useMemo(() => {
+    if (image) {
+      return { width: image.width(), height: image.height() };
+    }
+    return { width: 0, height: 0 };
+  }, [image]);
+  const picture = useMemo(() => {
+    if (image) {
+      const recorder = Skia.PictureRecorder();
+      const canvas = recorder.beginRecording({
+        x: 0,
+        y: 0,
+        width: size.width,
+        height: size.height,
+      });
+      canvas.drawImage(image, 0, 0);
+      return recorder.finishRecordingAsPicture();
+    } else {
+      return null;
+    }
+  }, [size, image]);
+  return usePictureAsTexture(picture, size);
 };


### PR DESCRIPTION
This new hook allows people to easily load images as texture.
It takes care of the process to first access the image from its source and then uploading it to the GPU.

It is a very convenient piece because before that, the user would need to take care of loading the image from source and then upload to the GPU by explicitly drawing it using SkiaDOM or PictureRecorder API.