### PR TITLE
Allows offscreen surfaces without onscreen surfaces

### DIFF
--- a/package/android/cpp/rnskia-android/SkiaOpenGLSurfaceFactory.cpp
+++ b/package/android/cpp/rnskia-android/SkiaOpenGLSurfaceFactory.cpp
@@ -29,7 +29,8 @@ sk_sp<SkSurface> SkiaOpenGLSurfaceFactory::makeOffscreenSurface(int width,
   SkSurfaceProps props(0, kUnknown_SkPixelGeometry);
 
   if (!SkiaOpenGLHelper::makeCurrent(
-          &ThreadContextHolder::ThreadSkiaOpenGLContext, ThreadContextHolder::ThreadSkiaOpenGLContext.gl1x1Surface)) {
+          &ThreadContextHolder::ThreadSkiaOpenGLContext,
+          ThreadContextHolder::ThreadSkiaOpenGLContext.gl1x1Surface)) {
     RNSkLogger::logToConsole(
         "Could not create EGL Surface from native window / surface. Could "
         "not set new surface as current surface.");

--- a/package/android/cpp/rnskia-android/SkiaOpenGLSurfaceFactory.cpp
+++ b/package/android/cpp/rnskia-android/SkiaOpenGLSurfaceFactory.cpp
@@ -28,11 +28,24 @@ sk_sp<SkSurface> SkiaOpenGLSurfaceFactory::makeOffscreenSurface(int width,
 
   SkSurfaceProps props(0, kUnknown_SkPixelGeometry);
 
+  if (!SkiaOpenGLHelper::makeCurrent(
+          &ThreadContextHolder::ThreadSkiaOpenGLContext, ThreadContextHolder::ThreadSkiaOpenGLContext.gl1x1Surface)) {
+    RNSkLogger::logToConsole(
+        "Could not create EGL Surface from native window / surface. Could "
+        "not set new surface as current surface.");
+    return nullptr;
+  }
+
   // Create texture
   auto texture =
       ThreadContextHolder::ThreadSkiaOpenGLContext.directContext
           ->createBackendTexture(width, height, colorType,
                                  skgpu::Mipmapped::kNo, GrRenderable::kYes);
+
+  if (!texture.isValid()) {
+    RNSkLogger::logToConsole("couldn't create offscreen texture %dx%d", width,
+                             height);
+  }
 
   struct ReleaseContext {
     SkiaOpenGLContext *context;


### PR DESCRIPTION
fixes #2253

@tsogzark found this really nice catch: creating an offscreen surface without a current opengl context. This is situation happens if no onscreen surfaces are alive.

This also updates the documentation to make it clear that right now, the JSX element for a texture drawing should have a stable identity (doesn't need to but this is probably what the user wants).