### PR TITLE
doc: Fixed issue in Paragraph API "Hello World" example

### DIFF
--- a/docs/docs/text/paragraph.md
+++ b/docs/docs/text/paragraph.md
@@ -15,7 +15,7 @@ Other system fonts will are available as well.
 
 ```tsx twoslash
 import { useMemo } from "react";
-import { Paragraph, Skia, useFonts, TextAlign } from "@shopify/react-native-skia";
+import { Paragraph, Skia, useFonts, TextAlign, Canvas } from "@shopify/react-native-skia";
 
 const MyParagraph = () => {
   const customFontMgr = useFonts({
@@ -48,7 +48,11 @@ const MyParagraph = () => {
   }, [customFontMgr]);
 
   // Render the paragraph
-  return <Paragraph paragraph={paragraph} x={0} y={0} width={300} />;
+  return (
+    <Canvas style={{ width: 256, height: 256 }}>
+      <Paragraph paragraph={paragraph} x={0} y={0} width={300} />
+    </Canvas>
+  );
 };
 ```
 


### PR DESCRIPTION
Hi @wcandillon, 

Congratulations to you & your team for V1.0 🎉. I just found an issue in the doc of "Paragraph" API "Hello World" example code.

### **ISSUE** 
- The **"Paragraph"** component was not wrapped by **"Canvas"** component.

<img width="351" alt="Screenshot 2024-04-09 at 7 09 25 PM" src="https://github.com/Shopify/react-native-skia/assets/40535268/74ea514a-5e39-49a4-ab67-836a3bb73b86">

### **SOLUTION**
- I just wrapped the **"Paragraph"** component by **"Canvas"** component.