### PR TITLE
Fix bridgeless support on Android

### DIFF
--- a/package/android/CMakeLists.txt
+++ b/package/android/CMakeLists.txt
@@ -73,6 +73,8 @@ target_include_directories(
         "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi"
         "${NODE_MODULES_DIR}/react-native/ReactCommon"
         "${NODE_MODULES_DIR}/react-native/ReactCommon/react/nativemodule/core"
+        "${NODE_MODULES_DIR}/react-native/ReactCommon/runtimeexecutor"
+        "${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/jni"
         "${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni"
 
         cpp/jni/include
@@ -178,6 +180,34 @@ else()
 endif()
 message("-- FBJNI   : " ${FBJNI_LIBRARY})
 
+unset(REACTNATIVEJNI_LIB CACHE)
+if(${REACT_NATIVE_VERSION} GREATER_EQUAL 71)
+    # RN 0.71 distributes prebuilt binaries.
+    set (REACTNATIVEJNI_LIB "ReactAndroid::reactnativejni")
+else()
+    find_library(
+            REACTNATIVEJNI_LIB
+            reactnativejni
+            PATHS ${LIBRN_DIR}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
+endif()
+message("-- REACTNATIVEJNI   : " ${REACTNATIVEJNI_LIB})
+
+unset(RUNTIMEEXECUTOR_LIB CACHE)
+if(${REACT_NATIVE_VERSION} GREATER_EQUAL 71)
+    # RN 0.71 distributes prebuilt binaries.
+    set (RUNTIMEEXECUTOR_LIB "ReactAndroid::runtimeexecutor")
+else()
+    find_library(
+            RUNTIMEEXECUTOR_LIB
+            runtimeexecutor
+            PATHS ${LIBRN_DIR}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
+endif()
+message("-- RUNTIMEEXECUTOR   : " ${RUNTIMEEXECUTOR_LIB})
+
 unset(TURBOMODULES_LIB CACHE)
 if(${REACT_NATIVE_VERSION} GREATER_EQUAL 71)
     # RN 0.71 distributes prebuilt binaries.
@@ -199,6 +229,8 @@ target_link_libraries(
         ${FBJNI_LIBRARY}
         ${REACT_LIB}
         ${JSI_LIB}
+        ${REACTNATIVEJNI_LIB}
+        ${RUNTIMEEXECUTOR_LIB}
         ${TURBOMODULES_LIB}
         ${SKIA_SVG_LIB}
         ${SKIA_SKSHAPER_LIB}

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -167,6 +167,16 @@ android {
                     "src/paper/java",
                 ]
             }
+
+            if (REACT_NATIVE_VERSION >= 74) {
+                srcDirs += [
+                    "src/reactnative74/java"
+                ]
+            } else {
+                srcDirs += [
+                    "src/reactnative69/java"
+                ]
+            }
         }
     }
 
@@ -182,6 +192,8 @@ android {
              "**/libfbjni.so",
              "**/libjsi.so",
              "**/libreact_nativemodule_core.so",
+             "**/libreactnativejni.so",
+             "**/libruntimeexecutor.so",
              "**/libturbomodulejsijni.so",
              "META-INF/**"
         ]

--- a/package/android/cpp/jni/JniSkiaManager.cpp
+++ b/package/android/cpp/jni/JniSkiaManager.cpp
@@ -7,6 +7,36 @@
 
 #include <RNSkManager.h>
 
+namespace {
+
+// For bridgeless mode, currently we don't have a way to get the JSCallInvoker
+// from Java. Workaround to use RuntimeExecutor to simulate the behavior of
+// JSCallInvoker. In the future when bridgeless mode is a standard and no more
+// backward compatible to be considered, we could just use RuntimeExecutor to
+// run task on JS thread.
+class BridgelessJSCallInvoker : public facebook::react::CallInvoker {
+public:
+  explicit BridgelessJSCallInvoker(
+      facebook::react::RuntimeExecutor runtimeExecutor)
+      : runtimeExecutor_(std::move(runtimeExecutor)) {}
+
+  void invokeAsync(std::function<void()> &&func) noexcept override {
+    runtimeExecutor_(
+        [func = std::move(func)](facebook::jsi::Runtime &runtime) { func(); });
+  }
+
+  void invokeSync(std::function<void()> &&func) override {
+    throw std::runtime_error(
+        "Synchronous native -> JS calls are currently not supported.");
+  }
+
+private:
+  facebook::react::RuntimeExecutor runtimeExecutor_;
+
+}; // class BridgelessJSCallInvoker
+
+} // namespace
+
 namespace RNSkia {
 
 namespace jsi = facebook::jsi;
@@ -22,14 +52,17 @@ void JniSkiaManager::registerNatives() {
 
 // JNI init
 jni::local_ref<jni::HybridClass<JniSkiaManager>::jhybriddata>
-JniSkiaManager::initHybrid(jni::alias_ref<jhybridobject> jThis, jlong jsContext,
-                           JSCallInvokerHolder jsCallInvokerHolder,
-                           JavaPlatformContext skiaContext) {
+JniSkiaManager::initHybrid(
+    jni::alias_ref<jhybridobject> jThis, jlong jsContext,
+    jni::alias_ref<facebook::react::JRuntimeExecutor::javaobject>
+        jRuntimeExecutor,
+    JavaPlatformContext skiaContext) {
 
+  auto jsCallInvoker = std::make_shared<BridgelessJSCallInvoker>(
+      jRuntimeExecutor->cthis()->get());
   // cast from JNI hybrid objects to C++ instances
   return makeCxxInstance(jThis, reinterpret_cast<jsi::Runtime *>(jsContext),
-                         jsCallInvokerHolder->cthis()->getCallInvoker(),
-                         skiaContext->cthis());
+                         jsCallInvoker, skiaContext->cthis());
 }
 
 void JniSkiaManager::initializeRuntime() {

--- a/package/android/cpp/jni/include/JniPlatformContext.h
+++ b/package/android/cpp/jni/include/JniPlatformContext.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ReactCommon/CallInvokerHolder.h>
 #include <fbjni/fbjni.h>
 
 #include <exception>
@@ -17,9 +16,6 @@ namespace RNSkia {
 
 namespace jsi = facebook::jsi;
 namespace jni = facebook::jni;
-
-using JSCallInvokerHolder =
-    jni::alias_ref<facebook::react::CallInvokerHolder::javaobject>;
 
 class JniPlatformContext : public jni::HybridClass<JniPlatformContext> {
 public:

--- a/package/android/cpp/jni/include/JniSkiaManager.h
+++ b/package/android/cpp/jni/include/JniSkiaManager.h
@@ -5,6 +5,7 @@
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
 #include <memory>
+#include <react/jni/JRuntimeExecutor.h>
 
 #include <JniPlatformContext.h>
 #include <RNSkAndroidPlatformContext.h>
@@ -17,9 +18,6 @@ class RNSkManager;
 
 namespace jsi = facebook::jsi;
 
-using JSCallInvokerHolder =
-    jni::alias_ref<facebook::react::CallInvokerHolder::javaobject>;
-
 using JavaPlatformContext = jni::alias_ref<JniPlatformContext::javaobject>;
 
 class JniSkiaManager : public jni::HybridClass<JniSkiaManager> {
@@ -30,7 +28,8 @@ public:
 
   static jni::local_ref<jni::HybridClass<JniSkiaManager>::jhybriddata>
   initHybrid(jni::alias_ref<jhybridobject> jThis, jlong jsContext,
-             JSCallInvokerHolder jsCallInvokerHolder,
+             jni::alias_ref<facebook::react::JRuntimeExecutor::javaobject>
+                 jRuntimeExecutor,
              JavaPlatformContext platformContext);
 
   static void registerNatives();

--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDomView.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaDomView.java
@@ -5,14 +5,15 @@ import android.content.Context;
 import com.facebook.jni.HybridData;
 import com.facebook.jni.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.ThemedReactContext;
 
 public class SkiaDomView extends SkiaBaseView {
     @DoNotStrip
     private HybridData mHybridData;
 
-    public SkiaDomView(Context context) {
+    public SkiaDomView(ThemedReactContext context) {
         super(context);
-        RNSkiaModule skiaModule = ((ReactContext) context).getNativeModule(RNSkiaModule.class);
+        RNSkiaModule skiaModule = context.getReactApplicationContext().getNativeModule(RNSkiaModule.class);
         mHybridData = initHybrid(skiaModule.getSkiaManager());
     }
 

--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaManager.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaManager.java
@@ -3,7 +3,7 @@ package com.shopify.reactnative.skia;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
+import com.facebook.react.bridge.RuntimeExecutor;
 
 @DoNotStrip
 public class SkiaManager {
@@ -22,11 +22,11 @@ public class SkiaManager {
         super();
         mContext = context;
 
-        CallInvokerHolderImpl holder = (CallInvokerHolderImpl) context.getCatalystInstance().getJSCallInvokerHolder();
+        RuntimeExecutor runtimeExecutor = ReactNativeCompatible.getRuntimeExecutor(context);
 
         mPlatformContext = new PlatformContext(context);
 
-        mHybridData = initHybrid(context.getJavaScriptContextHolder().get(), holder, mPlatformContext);
+        mHybridData = initHybrid(context.getJavaScriptContextHolder().get(), runtimeExecutor, mPlatformContext);
 
         initializeRuntime();
     }
@@ -48,7 +48,7 @@ public class SkiaManager {
     public void onHostPause() {  mPlatformContext.onPause(); }
 
     // private C++ functions
-    private native HybridData initHybrid(long jsContext, CallInvokerHolderImpl jsCallInvokerHolder,
+    private native HybridData initHybrid(long jsContext, RuntimeExecutor runtimeExecutor,
             PlatformContext platformContext);
 
     private native void initializeRuntime();

--- a/package/android/src/reactnative69/java/com/shopify/reactnative/skia/ReactNativeCompatible.java
+++ b/package/android/src/reactnative69/java/com/shopify/reactnative/skia/ReactNativeCompatible.java
@@ -1,0 +1,11 @@
+package com.shopify.reactnative.skia;
+
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.RuntimeExecutor;
+
+/* package */ final class ReactNativeCompatible {
+    public static RuntimeExecutor getRuntimeExecutor(ReactContext context) {
+        return context.getCatalystInstance().getRuntimeExecutor();
+    }
+}
+

--- a/package/android/src/reactnative74/java/com/shopify/reactnative/skia/ReactNativeCompatible.java
+++ b/package/android/src/reactnative74/java/com/shopify/reactnative/skia/ReactNativeCompatible.java
@@ -1,0 +1,14 @@
+package com.shopify.reactnative.skia;
+
+import androidx.annotation.OptIn;
+
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.RuntimeExecutor;
+import com.facebook.react.common.annotations.FrameworkAPI;
+
+/* package */ final class ReactNativeCompatible {
+    @OptIn(markerClass = FrameworkAPI.class)
+    public static RuntimeExecutor getRuntimeExecutor(ReactContext context) {
+        return context.getRuntimeExecutor();
+    }
+}


### PR DESCRIPTION
# Why

Fix bridgeless support on Android

# How

On bridgeless mode, we cannot use `context.getCatalystInstance()` and no way to get `CallInvokerHolderImpl` from java. As an alternative, this PR tries to use RuntimeExecutor to simulate a call invoker. It is exactly the same to the [upstream implementation](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/runtime/BridgelessJSCallInvoker.cpp) and we do the same internally at Expo. In the future when we don't have to support older react-native, we could try to migrate iOS for using RuntimeExecutor as well.

Even though RuntimeExecutor is supported from older react-native. The `context.getRuntimeExecutor()` is only availble from 0.74, so we have to add two **ReactNativeCompatible.java** for different versions.

# Test

- test new architecture mode on 0.74.0-rc.2 (default enabled bridgeless mode)
- test old architecture mode on 0.71 and 0.69. 