### PR TITLE
makeNonTextureImage should return a different reference when copying on Web

### DIFF
--- a/package/src/renderer/__tests__/Surfaces.spec.tsx
+++ b/package/src/renderer/__tests__/Surfaces.spec.tsx
@@ -17,7 +17,8 @@ describe("Surface", () => {
       canvas.clear(Skia.Color("cyan"));
       surface.flush();
       const image = surface.makeImageSnapshot();
-      image.makeNonTextureImage();
+      const copy = image.makeNonTextureImage();
+      copy.dispose();
       image.dispose();
       surface.dispose();
     }

--- a/package/src/skia/web/JsiSkImage.ts
+++ b/package/src/skia/web/JsiSkImage.ts
@@ -168,8 +168,6 @@ export class JsiSkImage extends HostObject<Image, "Image"> implements SkImage {
     if (!img) {
       throw new Error("Could not create image from bytes");
     }
-    this.ref.delete();
-    this.ref = img;
-    return this;
+    return new JsiSkImage(this.CanvasKit, img);
   }
 }


### PR DESCRIPTION
This is symmetric to the behaviour on native