### PR TITLE
Fix non texture images

### DIFF
--- a/package/src/external/reanimated/interpolators.ts
+++ b/package/src/external/reanimated/interpolators.ts
@@ -8,7 +8,7 @@ import { useCallback, useMemo } from "react";
 import type { SkPath, SkPoint } from "../../skia/types";
 import { interpolatePaths, interpolateVector } from "../../animation";
 import { Skia } from "../../skia";
-import { Platform } from "../../Platform";
+import { isOnMainThread } from "../../renderer/Offscreen";
 
 import {
   useAnimatedReaction,
@@ -19,7 +19,7 @@ import {
 
 export const notifyChange = (value: SharedValue<unknown>) => {
   "worklet";
-  if (_WORKLET || Platform.OS === "web") {
+  if (isOnMainThread()) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (value as any)._value = value.value;
   }

--- a/package/src/renderer/Offscreen.tsx
+++ b/package/src/renderer/Offscreen.tsx
@@ -5,6 +5,7 @@ import type { SkPicture, SkSize } from "../skia/types";
 import { Skia } from "../skia";
 
 import { SkiaRoot } from "./Reconciler";
+import { Platform } from "../Platform";
 
 export const drawAsPicture = (element: ReactElement) => {
   const recorder = Skia.PictureRecorder();
@@ -33,5 +34,11 @@ export const drawAsImageFromPicture = (picture: SkPicture, size: SkSize) => {
   canvas.scale(pd, pd);
   canvas.drawPicture(picture);
   surface.flush();
-  return surface.makeImageSnapshot();
+  const image = surface.makeImageSnapshot();
+  // If we are not on the UI thread, we need to make the image non-texture.
+  // On the web, everything is on the same thread
+  if (!_WORKLET && Platform.OS !== "web") {
+    image.makeNonTextureImage();
+  }
+  return image;
 };

--- a/package/src/renderer/Offscreen.tsx
+++ b/package/src/renderer/Offscreen.tsx
@@ -45,7 +45,7 @@ export const drawAsImageFromPicture = (picture: SkPicture, size: SkSize) => {
   surface.flush();
   const image = surface.makeImageSnapshot();
   // If we are not on the main thread, we need to make the image non-texture.
-  if (isOnMainThread()) {
+  if (!isOnMainThread()) {
     image.makeNonTextureImage();
   }
   return image;

--- a/package/src/renderer/Offscreen.tsx
+++ b/package/src/renderer/Offscreen.tsx
@@ -7,6 +7,15 @@ import { Platform } from "../Platform";
 
 import { SkiaRoot } from "./Reconciler";
 
+// We call it main thread because on web main is JS thread
+export const isOnMainThread = () => {
+  "worklet";
+  return (
+    (typeof _WORKLET !== "undefined" && _WORKLET === true) ||
+    Platform.OS === "web"
+  );
+};
+
 export const drawAsPicture = (element: ReactElement) => {
   const recorder = Skia.PictureRecorder();
   const canvas = recorder.beginRecording();
@@ -35,9 +44,8 @@ export const drawAsImageFromPicture = (picture: SkPicture, size: SkSize) => {
   canvas.drawPicture(picture);
   surface.flush();
   const image = surface.makeImageSnapshot();
-  // If we are not on the UI thread, we need to make the image non-texture.
-  // On the web, everything is on the same thread
-  if (!_WORKLET && Platform.OS !== "web") {
+  // If we are not on the main thread, we need to make the image non-texture.
+  if (isOnMainThread()) {
     image.makeNonTextureImage();
   }
   return image;

--- a/package/src/renderer/Offscreen.tsx
+++ b/package/src/renderer/Offscreen.tsx
@@ -46,7 +46,8 @@ export const drawAsImageFromPicture = (picture: SkPicture, size: SkSize) => {
   const image = surface.makeImageSnapshot();
   // If we are not on the main thread, we need to make the image non-texture.
   if (!isOnMainThread()) {
-    image.makeNonTextureImage();
+    return image.makeNonTextureImage();
+  } else {
+    return image;
   }
-  return image;
 };

--- a/package/src/renderer/Offscreen.tsx
+++ b/package/src/renderer/Offscreen.tsx
@@ -3,9 +3,9 @@ import type { ReactElement } from "react";
 import { JsiDrawingContext } from "../dom/types";
 import type { SkPicture, SkSize } from "../skia/types";
 import { Skia } from "../skia";
+import { Platform } from "../Platform";
 
 import { SkiaRoot } from "./Reconciler";
-import { Platform } from "../Platform";
 
 export const drawAsPicture = (element: ReactElement) => {
   const recorder = Skia.PictureRecorder();


### PR DESCRIPTION
fixes #2252

Images created on the UI thread need to be made as non textures. In the documentation we are careful to use the texture terminology only for images created on the UI thread.