### PR TITLE
fix(🐛): fix regression with missing exports in headless mode

### DIFF
--- a/package/src/headless/index.ts
+++ b/package/src/headless/index.ts
@@ -8,6 +8,8 @@ import { SkiaRoot } from "../renderer/Reconciler";
 import { JsiDrawingContext } from "../dom/types";
 import type { SkSurface } from "../skia";
 
+export * from "../renderer/components";
+
 let Skia: ReturnType<typeof JsiSkApi>;
 
 export const makeOffscreenSurface = (width: number, height: number) => {


### PR DESCRIPTION
fixes #2329 