### PR TITLE
fix(🐛): Fix memory leak with MakeOffscreen when using CPU fallback

### DIFF
--- a/package/src/renderer/__tests__/Surfaces.spec.tsx
+++ b/package/src/renderer/__tests__/Surfaces.spec.tsx
@@ -22,6 +22,20 @@ describe("Surface", () => {
     }
   });
   it("A raster surface shouldn't leak (2)", () => {
+    const { Skia } = setupSkia();
+    // When leaking, the WASM memory limit will be reached quite quickly
+    // causing the test to fail
+    for (let i = 0; i < 500; i++) {
+      const surface = Skia.Surface.MakeOffscreen(1920, 1080)!;
+      const canvas = surface.getCanvas();
+      canvas.clear(Skia.Color("cyan"));
+      surface.flush();
+      const image = surface.makeImageSnapshot();
+      image.dispose();
+      surface.dispose();
+    }
+  });
+  it("A raster surface shouldn't leak (3)", () => {
     for (let i = 0; i < 1000; i++) {
       //const t = performance.now();
       const r = 128;

--- a/package/src/renderer/__tests__/setup.tsx
+++ b/package/src/renderer/__tests__/setup.tsx
@@ -194,7 +194,7 @@ export const drawOnNode = (element: ReactNode) => {
 export const mountCanvas = (element: ReactNode) => {
   const Skia = global.SkiaApi;
   expect(Skia).toBeDefined();
-  const ckSurface = Skia.Surface.Make(width, height)!;
+  const ckSurface = Skia.Surface.MakeOffscreen(width, height)!;
   expect(ckSurface).toBeDefined();
   const canvas = ckSurface.getCanvas();
 

--- a/package/src/skia/web/JsiSkSurfaceFactory.ts
+++ b/package/src/skia/web/JsiSkSurfaceFactory.ts
@@ -39,7 +39,7 @@ export class JsiSkSurfaceFactory extends Host implements SurfaceFactory {
     const OC = (globalThis as any).OffscreenCanvas;
     let surface: Surface | null;
     if (OC === undefined) {
-      surface = this.CanvasKit.MakeSurface(width, height);
+      return this.Make(width, height);
     } else {
       const offscreen = new OC(width, height);
       const webglContext = this.CanvasKit.GetWebGLContext(offscreen);


### PR DESCRIPTION
fixes #2319 

We recently fixed a memory leak with `Surface.Make` but didn't fix it for `Surface.MakeOffscreen` using using the CPU fallback