### PR TITLE
fix(🐛): Fix memory leak with makeNonImageTexture on Web

### DIFF
--- a/package/src/renderer/__tests__/Surfaces.spec.tsx
+++ b/package/src/renderer/__tests__/Surfaces.spec.tsx
@@ -7,6 +7,21 @@ import { setupSkia } from "../../skia/__tests__/setup";
 import { drawOnNode } from "./setup";
 
 describe("Surface", () => {
+  it("MakeNonImageTexture on a CPU surface shouldn't leak", () => {
+    const { Skia } = setupSkia();
+    // When leaking, the WASM memory limit will be reached quite quickly
+    // causing the test to fail
+    for (let i = 0; i < 500; i++) {
+      const surface = Skia.Surface.Make(1920, 1080)!;
+      const canvas = surface.getCanvas();
+      canvas.clear(Skia.Color("cyan"));
+      surface.flush();
+      const image = surface.makeImageSnapshot();
+      image.makeNonTextureImage();
+      image.dispose();
+      surface.dispose();
+    }
+  });
   it("A raster surface shouldn't leak (1)", () => {
     const { Skia } = setupSkia();
     // When leaking, the WASM memory limit will be reached quite quickly
@@ -36,7 +51,7 @@ describe("Surface", () => {
     }
   });
   it("A raster surface shouldn't leak (3)", () => {
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 10; i++) {
       //const t = performance.now();
       const r = 128;
       const surface = drawOnNode(

--- a/package/src/skia/web/JsiSkSurface.ts
+++ b/package/src/skia/web/JsiSkSurface.ts
@@ -11,19 +11,12 @@ export class JsiSkSurface
   extends HostObject<Surface, "Surface">
   implements SkSurface
 {
-  constructor(
-    CanvasKit: CanvasKit,
-    ref: Surface,
-    private releaseCtx?: () => void
-  ) {
+  constructor(CanvasKit: CanvasKit, ref: Surface) {
     super(CanvasKit, ref, "Surface");
   }
 
   dispose = () => {
-    this.ref.delete();
-    if (this.releaseCtx) {
-      this.releaseCtx();
-    }
+    this.ref.dispose();
   };
 
   flush() {

--- a/package/src/skia/web/JsiSkSurfaceFactory.ts
+++ b/package/src/skia/web/JsiSkSurfaceFactory.ts
@@ -11,26 +11,10 @@ export class JsiSkSurfaceFactory extends Host implements SurfaceFactory {
   }
 
   Make(width: number, height: number) {
-    var pixelLen = width * height * 4;
-    const pixelPtr = this.CanvasKit.Malloc(Uint8Array, pixelLen);
-    const surface = this.CanvasKit.MakeRasterDirectSurface(
-      {
-        width: width,
-        height: height,
-        colorType: this.CanvasKit.ColorType.RGBA_8888,
-        alphaType: this.CanvasKit.AlphaType.Unpremul,
-        colorSpace: this.CanvasKit.ColorSpace.SRGB,
-      },
-      pixelPtr,
-      width * 4
+    return new JsiSkSurface(
+      this.CanvasKit,
+      this.CanvasKit.MakeSurface(width, height)!
     );
-    if (!surface) {
-      return null;
-    }
-    surface.getCanvas().clear(this.CanvasKit.TRANSPARENT);
-    return new JsiSkSurface(this.CanvasKit, surface, () => {
-      this.CanvasKit.Free(pixelPtr);
-    });
   }
 
   MakeOffscreen(width: number, height: number) {


### PR DESCRIPTION
The goal of this PR is three-fold:
- Fix a memory leak with `makeNonImageTexture` on Web
- Make `makeNonImageTexture()` return the reference of the original image instead of a copy.
- Simplify memory management in `Surface.Make` on Web