### PR TITLE
feat: Support YUV format in PlatformBuffers

### DIFF
--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
@@ -16,11 +16,37 @@ enum class CVPixelBufferBaseFormat {
   rgb
 };
 
+struct RGBFormatInfo {
+  MTLPixelFormat metalFormat;
+  SkColorType skiaFormat;
+};
+
 class SkiaCVPixelBufferUtils {
 public:
-  static GrBackendTexture getTextureFromCVPixelBuffer(CVPixelBufferRef pixelBuffer, size_t planeIndex, MTLPixelFormat pixelFormat);
-  static GrYUVABackendTextures getYUVTexturesFromCVPixelBuffer(CVPixelBufferRef pixelBuffer);
+  /**
+   Get the base format of the given CVPixelBuffer.
+   Returns either RGB or YUV, or throws if the pixel-buffer is in an unknown format.
+   */
   static CVPixelBufferBaseFormat getCVPixelBufferBaseFormat(CVPixelBufferRef pixelBuffer);
+  /**
+   Gets RGB-specific information about a CVPixelBuffer, such as the Metal format and the Skia-specific format.
+   */
+  static RGBFormatInfo getRGBCVPixelBufferFormatInfo(CVPixelBufferRef pixelBuffer);
+  /**
+   Get a Skia Texture backed by a MTLTexture from the given CVPixelBuffer.
+   For RGB:
+   ```
+   GrBackendTexture texture = getTextureFromCVPixelBuffer(pixelBuffer, 0, MTLPixelFormatBGRA8Unorm);
+   ```
+   For YUV use `getYUVTexturesFromCVPixelBuffer` instead, unless you want full control over the MTLPixelFormat per plane.
+   */
+  static GrBackendTexture getTextureFromCVPixelBuffer(CVPixelBufferRef pixelBuffer, size_t planeIndex, MTLPixelFormat pixelFormat);
+  /**
+   Get a Skia YUV Texture backed by multiple MTLTextures for the given CVPixelBuffer.
+   The CVPixelBuffer might be multi-planar (e.g. Y + UV) or single-planar.
+   Either way, it needs to be in a supported YUV format.
+   */
+  static GrYUVABackendTextures getYUVTexturesFromCVPixelBuffer(CVPixelBufferRef pixelBuffer);
 
 private:
   static CVMetalTextureCacheRef getTextureCache();

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
@@ -6,15 +6,12 @@
 //
 
 #pragma once
-#import <MetalKit/MetalKit.h>
 #import "include/gpu/GrYUVABackendTextures.h"
 #import <CoreMedia/CMSampleBuffer.h>
 #import <CoreVideo/CVMetalTextureCache.h>
+#import <MetalKit/MetalKit.h>
 
-enum class CVPixelBufferBaseFormat {
-  yuv,
-  rgb
-};
+enum class CVPixelBufferBaseFormat { yuv, rgb };
 
 struct RGBFormatInfo {
   MTLPixelFormat metalFormat;
@@ -25,32 +22,43 @@ class SkiaCVPixelBufferUtils {
 public:
   /**
    Get the base format of the given CVPixelBuffer.
-   Returns either RGB or YUV, or throws if the pixel-buffer is in an unknown format.
+   Returns either RGB or YUV, or throws if the pixel-buffer is in an unknown
+   format.
    */
-  static CVPixelBufferBaseFormat getCVPixelBufferBaseFormat(CVPixelBufferRef pixelBuffer);
+  static CVPixelBufferBaseFormat
+  getCVPixelBufferBaseFormat(CVPixelBufferRef pixelBuffer);
   /**
-   Gets RGB-specific information about a CVPixelBuffer, such as the Metal format and the Skia-specific format.
+   Gets RGB-specific information about a CVPixelBuffer, such as the Metal format
+   and the Skia-specific format.
    */
-  static RGBFormatInfo getRGBCVPixelBufferFormatInfo(CVPixelBufferRef pixelBuffer);
+  static RGBFormatInfo
+  getRGBCVPixelBufferFormatInfo(CVPixelBufferRef pixelBuffer);
   /**
    Get a Skia Texture backed by a MTLTexture from the given CVPixelBuffer.
    For RGB:
    ```
-   GrBackendTexture texture = getTextureFromCVPixelBuffer(pixelBuffer, 0, MTLPixelFormatBGRA8Unorm);
+   GrBackendTexture texture = getTextureFromCVPixelBuffer(pixelBuffer, 0,
+   MTLPixelFormatBGRA8Unorm);
    ```
-   For YUV use `getYUVTexturesFromCVPixelBuffer` instead, unless you want full control over the MTLPixelFormat per plane.
+   For YUV use `getYUVTexturesFromCVPixelBuffer` instead, unless you want full
+   control over the MTLPixelFormat per plane.
    */
-  static GrBackendTexture getTextureFromCVPixelBuffer(CVPixelBufferRef pixelBuffer, size_t planeIndex, MTLPixelFormat pixelFormat);
+  static GrBackendTexture
+  getTextureFromCVPixelBuffer(CVPixelBufferRef pixelBuffer, size_t planeIndex,
+                              MTLPixelFormat pixelFormat);
   /**
-   Get a Skia YUV Texture backed by multiple MTLTextures for the given CVPixelBuffer.
-   The CVPixelBuffer might be multi-planar (e.g. Y + UV) or single-planar.
-   Either way, it needs to be in a supported YUV format.
+   Get a Skia YUV Texture backed by multiple MTLTextures for the given
+   CVPixelBuffer. The CVPixelBuffer might be multi-planar (e.g. Y + UV) or
+   single-planar. Either way, it needs to be in a supported YUV format.
    */
-  static GrYUVABackendTextures getYUVTexturesFromCVPixelBuffer(CVPixelBufferRef pixelBuffer);
+  static GrYUVABackendTextures
+  getYUVTexturesFromCVPixelBuffer(CVPixelBufferRef pixelBuffer);
 
 private:
   static CVMetalTextureCacheRef getTextureCache();
-  static MTLPixelFormat getMTLPixelFormatForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex);
+  static MTLPixelFormat
+  getMTLPixelFormatForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer,
+                                         size_t planeIndex);
 
   static SkYUVAInfo::PlaneConfig getPlaneConfig(OSType pixelFormat);
   static SkYUVAInfo::Subsampling getSubsampling(OSType pixelFormat);

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
@@ -1,0 +1,33 @@
+//
+//  SkiaCVPixelBufferUtils.h
+//  react-native-skia
+//
+//  Created by Marc Rousavy on 10.04.24.
+//
+
+#pragma once
+#import <MetalKit/MetalKit.h>
+#import "include/gpu/GrYUVABackendTextures.h"
+#import <CoreMedia/CMSampleBuffer.h>
+#import <CoreVideo/CVMetalTextureCache.h>
+
+enum class CVPixelBufferBaseFormat {
+  yuv,
+  rgb
+};
+
+class SkiaCVPixelBufferUtils {
+public:
+  static GrBackendTexture getTextureFromCVPixelBuffer(CVPixelBufferRef pixelBuffer, size_t planeIndex, MTLPixelFormat pixelFormat);
+  static GrYUVABackendTextures getYUVTexturesFromCVPixelBuffer(CVPixelBufferRef pixelBuffer);
+  static CVPixelBufferBaseFormat getCVPixelBufferBaseFormat(CVPixelBufferRef pixelBuffer);
+
+private:
+  static CVMetalTextureCacheRef getTextureCache();
+  static MTLPixelFormat getMTLPixelFormatForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex);
+
+  static SkYUVAInfo::PlaneConfig getPlaneConfig(OSType pixelFormat);
+  static SkYUVAInfo::Subsampling getSubsampling(OSType pixelFormat);
+  static SkYUVColorSpace getColorspace(OSType pixelFormat);
+  static SkYUVAInfo getYUVAInfoForCVPixelBuffer(CVPixelBufferRef pixelBuffer);
+};

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
@@ -205,7 +205,6 @@ GrYUVABackendTextures SkiaCVPixelBufferUtils::getYUVTexturesFromCVPixelBuffer(CV
 
   for (size_t planeIndex = 0; planeIndex < planesCount; planeIndex++) {
     MTLPixelFormat pixelFormat = getMTLPixelFormatForCVPixelBufferPlane(pixelBuffer, planeIndex);
-    NSLog(@"Plane %zu is in %zu", planeIndex, pixelFormat);
     GrBackendTexture texture = getTextureFromCVPixelBuffer(pixelBuffer, planeIndex, pixelFormat);
     textures[planeIndex] = texture;
   }

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
@@ -1,0 +1,253 @@
+//
+//  SkiaCVPixelBufferUtils.mm
+//  react-native-skia
+//
+//  Created by Marc Rousavy on 10.04.24.
+//
+
+#import "SkiaCVPixelBufferUtils.h"
+#import "SkiaMetalSurfaceFactory.h"
+
+#include <TargetConditionals.h>
+#if TARGET_RT_BIG_ENDIAN
+#define FourCC2Str(fourcc)                                                     \
+  (const char[]) {                                                             \
+    *((char *)&fourcc), *(((char *)&fourcc) + 1), *(((char *)&fourcc) + 2),    \
+        *(((char *)&fourcc) + 3), 0                                            \
+  }
+#else
+#define FourCC2Str(fourcc)                                                     \
+  (const char[]) {                                                             \
+    *(((char *)&fourcc) + 3), *(((char *)&fourcc) + 2),                        \
+        *(((char *)&fourcc) + 1), *(((char *)&fourcc) + 0), 0                  \
+  }
+#endif
+
+
+CVMetalTextureCacheRef SkiaCVPixelBufferUtils::getTextureCache() {
+  static thread_local CVMetalTextureCacheRef textureCache = nil;
+  static thread_local size_t accessCounter = 0;
+  if (textureCache == nil) {
+    // Create a new Texture Cache
+    const auto& context = ThreadContextHolder::getThreadSpecificSkiaContext();
+    auto result = CVMetalTextureCacheCreate(kCFAllocatorDefault, nil, context->device,
+                                            nil, &textureCache);
+    if (result != kCVReturnSuccess || textureCache == nil) {
+      throw std::runtime_error("Failed to create Metal Texture Cache!");
+    }
+  }
+  accessCounter++;
+  if (accessCounter > 30) {
+    // Every 30 accesses, we perform some internal recycling/housekeeping
+    // operations.
+    CVMetalTextureCacheFlush(textureCache, 0);
+    accessCounter = 0;
+  }
+  return textureCache;
+}
+
+GrBackendTexture SkiaCVPixelBufferUtils::getTextureFromCVPixelBuffer(CVPixelBufferRef pixelBuffer, size_t planeIndex, MTLPixelFormat pixelFormat) {
+  // 1. Get cache
+  CVMetalTextureCacheRef textureCache = getTextureCache();
+
+  // 2. Get MetalTexture from CMSampleBuffer
+  CVMetalTextureRef textureHolder;
+  size_t width = CVPixelBufferGetWidthOfPlane(pixelBuffer, planeIndex);
+  size_t height = CVPixelBufferGetHeightOfPlane(pixelBuffer, planeIndex);
+  CVReturn result = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault, textureCache, pixelBuffer, nil,
+                                                              pixelFormat, width, height, planeIndex, &textureHolder);
+  if (result != kCVReturnSuccess) {
+    throw std::runtime_error("Failed to create Metal Texture from CMSampleBuffer! Result: " +
+                             std::to_string(result));
+  }
+
+  // 2. Unwrap the underlying MTLTexture
+  id<MTLTexture> mtlTexture = CVMetalTextureGetTexture(textureHolder);
+  if (mtlTexture == nil) {
+    throw std::runtime_error("Failed to get MTLTexture from CVMetalTextureRef!");
+  }
+
+  // 3. Wrap MTLTexture in Skia's GrBackendTexture
+  GrMtlTextureInfo textureInfo;
+  textureInfo.fTexture.retain((__bridge void *)mtlTexture);
+  GrBackendTexture texture = GrBackendTexture((int)mtlTexture.width, (int)mtlTexture.height,
+                                  skgpu::Mipmapped::kNo, textureInfo);
+  CFRelease(textureHolder);
+  return texture;
+}
+
+SkYUVAInfo::PlaneConfig SkiaCVPixelBufferUtils::getPlaneConfig(OSType pixelFormat) {
+  switch (pixelFormat) {
+    case kCVPixelFormatType_420YpCbCr8Planar:
+    case kCVPixelFormatType_420YpCbCr8PlanarFullRange:
+      return SkYUVAInfo::PlaneConfig::kYUV;
+    case kCVPixelFormatType_422YpCbCr_4A_8BiPlanar:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_422YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_444YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr16BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr16BiPlanarVideoRange:
+      return SkYUVAInfo::PlaneConfig::kY_UV;
+    case kCVPixelFormatType_420YpCbCr8VideoRange_8A_TriPlanar:
+    case kCVPixelFormatType_444YpCbCr16VideoRange_16A_TriPlanar:
+      return SkYUVAInfo::PlaneConfig::kY_U_V;
+    default:
+      throw std::runtime_error("Invalid pixel format! " + std::string(FourCC2Str(pixelFormat)));
+  }
+}
+SkYUVAInfo::Subsampling SkiaCVPixelBufferUtils::getSubsampling(OSType pixelFormat) {
+  switch (pixelFormat) {
+    case kCVPixelFormatType_420YpCbCr8Planar:
+    case kCVPixelFormatType_420YpCbCr8PlanarFullRange:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_420YpCbCr8VideoRange_8A_TriPlanar:
+      return SkYUVAInfo::Subsampling::k420;
+    case kCVPixelFormatType_4444YpCbCrA8:
+    case kCVPixelFormatType_4444YpCbCrA8R:
+    case kCVPixelFormatType_4444AYpCbCr8:
+    case kCVPixelFormatType_4444AYpCbCr16:
+    case kCVPixelFormatType_4444AYpCbCrFloat:
+    case kCVPixelFormatType_444YpCbCr8:
+    case kCVPixelFormatType_444YpCbCr10:
+    case kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_444YpCbCr16BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr16VideoRange_16A_TriPlanar:
+      return SkYUVAInfo::Subsampling::k444;
+    case kCVPixelFormatType_422YpCbCr8:
+    case kCVPixelFormatType_422YpCbCr16:
+    case kCVPixelFormatType_422YpCbCr10:
+    case kCVPixelFormatType_422YpCbCr_4A_8BiPlanar:
+    case kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_422YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr8_yuvs:
+    case kCVPixelFormatType_422YpCbCr8FullRange:
+    case kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_422YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr16BiPlanarVideoRange:
+      return SkYUVAInfo::Subsampling::k422;
+    default:
+      throw std::runtime_error("Invalid pixel format! " + std::string(FourCC2Str(pixelFormat)));
+  }
+}
+SkYUVColorSpace SkiaCVPixelBufferUtils::getColorspace(OSType pixelFormat) {
+  switch (pixelFormat) {
+    case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr8VideoRange_8A_TriPlanar:
+    case kCVPixelFormatType_422YpCbCr16BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr16BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr16VideoRange_16A_TriPlanar:
+      return SkYUVColorSpace::kRec709_Limited_SkYUVColorSpace;
+    case kCVPixelFormatType_420YpCbCr8PlanarFullRange:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_444YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr8FullRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_444YpCbCr10BiPlanarFullRange:
+      return SkYUVColorSpace::kRec709_Full_SkYUVColorSpace;
+    default:
+      throw std::runtime_error("Invalid pixel format! " + std::string(FourCC2Str(pixelFormat)));
+  }
+}
+
+SkYUVAInfo SkiaCVPixelBufferUtils::getYUVAInfoForCVPixelBuffer(CVPixelBufferRef pixelBuffer) {
+  size_t width = CVPixelBufferGetWidth(pixelBuffer);
+  size_t height = CVPixelBufferGetHeight(pixelBuffer);
+  SkISize size = SkISize::Make(static_cast<int>(width), static_cast<int>(height));
+
+  OSType format = CVPixelBufferGetPixelFormatType(pixelBuffer);
+  SkYUVAInfo::PlaneConfig planeConfig = getPlaneConfig(format);
+  SkYUVAInfo::Subsampling subsampling = getSubsampling(format);
+  SkYUVColorSpace colorspace = getColorspace(format);
+
+  return SkYUVAInfo(size, planeConfig, subsampling, colorspace);
+}
+
+MTLPixelFormat SkiaCVPixelBufferUtils::getMTLPixelFormatForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex) {
+  size_t width = CVPixelBufferGetWidthOfPlane(pixelBuffer, planeIndex);
+  size_t bytesPerRow = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, planeIndex);
+  double bytesPerPixel = round(static_cast<double>(bytesPerRow) / width);
+  if (bytesPerPixel == 1) {
+    return MTLPixelFormatR8Unorm;
+  } else if (bytesPerPixel == 2) {
+    return MTLPixelFormatRG8Unorm;
+  } else if (bytesPerPixel == 4) {
+    return MTLPixelFormatRGBA8Unorm;
+  } else {
+    throw std::runtime_error("Invalid bytes per row! Expected 1 (R), 2 (RG) or 4 (RGBA), but received " + std::to_string(bytesPerPixel));
+  }
+}
+
+GrYUVABackendTextures SkiaCVPixelBufferUtils::getYUVTexturesFromCVPixelBuffer(CVPixelBufferRef pixelBuffer) {
+  // 1. Get all planes (YUV, Y_UV, Y_U_V or Y_U_V_A)
+  size_t planesCount = CVPixelBufferGetPlaneCount(pixelBuffer);
+  GrBackendTexture textures[planesCount];
+
+  for (size_t planeIndex = 0; planeIndex < planesCount; planeIndex++) {
+    MTLPixelFormat pixelFormat = getMTLPixelFormatForCVPixelBufferPlane(pixelBuffer, planeIndex);
+    NSLog(@"Plane %zu is in %zu", planeIndex, pixelFormat);
+    GrBackendTexture texture = getTextureFromCVPixelBuffer(pixelBuffer, planeIndex, pixelFormat);
+    textures[planeIndex] = texture;
+  }
+
+  // 2. Wrap info about buffer
+  SkYUVAInfo info = getYUVAInfoForCVPixelBuffer(pixelBuffer);
+
+  // 3. Return all textures
+  return GrYUVABackendTextures(info, textures, kTopLeft_GrSurfaceOrigin);
+}
+
+CVPixelBufferBaseFormat SkiaCVPixelBufferUtils::getCVPixelBufferBaseFormat(CVPixelBufferRef pixelBuffer) {
+  OSType format = CVPixelBufferGetPixelFormatType(pixelBuffer);
+  switch (format) {
+    // 8-bit YUV formats
+    case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_422YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr8BiPlanarFullRange:
+    // 10-bit YUV formats
+    case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_444YpCbCr10BiPlanarFullRange:
+      return CVPixelBufferBaseFormat::yuv;
+    case kCVPixelFormatType_24RGB:
+    case kCVPixelFormatType_24BGR:
+    case kCVPixelFormatType_32ARGB:
+    case kCVPixelFormatType_32BGRA:
+    case kCVPixelFormatType_32ABGR:
+    case kCVPixelFormatType_32RGBA:
+    case kCVPixelFormatType_64ARGB:
+    case kCVPixelFormatType_64RGBALE:
+    case kCVPixelFormatType_48RGB:
+    case kCVPixelFormatType_30RGB:
+      return CVPixelBufferBaseFormat::rgb;
+    default:
+      throw std::runtime_error("Invalid CVPixelBuffer format! " + std::string(FourCC2Str(format)));
+  }
+}

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
@@ -54,6 +54,7 @@ RGBFormatInfo SkiaCVPixelBufferUtils::getRGBCVPixelBufferFormatInfo(CVPixelBuffe
     case kCVPixelFormatType_32BGRA:
       metalFormat = MTLPixelFormatBGRA8Unorm;
       skiaFormat = kBGRA_8888_SkColorType;
+      break;
     // This can be extended with branches for specific RGB formats if new Apple uses new formats.
     default:
       throw std::runtime_error("CVPixelBuffer has unknown RGB format! " + std::string(FourCC2Str(format)));

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
@@ -29,8 +29,7 @@ CVMetalTextureCacheRef SkiaCVPixelBufferUtils::getTextureCache() {
   static thread_local size_t accessCounter = 0;
   if (textureCache == nil) {
     // Create a new Texture Cache
-    const auto& context = ThreadContextHolder::getThreadSpecificSkiaContext();
-    auto result = CVMetalTextureCacheCreate(kCFAllocatorDefault, nil, context->device,
+    auto result = CVMetalTextureCacheCreate(kCFAllocatorDefault, nil, MTLCreateSystemDefaultDevice(),
                                             nil, &textureCache);
     if (result != kCVReturnSuccess || textureCache == nil) {
       throw std::runtime_error("Failed to create Metal Texture Cache!");

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.h
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.h
@@ -5,7 +5,6 @@
 
 #import "include/core/SkCanvas.h"
 #import <CoreMedia/CMSampleBuffer.h>
-#import <CoreVideo/CVMetalTextureCache.h>
 #import <include/gpu/GrDirectContext.h>
 
 #pragma clang diagnostic pop
@@ -33,5 +32,4 @@ private:
   static id<MTLDevice> device;
   static bool
   createSkiaDirectContextIfNecessary(SkiaMetalContext *threadContext);
-  static CVMetalTextureCacheRef getTextureCache();
 };

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -121,11 +121,10 @@ sk_sp<SkImage> SkiaMetalSurfaceFactory::makeImageFromCMSampleBuffer(
 
   CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
 
-  // Make sure the format is RGB (BGRA_8888)
   CVPixelBufferBaseFormat baseFormat = SkiaCVPixelBufferUtils::getCVPixelBufferBaseFormat(pixelBuffer);
   switch (baseFormat) {
     case CVPixelBufferBaseFormat::rgb: {
-      // It's in RGB (BGRA_32), single plane
+      // It's in RGB, single plane
       RGBFormatInfo rgbInfo = SkiaCVPixelBufferUtils::getRGBCVPixelBufferFormatInfo(pixelBuffer);
       GrBackendTexture texture = SkiaCVPixelBufferUtils::getTextureFromCVPixelBuffer(pixelBuffer, /*planeIndex */ 0, rgbInfo.metalFormat);
       return SkImages::AdoptTextureFrom(context.skContext.get(), texture, kTopLeft_GrSurfaceOrigin, rgbInfo.skiaFormat, kOpaque_SkAlphaType);

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -1,6 +1,7 @@
 #import "RNSkLog.h"
 
 #include "SkiaMetalSurfaceFactory.h"
+#import "SkiaCVPixelBufferUtils.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
@@ -16,20 +17,6 @@
 
 #pragma clang diagnostic pop
 
-#include <TargetConditionals.h>
-#if TARGET_RT_BIG_ENDIAN
-#define FourCC2Str(fourcc)                                                     \
-  (const char[]) {                                                             \
-    *((char *)&fourcc), *(((char *)&fourcc) + 1), *(((char *)&fourcc) + 2),    \
-        *(((char *)&fourcc) + 3), 0                                            \
-  }
-#else
-#define FourCC2Str(fourcc)                                                     \
-  (const char[]) {                                                             \
-    *(((char *)&fourcc) + 3), *(((char *)&fourcc) + 2),                        \
-        *(((char *)&fourcc) + 1), *(((char *)&fourcc) + 0), 0                  \
-  }
-#endif
 
 thread_local SkiaMetalContext ThreadContextHolder::ThreadSkiaMetalContext;
 
@@ -120,88 +107,41 @@ sk_sp<SkSurface> SkiaMetalSurfaceFactory::makeOffscreenSurface(int width,
   return surface;
 }
 
-CVMetalTextureCacheRef SkiaMetalSurfaceFactory::getTextureCache() {
-  static thread_local CVMetalTextureCacheRef textureCache = nil;
-  static thread_local size_t accessCounter = 0;
-  if (textureCache == nil) {
-    // Create a new Texture Cache
-    auto result = CVMetalTextureCacheCreate(kCFAllocatorDefault, nil, device,
-                                            nil, &textureCache);
-    if (result != kCVReturnSuccess || textureCache == nil) {
-      throw std::runtime_error("Failed to create Metal Texture Cache!");
-    }
-  }
-  accessCounter++;
-  if (accessCounter > 5) {
-    // Every 5 accesses, we perform some internal recycling/housekeeping
-    // operations.
-    CVMetalTextureCacheFlush(textureCache, 0);
-    accessCounter = 0;
-  }
-  return textureCache;
-}
-
 sk_sp<SkImage> SkiaMetalSurfaceFactory::makeImageFromCMSampleBuffer(
     CMSampleBufferRef sampleBuffer) {
   if (!SkiaMetalSurfaceFactory::createSkiaDirectContextIfNecessary(
           &ThreadContextHolder::ThreadSkiaMetalContext)) {
     throw std::runtime_error("Failed to create Skia Context for this Thread!");
   }
+  const SkiaMetalContext& context = ThreadContextHolder::ThreadSkiaMetalContext;
 
   if (!CMSampleBufferIsValid(sampleBuffer)) {
     throw std::runtime_error("The given CMSampleBuffer is not valid!");
   }
 
   CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
-  double width = CVPixelBufferGetWidth(pixelBuffer);
-  double height = CVPixelBufferGetHeight(pixelBuffer);
 
   // Make sure the format is RGB (BGRA_8888)
-  OSType format = CVPixelBufferGetPixelFormatType(pixelBuffer);
-  if (format != kCVPixelFormatType_32BGRA) {
-    // TODO: Also support YUV (kCVPixelFormatType_420YpCbCr8Planar) as that is
-    // much more efficient!
-    auto error = std::string("CMSampleBuffer has unknown Pixel Format (") +
-                 FourCC2Str(format) +
-                 std::string(") - cannot convert to SkImage!");
-    throw std::runtime_error(error);
+  CVPixelBufferBaseFormat baseFormat = SkiaCVPixelBufferUtils::getCVPixelBufferBaseFormat(pixelBuffer);
+  switch (baseFormat) {
+    case CVPixelBufferBaseFormat::rgb: {
+      // It's in RGB (BGRA_32), single plane
+      GrBackendTexture backendTexture = SkiaCVPixelBufferUtils::getTextureFromCVPixelBuffer(pixelBuffer, /*planeIndex */ 0, MTLPixelFormatBGRA8Unorm);
+      auto image = SkImages::AdoptTextureFrom(context.skContext.get(), backendTexture, kTopLeft_GrSurfaceOrigin,
+                                              kBGRA_8888_SkColorType, kOpaque_SkAlphaType);
+      return image;
+    }
+    case CVPixelBufferBaseFormat::yuv: {
+      // It's in YUV, multi-plane
+      GrYUVABackendTextures textures = SkiaCVPixelBufferUtils::getYUVTexturesFromCVPixelBuffer(pixelBuffer);
+
+      auto image = SkImages::TextureFromYUVATextures(context.skContext.get(), textures, nullptr, [](void* context) {
+        // TODO: Proper cleanup
+      }, nullptr);
+      return image;
+    }
+    default: {
+      throw std::runtime_error("Unknown PixelBuffer format!");
+    }
   }
-
-  CVMetalTextureCacheRef textureCache = getTextureCache();
-
-  // Convert CMSampleBuffer* -> CVMetalTexture*
-  CVMetalTextureRef cvTexture;
-  CVReturn result = CVMetalTextureCacheCreateTextureFromImage(
-      kCFAllocatorDefault, textureCache, pixelBuffer, nil,
-      MTLPixelFormatBGRA8Unorm, width, height,
-      0, // plane index
-      &cvTexture);
-  if (result != kCVReturnSuccess) {
-    throw std::runtime_error(
-        "Failed to create Metal Texture from CMSampleBuffer! Result: " +
-        std::to_string(result));
-  }
-
-  id<MTLTexture> mtlTexture = CVMetalTextureGetTexture(cvTexture);
-  if (mtlTexture == nil) {
-    throw std::runtime_error(
-        "Failed to convert CMSampleBuffer to SkImage - cannot get MTLTexture!");
-  }
-
-  // Convert the rendered MTLTexture to an SkImage
-  GrMtlTextureInfo textureInfo;
-  textureInfo.fTexture.retain((__bridge void *)mtlTexture);
-  GrBackendTexture backendTexture((int)mtlTexture.width, (int)mtlTexture.height,
-                                  skgpu::Mipmapped::kNo, textureInfo);
-
-  auto context = ThreadContextHolder::ThreadSkiaMetalContext.skContext;
-  // TODO: Adopt or Borrow?
-  auto image = SkImages::AdoptTextureFrom(
-      context.get(), backendTexture, kTopLeft_GrSurfaceOrigin,
-      kBGRA_8888_SkColorType, kOpaque_SkAlphaType, SkColorSpace::MakeSRGB());
-
-  // Release the Texture wrapper (it will still be strong)
-  CFRelease(cvTexture);
-
-  return image;
 }

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -1,7 +1,7 @@
 #import "RNSkLog.h"
 
-#include "SkiaMetalSurfaceFactory.h"
 #import "SkiaCVPixelBufferUtils.h"
+#include "SkiaMetalSurfaceFactory.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
@@ -16,7 +16,6 @@
 #import <include/gpu/ganesh/SkSurfaceGanesh.h>
 
 #pragma clang diagnostic pop
-
 
 thread_local SkiaMetalContext ThreadContextHolder::ThreadSkiaMetalContext;
 
@@ -113,7 +112,7 @@ sk_sp<SkImage> SkiaMetalSurfaceFactory::makeImageFromCMSampleBuffer(
           &ThreadContextHolder::ThreadSkiaMetalContext)) [[unlikely]] {
     throw std::runtime_error("Failed to create Skia Context for this Thread!");
   }
-  const SkiaMetalContext& context = ThreadContextHolder::ThreadSkiaMetalContext;
+  const SkiaMetalContext &context = ThreadContextHolder::ThreadSkiaMetalContext;
 
   if (!CMSampleBufferIsValid(sampleBuffer)) [[unlikely]] {
     throw std::runtime_error("The given CMSampleBuffer is not valid!");
@@ -121,21 +120,27 @@ sk_sp<SkImage> SkiaMetalSurfaceFactory::makeImageFromCMSampleBuffer(
 
   CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
 
-  CVPixelBufferBaseFormat baseFormat = SkiaCVPixelBufferUtils::getCVPixelBufferBaseFormat(pixelBuffer);
+  CVPixelBufferBaseFormat baseFormat =
+      SkiaCVPixelBufferUtils::getCVPixelBufferBaseFormat(pixelBuffer);
   switch (baseFormat) {
-    case CVPixelBufferBaseFormat::rgb: {
-      // It's in RGB, single plane
-      RGBFormatInfo rgbInfo = SkiaCVPixelBufferUtils::getRGBCVPixelBufferFormatInfo(pixelBuffer);
-      GrBackendTexture texture = SkiaCVPixelBufferUtils::getTextureFromCVPixelBuffer(pixelBuffer, /*planeIndex */ 0, rgbInfo.metalFormat);
-      return SkImages::AdoptTextureFrom(context.skContext.get(), texture, kTopLeft_GrSurfaceOrigin, rgbInfo.skiaFormat, kOpaque_SkAlphaType);
-    }
-    case CVPixelBufferBaseFormat::yuv: {
-      // It's in YUV, multi-plane
-      GrYUVABackendTextures textures = SkiaCVPixelBufferUtils::getYUVTexturesFromCVPixelBuffer(pixelBuffer);
-      return SkImages::TextureFromYUVATextures(context.skContext.get(), textures);
-    }
-    default: [[unlikely]] {
-      throw std::runtime_error("Unknown PixelBuffer format!");
-    }
+  case CVPixelBufferBaseFormat::rgb: {
+    // It's in RGB, single plane
+    RGBFormatInfo rgbInfo =
+        SkiaCVPixelBufferUtils::getRGBCVPixelBufferFormatInfo(pixelBuffer);
+    GrBackendTexture texture =
+        SkiaCVPixelBufferUtils::getTextureFromCVPixelBuffer(
+            pixelBuffer, /*planeIndex */ 0, rgbInfo.metalFormat);
+    return SkImages::AdoptTextureFrom(context.skContext.get(), texture,
+                                      kTopLeft_GrSurfaceOrigin,
+                                      rgbInfo.skiaFormat, kOpaque_SkAlphaType);
+  }
+  case CVPixelBufferBaseFormat::yuv: {
+    // It's in YUV, multi-plane
+    GrYUVABackendTextures textures =
+        SkiaCVPixelBufferUtils::getYUVTexturesFromCVPixelBuffer(pixelBuffer);
+    return SkImages::TextureFromYUVATextures(context.skContext.get(), textures);
+  }
+  default:
+    [[unlikely]] { throw std::runtime_error("Unknown PixelBuffer format!"); }
   }
 }

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -110,12 +110,12 @@ sk_sp<SkSurface> SkiaMetalSurfaceFactory::makeOffscreenSurface(int width,
 sk_sp<SkImage> SkiaMetalSurfaceFactory::makeImageFromCMSampleBuffer(
     CMSampleBufferRef sampleBuffer) {
   if (!SkiaMetalSurfaceFactory::createSkiaDirectContextIfNecessary(
-          &ThreadContextHolder::ThreadSkiaMetalContext)) {
+          &ThreadContextHolder::ThreadSkiaMetalContext)) [[unlikely]] {
     throw std::runtime_error("Failed to create Skia Context for this Thread!");
   }
   const SkiaMetalContext& context = ThreadContextHolder::ThreadSkiaMetalContext;
 
-  if (!CMSampleBufferIsValid(sampleBuffer)) {
+  if (!CMSampleBufferIsValid(sampleBuffer)) [[unlikely]] {
     throw std::runtime_error("The given CMSampleBuffer is not valid!");
   }
 
@@ -134,7 +134,7 @@ sk_sp<SkImage> SkiaMetalSurfaceFactory::makeImageFromCMSampleBuffer(
       GrYUVABackendTextures textures = SkiaCVPixelBufferUtils::getYUVTexturesFromCVPixelBuffer(pixelBuffer);
       return SkImages::TextureFromYUVATextures(context.skContext.get(), textures);
     }
-    default: {
+    default: [[unlikely]] {
       throw std::runtime_error("Unknown PixelBuffer format!");
     }
   }


### PR DESCRIPTION
### Backstory

PlatformBuffers (`CMSampleBuffer` and `AHardwareBuffer*`) are image buffers (often on the GPU) that are coming from a realtime source.
This realtime source might be a Video Player playing back or a Camera streaming Frames from it's sensor.

In pretty much all cases, the "native" format of such platform buffers is YUV, not RGB.

In the case of VisionCamera, there is an option to convert from YUV to RGB at application level before I pass the PlatformBuffer to Skia (so I can pass an RGB PlatformBuffer to `MakeImageFromPlatformBuffer`), but it comes with an overhead.
On iOS, that overhead is a bit smaller but on Android the overhead is quite large as it is a CPU operation to convert from YUV to RGB.

Additionally, YUV supports some HDR formats which we can support in Skia in the future, so it is a good idea to already build the foundation for that.

I also [created a thread in the skia-discuss google group](https://groups.google.com/g/skia-discuss/c/J4dH2PJr2-E) to ask about YUV buffers and the related APIs.

### YUV Formats

With this PR we can now use `MakeImageFromPlatformBuffer(..)` with truly native YUV PlatformBuffers, and all conversions (YUV -> RGB) will be handled by Skia, probably on the GPU.

This is much more efficient and easier than doing it on application level before Skia.

Also, this supports multiple different YUV formats such as 8-bit and 10-bit YUV, single-, bi- and tri-planar buffers, and 4:2:0, 4:4:4, 4:2:2 layouts.

Everything is inside `SkiaCVPixelBufferUtils`, and can be extended in the future if we want to support a new YUV format (this happened a few years ago when apple introduced 10-bit YUV formats)