### PR TITLE
feat(📸): makeImageSnapshotAsync()

### DIFF
--- a/docs/docs/canvas/canvas.md
+++ b/docs/docs/canvas/canvas.md
@@ -25,7 +25,10 @@ If the size of the Canvas is unknown, there are two ways to access it:
 
 ## Getting a Canvas Snapshot
 
-You can save your drawings as an image, using `makeImageSnapshot`. This method will return an [Image instance](/docs/images#instance-methods). This instance can be used to draw it via the `<Image>` component, or be saved or shared using binary or base64 encoding.
+You can save your drawings as an image by using the `makeImageSnapshotAsync` method. This method returns a promise that resolves to an [Image](/docs/images).
+It executes on the UI thread, ensuring access to the same Skia context as your on-screen canvases, including [textures](https://shopify.github.io/react-native-skia/docs/animations/textures).
+
+If your drawing does not contain textures, you may also use the synchronous `makeImageSnapshot` method for simplicity.
 
 ### Example
 

--- a/example/src/Tests/Tests.tsx
+++ b/example/src/Tests/Tests.tsx
@@ -72,15 +72,24 @@ export const Tests = ({ assets }: TestsProps) => {
   useEffect(() => {
     if (drawing) {
       const it = setTimeout(() => {
-        const image = ref.current?.makeImageSnapshot({
-          x: 0,
-          y: 0,
-          width: size,
-          height: size,
-        });
-        if (image && client) {
-          const data = image.encodeToBytes();
-          client.send(data);
+        if (ref.current) {
+          ref.current
+            .makeImageSnapshotAsync({
+              x: 0,
+              y: 0,
+              width: size,
+              height: size,
+            })
+            .then((image) => {
+              console.log({ image });
+              if (image && client) {
+                const data = image.encodeToBytes();
+                client.send(data);
+              }
+            })
+            .catch((e) => {
+              console.error(e);
+            });
         }
       }, timeToDraw);
       return () => {

--- a/example/src/Tests/Tests.tsx
+++ b/example/src/Tests/Tests.tsx
@@ -81,7 +81,6 @@ export const Tests = ({ assets }: TestsProps) => {
               height: size,
             })
             .then((image) => {
-              console.log({ image });
               if (image && client) {
                 const data = image.encodeToBytes();
                 client.send(data);

--- a/example/src/Tests/deserialize.ts
+++ b/example/src/Tests/deserialize.ts
@@ -61,6 +61,9 @@ const parseProp = (value: any, assets: Assets): any => {
       if (!asset) {
         throw new Error(`Asset ${value.name} not found`);
       }
+      if (asset.value) {
+        return asset.value;
+      }
       return asset;
     } else if (value.__typename__ === "RuntimeEffect") {
       return Skia.RuntimeEffect.Make(value.source);

--- a/example/src/Tests/useAssets.ts
+++ b/example/src/Tests/useAssets.ts
@@ -1,4 +1,8 @@
-import { useImage, useTypeface } from "@shopify/react-native-skia";
+import {
+  useImage,
+  useImageAsTexture,
+  useTypeface,
+} from "@shopify/react-native-skia";
 import { useCallback, useState } from "react";
 import { Platform } from "react-native";
 
@@ -19,7 +23,7 @@ export const useAssets = () => {
   const [error, setError] = useState<Error | null>(null);
   const errorHandler = useCallback((e: Error) => setError(e), []);
   const mask = useImage(require("./assets/mask.png"), errorHandler);
-  const oslo = useImage(require("./assets/oslo.jpg"), errorHandler);
+  const oslo = useImageAsTexture(require("./assets/oslo.jpg"));
   const skiaLogoJpeg = useImage(SkiaLogoJpeg, errorHandler);
   const skiaLogoPng = useImage(SkiaLogo, errorHandler);
   const RobotoMedium = useTypeface(

--- a/fabricexample/src/Tests/Tests.tsx
+++ b/fabricexample/src/Tests/Tests.tsx
@@ -72,15 +72,23 @@ export const Tests = ({ assets }: TestsProps) => {
   useEffect(() => {
     if (drawing) {
       const it = setTimeout(() => {
-        const image = ref.current?.makeImageSnapshot({
-          x: 0,
-          y: 0,
-          width: size,
-          height: size,
-        });
-        if (image && client) {
-          const data = image.encodeToBytes();
-          client.send(data);
+        if (ref.current) {
+          ref.current
+            .makeImageSnapshotAsync({
+              x: 0,
+              y: 0,
+              width: size,
+              height: size,
+            })
+            .then((image) => {
+              if (image && client) {
+                const data = image.encodeToBytes();
+                client.send(data);
+              }
+            })
+            .catch((e) => {
+              console.error(e);
+            });
         }
       }, timeToDraw);
       return () => {

--- a/fabricexample/src/Tests/deserialize.ts
+++ b/fabricexample/src/Tests/deserialize.ts
@@ -61,6 +61,9 @@ const parseProp = (value: any, assets: Assets): any => {
       if (!asset) {
         throw new Error(`Asset ${value.name} not found`);
       }
+      if (asset.value) {
+        return asset.value;
+      }
       return asset;
     } else if (value.__typename__ === "RuntimeEffect") {
       return Skia.RuntimeEffect.Make(value.source);

--- a/fabricexample/src/Tests/useAssets.ts
+++ b/fabricexample/src/Tests/useAssets.ts
@@ -1,4 +1,8 @@
-import { useImage, useTypeface } from "@shopify/react-native-skia";
+import {
+  useImage,
+  useImageAsTexture,
+  useTypeface,
+} from "@shopify/react-native-skia";
 import { useCallback, useState } from "react";
 import { Platform } from "react-native";
 
@@ -19,7 +23,7 @@ export const useAssets = () => {
   const [error, setError] = useState<Error | null>(null);
   const errorHandler = useCallback((e: Error) => setError(e), []);
   const mask = useImage(require("./assets/mask.png"), errorHandler);
-  const oslo = useImage(require("./assets/oslo.jpg"), errorHandler);
+  const oslo = useImageAsTexture(require("./assets/oslo.jpg"));
   const skiaLogoJpeg = useImage(SkiaLogoJpeg, errorHandler);
   const skiaLogoPng = useImage(SkiaLogo, errorHandler);
   const RobotoMedium = useTypeface(

--- a/package/cpp/api/JsiSkImageFactory.h
+++ b/package/cpp/api/JsiSkImageFactory.h
@@ -47,7 +47,6 @@ public:
         [context = std::move(context), viewTag](
             jsi::Runtime &runtime,
             std::shared_ptr<RNJsi::JsiPromises::Promise> promise) -> void {
-          // Create a stream operation - this will be run on the main thread
           context->makeViewScreenshot(
               viewTag, [&runtime, context = std::move(context),
                         promise = std::move(promise)](sk_sp<SkImage> image) {

--- a/package/cpp/rnskia/RNSkJsiViewApi.h
+++ b/package/cpp/rnskia/RNSkJsiViewApi.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <utility>
 
 #include "JsiHostObject.h"
 #include "JsiValueWrapper.h"
@@ -180,7 +181,7 @@ public:
   JSI_HOST_FUNCTION(makeImageSnapshotAsync) {
     if (count < 1) {
       _platformContext->raiseError(
-          std::string("makeImageSnapshot: Expected at least 1 argument, got " +
+          std::string("makeImageSnapshotAsync: Expected at least 1 argument, got " +
                       std::to_string(count) + "."));
       return jsi::Value::undefined();
     }

--- a/package/cpp/rnskia/RNSkJsiViewApi.h
+++ b/package/cpp/rnskia/RNSkJsiViewApi.h
@@ -5,8 +5,8 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "JsiHostObject.h"
 #include "JsiValueWrapper.h"
@@ -180,9 +180,9 @@ public:
 
   JSI_HOST_FUNCTION(makeImageSnapshotAsync) {
     if (count < 1) {
-      _platformContext->raiseError(
-          std::string("makeImageSnapshotAsync: Expected at least 1 argument, got " +
-                      std::to_string(count) + "."));
+      _platformContext->raiseError(std::string(
+          "makeImageSnapshotAsync: Expected at least 1 argument, got " +
+          std::to_string(count) + "."));
       return jsi::Value::undefined();
     }
 
@@ -201,18 +201,17 @@ public:
             ? JsiSkRect::fromValue(runtime, arguments[1])
             : nullptr;
     return RNJsi::JsiPromises::createPromiseAsJSIValue(
-        runtime,
-        [context = std::move(context), info,
-         bounds](jsi::Runtime &runtime,
-                 std::shared_ptr<RNJsi::JsiPromises::Promise> promise)  {
-          context->runOnMainThread(
-              [&runtime, info = std::move(info), promise = std::move(promise), context = std::move(context), bounds]() {
-                auto image = info->view->makeImageSnapshot(
-                    bounds == nullptr ? nullptr : bounds.get());
-                 context->runOnJavascriptThread([&runtime,
-                                                context = std::move(context),
-                                                promise = std::move(promise),
-                                                image = std::move(image)]() {
+        runtime, [context = std::move(context), info, bounds](
+                     jsi::Runtime &runtime,
+                     std::shared_ptr<RNJsi::JsiPromises::Promise> promise) {
+          context->runOnMainThread([&runtime, info = std::move(info),
+                                    promise = std::move(promise),
+                                    context = std::move(context), bounds]() {
+            auto image = info->view->makeImageSnapshot(
+                bounds == nullptr ? nullptr : bounds.get());
+            context->runOnJavascriptThread(
+                [&runtime, context = std::move(context),
+                 promise = std::move(promise), image = std::move(image)]() {
                   if (image == nullptr) {
                     promise->reject("Failed to make snapshot from view.");
                     return;
@@ -221,7 +220,7 @@ public:
                       runtime, std::make_shared<JsiSkImage>(std::move(context),
                                                             std::move(image))));
                 });
-              });
+          });
         });
   }
 

--- a/package/src/mock/index.ts
+++ b/package/src/mock/index.ts
@@ -31,6 +31,7 @@ export const Mock = (CanvasKit: CanvasKit) => {
     // Reanimated hooks
     useClock: NoopSharedValue,
     usePathInterpolation: NoopSharedValue,
+    useImageAsTexture: NoopSharedValue,
     useTextureValue: NoopSharedValue,
     useTextureValueFromPicture: NoopSharedValue,
     useRSXformBuffer: NoopSharedValue,

--- a/package/src/views/SkiaDomView.tsx
+++ b/package/src/views/SkiaDomView.tsx
@@ -67,6 +67,16 @@ export class SkiaDomView extends React.Component<SkiaDomViewProps> {
   }
 
   /**
+   * Creates a snapshot from the canvas in the surface
+   * @param rect Rect to use as bounds. Optional.
+   * @returns An Image object.
+   */
+  public makeImageSnapshotAsync(rect?: SkRect) {
+    assertSkiaViewApi();
+    return SkiaViewApi.makeImageSnapshotAsync(this._nativeId, rect);
+  }
+
+  /**
    * Sends a redraw request to the native SkiaView.
    */
   public redraw() {

--- a/package/src/views/types.ts
+++ b/package/src/views/types.ts
@@ -65,6 +65,7 @@ export interface ISkiaViewApi {
   ) => void;
   requestRedraw: (nativeId: number) => void;
   makeImageSnapshot: (nativeId: number, rect?: SkRect) => SkImage;
+  makeImageSnapshotAsync: (nativeId: number, rect?: SkRect) => Promise<SkImage>;
 }
 
 export interface SkiaBaseViewProps extends ViewProps {


### PR DESCRIPTION
fixes #2320
The goal is this PR is to offer a makeSnapshotAsync() that runs on the UI so it shares the same context as onscreen canvases. By doing so textures created on the UI thread will be available when taking the snapshot.