### PR TITLE
Fixing `LoadSkiaWeb` instructions for Expo Router

### DIFF
--- a/docs/docs/getting-started/web.mdx
+++ b/docs/docs/getting-started/web.mdx
@@ -58,7 +58,9 @@ import { renderRootComponent } from 'expo-router/build/renderRootComponent';
 
 import { LoadSkiaWeb } from '@shopify/react-native-skia/lib/module/web';
 
-LoadSkiaWeb().then(async () => {
+LoadSkiaWeb({
+  locateFile: (file) => `${file}`, // load CanvasKit from the `public/canvaskit.wasm` URL
+}).then(async () => {
   renderRootComponent(App);
 });
 ```


### PR DESCRIPTION
Calling `LoadSkiaWeb().then(...)` with no parameters doesn't work with Metro.

👉 It tries to call `/src/canvaskit.wasm` from the localhost URL instead of from the `node_modules`:
<img width="672" alt="CleanShot 2024-02-21 at 09 01 43@2x" src="https://github.com/Shopify/react-native-skia/assets/2856923/55f952a5-0837-4e13-bb9f-492473e7435d">

The only code that works for me is:

```js
LoadSkiaWeb({
  locateFile: (file) => `${file}`, // load CanvasKit from the `/public/canvaskit.wasm` URL
}).then(async () => {
  renderRootComponent(App);
});
```

=> `locateFile` tells `LoadSkiaWeb` to call the `/canvakit.wasm` endpoint that returns the file from `public/canvaskit.wasm`.

Therefore, suggesting updating the docs accordingly with this commit. 🤓

