### PR TITLE
feat: Use Metal for creating PlatformBuffers

### DIFF
--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
@@ -5,8 +5,8 @@
 #include <thread>
 #include <utility>
 
-#import "SkiaMetalSurfaceFactory.h"
 #import "SkiaCVPixelBufferUtils.h"
+#import "SkiaMetalSurfaceFactory.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"

--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
@@ -112,7 +112,7 @@ uint64_t RNSkiOSPlatformContext::makePlatformBuffer(sk_sp<SkImage> image) {
   // Create the CVPixelBuffer with the image data
   void *context = static_cast<void *>(
       new sk_sp<SkData>(buf)); // Create a copy for the context
-  CVReturn r = CVPixelBufferCreateWithBytes(
+  CVReturn result = CVPixelBufferCreateWithBytes(
       nullptr, // allocator
       image->width(), image->height(), pixelFormatType,
       pixelData,                                         // pixel data
@@ -127,8 +127,8 @@ uint64_t RNSkiOSPlatformContext::makePlatformBuffer(sk_sp<SkImage> image) {
       &pixelBuffer // the newly created pixel buffer
   );
 
-  if (r != kCVReturnSuccess) {
-    return 0; // or handle error appropriately
+  if (result != kCVReturnSuccess) {
+    throw std::runtime_error("Failed to create CVPixelBuffer from SkImage! Return value: " + std::to_string(result));
   }
 
   // Wrap the CVPixelBuffer in a CMSampleBuffer
@@ -157,7 +157,7 @@ uint64_t RNSkiOSPlatformContext::makePlatformBuffer(sk_sp<SkImage> image) {
     if (pixelBuffer) {
       CFRelease(pixelBuffer);
     }
-    return 0;
+    throw std::runtime_error("Failed to wrap CVPixelBuffer in CMSampleBuffer! Return value: " + std::to_string(status));
   }
 
   // Return sampleBuffer casted to uint64_t

--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
@@ -70,7 +70,8 @@ void RNSkiOSPlatformContext::releasePlatformBuffer(uint64_t pointer) {
 }
 
 OSType getCVPixelBufferPixelFormatForSkColorType(SkColorType colorType) {
-  // iOS only supports 32BGRA and 32ARGB for RGB CVPixelBuffers. Other formats are not supported.
+  // iOS only supports 32BGRA and 32ARGB for RGB CVPixelBuffers. Other formats
+  // are not supported.
   switch (colorType) {
   case SkColorType::kBGRA_8888_SkColorType:
     return kCVPixelFormatType_32BGRA;
@@ -84,14 +85,16 @@ OSType getCVPixelBufferPixelFormatForSkColorType(SkColorType colorType) {
 uint64_t RNSkiOSPlatformContext::makePlatformBuffer(sk_sp<SkImage> image) {
   if (image->colorType() != kBGRA_8888_SkColorType) {
     // on iOS, 32_BGRA is the only supported RGB format for CVPixelBuffers.
-    image = image->makeColorTypeAndColorSpace(ThreadContextHolder::ThreadSkiaMetalContext.skContext.get(),
-                                              kBGRA_8888_SkColorType,
-                                              SkColorSpace::MakeSRGB());
+    image = image->makeColorTypeAndColorSpace(
+        ThreadContextHolder::ThreadSkiaMetalContext.skContext.get(),
+        kBGRA_8888_SkColorType, SkColorSpace::MakeSRGB());
     if (image == nullptr) {
-      throw std::runtime_error("Failed to convert image to BGRA_8888 colortype! Only BGRA_8888 PlatformBuffers are supported.");
+      throw std::runtime_error(
+          "Failed to convert image to BGRA_8888 colortype! Only BGRA_8888 "
+          "PlatformBuffers are supported.");
     }
   }
-  
+
   auto bytesPerPixel = image->imageInfo().bytesPerPixel();
   int bytesPerRow = image->width() * bytesPerPixel;
   auto buf = SkData::MakeUninitialized(image->width() * image->height() *
@@ -128,7 +131,9 @@ uint64_t RNSkiOSPlatformContext::makePlatformBuffer(sk_sp<SkImage> image) {
   );
 
   if (result != kCVReturnSuccess) {
-    throw std::runtime_error("Failed to create CVPixelBuffer from SkImage! Return value: " + std::to_string(result));
+    throw std::runtime_error(
+        "Failed to create CVPixelBuffer from SkImage! Return value: " +
+        std::to_string(result));
   }
 
   // Wrap the CVPixelBuffer in a CMSampleBuffer
@@ -157,7 +162,9 @@ uint64_t RNSkiOSPlatformContext::makePlatformBuffer(sk_sp<SkImage> image) {
     if (pixelBuffer) {
       CFRelease(pixelBuffer);
     }
-    throw std::runtime_error("Failed to wrap CVPixelBuffer in CMSampleBuffer! Return value: " + std::to_string(status));
+    throw std::runtime_error(
+        "Failed to wrap CVPixelBuffer in CMSampleBuffer! Return value: " +
+        std::to_string(status));
   }
 
   // Return sampleBuffer casted to uint64_t

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
@@ -18,6 +18,16 @@
 
 class SkiaCVPixelBufferUtils {
 public:
+  enum class CVPixelBufferBaseFormat { rgb };
+
+  /**
+   Get the base format (currently only RGB) of the PixelBuffer.
+   Depending on the base-format, different methods have to be used to create
+   Skia buffers.
+   */
+  static CVPixelBufferBaseFormat
+  getCVPixelBufferBaseFormat(CVPixelBufferRef pixelBuffer);
+
   class RGB {
   public:
     /**

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
@@ -12,32 +12,36 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
-#import <include/gpu/GrBackendSurface.h>
 #import "include/core/SkColorSpace.h"
+#import <include/gpu/GrBackendSurface.h>
 #pragma clang diagnostic pop
 
 class SkiaCVPixelBufferUtils {
 public:
-
-class RGB {
-public:
-  struct FormatInfo {
-    MTLPixelFormat metalFormat;
-    SkColorType skiaFormat;
+  class RGB {
+  public:
+    struct FormatInfo {
+      MTLPixelFormat metalFormat;
+      SkColorType skiaFormat;
+    };
+    /**
+     Gets RGB-specific information about a CVPixelBuffer, such as the Metal
+     format and the Skia-specific format.
+     */
+    static FormatInfo getCVPixelBufferFormatInfo(CVPixelBufferRef pixelBuffer);
+    /**
+     Gets a GPU-backed Skia Texture for the given RGB CVPixelBuffer.
+     */
+    static GrBackendTexture
+    getSkiaTextureForCVPixelBuffer(CVPixelBufferRef pixelBuffer);
   };
-  /**
-   Gets RGB-specific information about a CVPixelBuffer, such as the Metal format
-   and the Skia-specific format.
-   */
-  static FormatInfo getCVPixelBufferFormatInfo(CVPixelBufferRef pixelBuffer);
-  /**
-   Gets a GPU-backed Skia Texture for the given RGB CVPixelBuffer.
-   */
-  static GrBackendTexture getSkiaTextureForCVPixelBuffer(CVPixelBufferRef pixelBuffer);
-};
 
 private:
   static CVMetalTextureCacheRef getTextureCache();
-  static GrBackendTexture getSkiaTextureForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex);
-  static MTLPixelFormat getMTLPixelFormatForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex);
+  static GrBackendTexture
+  getSkiaTextureForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer,
+                                      size_t planeIndex);
+  static MTLPixelFormat
+  getMTLPixelFormatForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer,
+                                         size_t planeIndex);
 };

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
@@ -1,0 +1,43 @@
+//
+//  SkiaCVPixelBufferUtils.h
+//  react-native-skia
+//
+//  Created by Marc Rousavy on 10.04.24.
+//
+
+#pragma once
+#import <CoreMedia/CMSampleBuffer.h>
+#import <CoreVideo/CVMetalTextureCache.h>
+#import <MetalKit/MetalKit.h>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
+#import <include/gpu/GrBackendSurface.h>
+#import "include/core/SkColorSpace.h"
+#pragma clang diagnostic pop
+
+class SkiaCVPixelBufferUtils {
+public:
+
+class RGB {
+public:
+  struct FormatInfo {
+    MTLPixelFormat metalFormat;
+    SkColorType skiaFormat;
+  };
+  /**
+   Gets RGB-specific information about a CVPixelBuffer, such as the Metal format
+   and the Skia-specific format.
+   */
+  static FormatInfo getCVPixelBufferFormatInfo(CVPixelBufferRef pixelBuffer);
+  /**
+   Gets a GPU-backed Skia Texture for the given RGB CVPixelBuffer.
+   */
+  static GrBackendTexture getSkiaTextureForCVPixelBuffer(CVPixelBufferRef pixelBuffer);
+};
+
+private:
+  static CVMetalTextureCacheRef getTextureCache();
+  static GrBackendTexture getSkiaTextureForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex);
+  static MTLPixelFormat getMTLPixelFormatForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex);
+};

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
@@ -20,15 +20,10 @@ class SkiaCVPixelBufferUtils {
 public:
   class RGB {
   public:
-    struct FormatInfo {
-      MTLPixelFormat metalFormat;
-      SkColorType skiaFormat;
-    };
     /**
-     Gets RGB-specific information about a CVPixelBuffer, such as the Metal
-     format and the Skia-specific format.
+     Gets the Skia Color Type of the RGB pixel-buffer.
      */
-    static FormatInfo getCVPixelBufferFormatInfo(CVPixelBufferRef pixelBuffer);
+    static SkColorType getCVPixelBufferColorType(CVPixelBufferRef pixelBuffer);
     /**
      Gets a GPU-backed Skia Texture for the given RGB CVPixelBuffer.
      */

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
@@ -124,6 +124,7 @@ CVMetalTextureCacheRef SkiaCVPixelBufferUtils::getTextureCache() {
       throw std::runtime_error("Failed to create Metal Texture Cache!");
     }
   }
+  return textureCache;
 }
 
 // pragma MARK: Get CVPixelBuffer MTLPixelFormat

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
@@ -10,8 +10,8 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
-#import <include/gpu/GrBackendSurface.h>
 #import "include/core/SkColorSpace.h"
+#import <include/gpu/GrBackendSurface.h>
 #pragma clang diagnostic pop
 
 #include <TargetConditionals.h>
@@ -29,10 +29,10 @@
   }
 #endif
 
-
 // pragma MARK: RGB
 
-SkiaCVPixelBufferUtils::RGB::FormatInfo SkiaCVPixelBufferUtils::RGB::getCVPixelBufferFormatInfo(
+SkiaCVPixelBufferUtils::RGB::FormatInfo
+SkiaCVPixelBufferUtils::RGB::getCVPixelBufferFormatInfo(
     CVPixelBufferRef pixelBuffer) {
   OSType format = CVPixelBufferGetPixelFormatType(pixelBuffer);
 
@@ -50,16 +50,19 @@ SkiaCVPixelBufferUtils::RGB::FormatInfo SkiaCVPixelBufferUtils::RGB::getCVPixelB
         "CVPixelBuffer has unknown RGB format! " +
         std::string(FourCC2Str(format)));
   }
-  return SkiaCVPixelBufferUtils::RGB::FormatInfo{.metalFormat = metalFormat, .skiaFormat = skiaFormat};
+  return SkiaCVPixelBufferUtils::RGB::FormatInfo{.metalFormat = metalFormat,
+                                                 .skiaFormat = skiaFormat};
 }
 
-GrBackendTexture SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(CVPixelBufferRef pixelBuffer) {
+GrBackendTexture SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(
+    CVPixelBufferRef pixelBuffer) {
   return getSkiaTextureForCVPixelBufferPlane(pixelBuffer, /* planeIndex */ 0);
 }
 
 // pragma MARK: CVPixelBuffer -> Skia Texture
 
-GrBackendTexture SkiaCVPixelBufferUtils::getSkiaTextureForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex) {
+GrBackendTexture SkiaCVPixelBufferUtils::getSkiaTextureForCVPixelBufferPlane(
+    CVPixelBufferRef pixelBuffer, size_t planeIndex) {
   // 1. Get cache
   CVMetalTextureCacheRef textureCache = getTextureCache();
 
@@ -67,7 +70,8 @@ GrBackendTexture SkiaCVPixelBufferUtils::getSkiaTextureForCVPixelBufferPlane(CVP
   CVMetalTextureRef textureHolder;
   size_t width = CVPixelBufferGetWidthOfPlane(pixelBuffer, planeIndex);
   size_t height = CVPixelBufferGetHeightOfPlane(pixelBuffer, planeIndex);
-  MTLPixelFormat pixelFormat = getMTLPixelFormatForCVPixelBufferPlane(pixelBuffer, planeIndex);
+  MTLPixelFormat pixelFormat =
+      getMTLPixelFormatForCVPixelBufferPlane(pixelBuffer, planeIndex);
   CVReturn result = CVMetalTextureCacheCreateTextureFromImage(
       kCFAllocatorDefault, textureCache, pixelBuffer, nil, pixelFormat, width,
       height, planeIndex, &textureHolder);

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
@@ -1,0 +1,140 @@
+//
+//  SkiaCVPixelBufferUtils.mm
+//  react-native-skia
+//
+//  Created by Marc Rousavy on 10.04.24.
+//
+
+#import "SkiaCVPixelBufferUtils.h"
+#import "SkiaMetalSurfaceFactory.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
+#import <include/gpu/GrBackendSurface.h>
+#import "include/core/SkColorSpace.h"
+#pragma clang diagnostic pop
+
+#include <TargetConditionals.h>
+#if TARGET_RT_BIG_ENDIAN
+#define FourCC2Str(fourcc)                                                     \
+  (const char[]) {                                                             \
+    *((char *)&fourcc), *(((char *)&fourcc) + 1), *(((char *)&fourcc) + 2),    \
+        *(((char *)&fourcc) + 3), 0                                            \
+  }
+#else
+#define FourCC2Str(fourcc)                                                     \
+  (const char[]) {                                                             \
+    *(((char *)&fourcc) + 3), *(((char *)&fourcc) + 2),                        \
+        *(((char *)&fourcc) + 1), *(((char *)&fourcc) + 0), 0                  \
+  }
+#endif
+
+
+// pragma MARK: RGB
+
+SkiaCVPixelBufferUtils::RGB::FormatInfo SkiaCVPixelBufferUtils::RGB::getCVPixelBufferFormatInfo(
+    CVPixelBufferRef pixelBuffer) {
+  OSType format = CVPixelBufferGetPixelFormatType(pixelBuffer);
+
+  MTLPixelFormat metalFormat;
+  SkColorType skiaFormat;
+  switch (format) {
+  case kCVPixelFormatType_32BGRA:
+    [[likely]] metalFormat = MTLPixelFormatBGRA8Unorm;
+    skiaFormat = kBGRA_8888_SkColorType;
+    break;
+  // This can be extended with branches for specific RGB formats if new Apple
+  // uses new formats.
+  default:
+    [[unlikely]] throw std::runtime_error(
+        "CVPixelBuffer has unknown RGB format! " +
+        std::string(FourCC2Str(format)));
+  }
+  return SkiaCVPixelBufferUtils::RGB::FormatInfo{.metalFormat = metalFormat, .skiaFormat = skiaFormat};
+}
+
+GrBackendTexture SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(CVPixelBufferRef pixelBuffer) {
+  return getSkiaTextureForCVPixelBufferPlane(pixelBuffer, /* planeIndex */ 0);
+}
+
+// pragma MARK: CVPixelBuffer -> Skia Texture
+
+GrBackendTexture SkiaCVPixelBufferUtils::getSkiaTextureForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex) {
+  // 1. Get cache
+  CVMetalTextureCacheRef textureCache = getTextureCache();
+
+  // 2. Get MetalTexture from CMSampleBuffer
+  CVMetalTextureRef textureHolder;
+  size_t width = CVPixelBufferGetWidthOfPlane(pixelBuffer, planeIndex);
+  size_t height = CVPixelBufferGetHeightOfPlane(pixelBuffer, planeIndex);
+  MTLPixelFormat pixelFormat = getMTLPixelFormatForCVPixelBufferPlane(pixelBuffer, planeIndex);
+  CVReturn result = CVMetalTextureCacheCreateTextureFromImage(
+      kCFAllocatorDefault, textureCache, pixelBuffer, nil, pixelFormat, width,
+      height, planeIndex, &textureHolder);
+  if (result != kCVReturnSuccess) [[unlikely]] {
+    throw std::runtime_error(
+        "Failed to create Metal Texture from CMSampleBuffer! Result: " +
+        std::to_string(result));
+  }
+
+  // 2. Unwrap the underlying MTLTexture
+  id<MTLTexture> mtlTexture = CVMetalTextureGetTexture(textureHolder);
+  if (mtlTexture == nil) [[unlikely]] {
+    throw std::runtime_error(
+        "Failed to get MTLTexture from CVMetalTextureRef!");
+  }
+
+  // 3. Wrap MTLTexture in Skia's GrBackendTexture
+  GrMtlTextureInfo textureInfo;
+  textureInfo.fTexture.retain((__bridge void *)mtlTexture);
+  GrBackendTexture texture =
+      GrBackendTexture((int)mtlTexture.width, (int)mtlTexture.height,
+                       skgpu::Mipmapped::kNo, textureInfo);
+  CFRelease(textureHolder);
+  return texture;
+}
+
+// pragma MARK: getTextureCache()
+
+CVMetalTextureCacheRef SkiaCVPixelBufferUtils::getTextureCache() {
+  static thread_local CVMetalTextureCacheRef textureCache = nil;
+  static thread_local size_t accessCounter = 0;
+  if (textureCache == nil) {
+    // Create a new Texture Cache
+    auto result = CVMetalTextureCacheCreate(kCFAllocatorDefault, nil,
+                                            MTLCreateSystemDefaultDevice(), nil,
+                                            &textureCache);
+    if (result != kCVReturnSuccess || textureCache == nil) {
+      throw std::runtime_error("Failed to create Metal Texture Cache!");
+    }
+  }
+  accessCounter++;
+  if (accessCounter > 30) {
+    // Every 30 accesses, we perform some internal recycling/housekeeping
+    // operations.
+    CVMetalTextureCacheFlush(textureCache, 0);
+    accessCounter = 0;
+  }
+  return textureCache;
+}
+
+// pragma MARK: Get CVPixelBuffer MTLPixelFormat
+
+MTLPixelFormat SkiaCVPixelBufferUtils::getMTLPixelFormatForCVPixelBufferPlane(
+    CVPixelBufferRef pixelBuffer, size_t planeIndex) {
+  size_t width = CVPixelBufferGetWidthOfPlane(pixelBuffer, planeIndex);
+  size_t bytesPerRow =
+      CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, planeIndex);
+  double bytesPerPixel = round(static_cast<double>(bytesPerRow) / width);
+  if (bytesPerPixel == 1) [[likely]] {
+    return MTLPixelFormatR8Unorm;
+  } else if (bytesPerPixel == 2) [[likely]] {
+    return MTLPixelFormatRG8Unorm;
+  } else if (bytesPerPixel == 4) {
+    return MTLPixelFormatBGRA8Unorm;
+  } else [[unlikely]] {
+    throw std::runtime_error("Invalid bytes per row! Expected 1 (R), 2 (RG) or "
+                             "4 (RGBA), but received " +
+                             std::to_string(bytesPerPixel));
+  }
+}

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
@@ -125,9 +125,9 @@ MTLPixelFormat SkiaCVPixelBufferUtils::getMTLPixelFormatForCVPixelBufferPlane(
   size_t bytesPerRow =
       CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, planeIndex);
   double bytesPerPixel = round(static_cast<double>(bytesPerRow) / width);
-  if (bytesPerPixel == 1) [[likely]] {
+  if (bytesPerPixel == 1) {
     return MTLPixelFormatR8Unorm;
-  } else if (bytesPerPixel == 2) [[likely]] {
+  } else if (bytesPerPixel == 2) {
     return MTLPixelFormatRG8Unorm;
   } else if (bytesPerPixel == 4) {
     return MTLPixelFormatBGRA8Unorm;

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
@@ -115,7 +115,6 @@ GrBackendTexture SkiaCVPixelBufferUtils::getSkiaTextureForCVPixelBufferPlane(
 
 CVMetalTextureCacheRef SkiaCVPixelBufferUtils::getTextureCache() {
   static thread_local CVMetalTextureCacheRef textureCache = nil;
-  static thread_local size_t accessCounter = 0;
   if (textureCache == nil) {
     // Create a new Texture Cache
     auto result = CVMetalTextureCacheCreate(kCFAllocatorDefault, nil,
@@ -125,14 +124,6 @@ CVMetalTextureCacheRef SkiaCVPixelBufferUtils::getTextureCache() {
       throw std::runtime_error("Failed to create Metal Texture Cache!");
     }
   }
-  accessCounter++;
-  if (accessCounter > 30) {
-    // Every 30 accesses, we perform some internal recycling/housekeeping
-    // operations.
-    CVMetalTextureCacheFlush(textureCache, 0);
-    accessCounter = 0;
-  }
-  return textureCache;
 }
 
 // pragma MARK: Get CVPixelBuffer MTLPixelFormat

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
@@ -31,18 +31,15 @@
 
 // pragma MARK: RGB
 
-SkiaCVPixelBufferUtils::RGB::FormatInfo
-SkiaCVPixelBufferUtils::RGB::getCVPixelBufferFormatInfo(
+SkColorType SkiaCVPixelBufferUtils::RGB::getCVPixelBufferColorType(
     CVPixelBufferRef pixelBuffer) {
   OSType format = CVPixelBufferGetPixelFormatType(pixelBuffer);
 
-  MTLPixelFormat metalFormat;
-  SkColorType skiaFormat;
   switch (format) {
   case kCVPixelFormatType_32BGRA:
-    [[likely]] metalFormat = MTLPixelFormatBGRA8Unorm;
-    skiaFormat = kBGRA_8888_SkColorType;
-    break;
+    [[likely]] return kBGRA_8888_SkColorType;
+  case kCVPixelFormatType_32RGBA:
+    return kRGBA_8888_SkColorType;
   // This can be extended with branches for specific RGB formats if new Apple
   // uses new formats.
   default:
@@ -50,8 +47,6 @@ SkiaCVPixelBufferUtils::RGB::getCVPixelBufferFormatInfo(
         "CVPixelBuffer has unknown RGB format! " +
         std::string(FourCC2Str(format)));
   }
-  return SkiaCVPixelBufferUtils::RGB::FormatInfo{.metalFormat = metalFormat,
-                                                 .skiaFormat = skiaFormat};
 }
 
 GrBackendTexture SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(

--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.mm
@@ -29,6 +29,24 @@
   }
 #endif
 
+// pragma MARK: Base
+
+SkiaCVPixelBufferUtils::CVPixelBufferBaseFormat
+SkiaCVPixelBufferUtils::getCVPixelBufferBaseFormat(
+    CVPixelBufferRef pixelBuffer) {
+  OSType format = CVPixelBufferGetPixelFormatType(pixelBuffer);
+
+  switch (format) {
+  case kCVPixelFormatType_32BGRA:
+  case kCVPixelFormatType_32RGBA:
+    return CVPixelBufferBaseFormat::rgb;
+  default:
+    [[unlikely]] throw std::runtime_error(
+        "CVPixelBuffer has unsupported pixel-format! " +
+        std::string(FourCC2Str(format)));
+  }
+}
+
 // pragma MARK: RGB
 
 SkColorType SkiaCVPixelBufferUtils::RGB::getCVPixelBufferColorType(

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.h
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.h
@@ -26,7 +26,8 @@ public:
                                               int height);
   static sk_sp<SkSurface> makeOffscreenSurface(int width, int height);
 
-  static sk_sp<SkImage> makeTextureFromCMSampleBuffer(CMSampleBufferRef sampleBuffer);
+  static sk_sp<SkImage>
+  makeTextureFromCMSampleBuffer(CMSampleBufferRef sampleBuffer);
 
 private:
   static id<MTLDevice> device;

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.h
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.h
@@ -26,7 +26,7 @@ public:
                                               int height);
   static sk_sp<SkSurface> makeOffscreenSurface(int width, int height);
 
-  static sk_sp<SkImage> makeTextureFromImage(sk_sp<SkImage> image);
+  static sk_sp<SkImage> makeTextureFromCMSampleBuffer(CMSampleBufferRef sampleBuffer);
 
 private:
   static id<MTLDevice> device;

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -121,12 +121,25 @@ sk_sp<SkImage> SkiaMetalSurfaceFactory::makeTextureFromCMSampleBuffer(
 
   CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
 
-  // Assume the CMSampleBuffer is in RGB.
-  SkColorType colorType =
-      SkiaCVPixelBufferUtils::RGB::getCVPixelBufferColorType(pixelBuffer);
-  GrBackendTexture texture =
-      SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(pixelBuffer);
-  return SkImages::AdoptTextureFrom(context.skContext.get(), texture,
-                                    kTopLeft_GrSurfaceOrigin, colorType,
-                                    kOpaque_SkAlphaType);
+  SkiaCVPixelBufferUtils::CVPixelBufferBaseFormat format =
+      SkiaCVPixelBufferUtils::getCVPixelBufferBaseFormat(pixelBuffer);
+  switch (format) {
+  case SkiaCVPixelBufferUtils::CVPixelBufferBaseFormat::rgb: {
+    // CVPixelBuffer is in any RGB format.
+    SkColorType colorType =
+        SkiaCVPixelBufferUtils::RGB::getCVPixelBufferColorType(pixelBuffer);
+    GrBackendTexture texture =
+        SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(
+            pixelBuffer);
+    return SkImages::AdoptTextureFrom(context.skContext.get(), texture,
+                                      kTopLeft_GrSurfaceOrigin, colorType,
+                                      kOpaque_SkAlphaType);
+  }
+  default:
+    [[unlikely]] {
+      throw std::runtime_error("Failed to convert PlatformBuffer to SkImage - "
+                               "PlatformBuffer has unsupported PixelFormat! " +
+                               std::to_string(static_cast<int>(format)));
+    }
+  }
 }

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -122,11 +122,11 @@ sk_sp<SkImage> SkiaMetalSurfaceFactory::makeTextureFromCMSampleBuffer(
   CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
 
   // Assume the CMSampleBuffer is in RGB.
-  SkiaCVPixelBufferUtils::RGB::FormatInfo rgbInfo =
-      SkiaCVPixelBufferUtils::RGB::getCVPixelBufferFormatInfo(pixelBuffer);
+  SkColorType colorType =
+      SkiaCVPixelBufferUtils::RGB::getCVPixelBufferColorType(pixelBuffer);
   GrBackendTexture texture =
       SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(pixelBuffer);
   return SkImages::AdoptTextureFrom(context.skContext.get(), texture,
-                                    kTopLeft_GrSurfaceOrigin,
-                                    rgbInfo.skiaFormat, kOpaque_SkAlphaType);
+                                    kTopLeft_GrSurfaceOrigin, colorType,
+                                    kOpaque_SkAlphaType);
 }

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -1,7 +1,7 @@
 #import "RNSkLog.h"
 
-#import "SkiaMetalSurfaceFactory.h"
 #import "SkiaCVPixelBufferUtils.h"
+#import "SkiaMetalSurfaceFactory.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
@@ -107,8 +107,8 @@ sk_sp<SkSurface> SkiaMetalSurfaceFactory::makeOffscreenSurface(int width,
   return surface;
 }
 
-sk_sp<SkImage>
-SkiaMetalSurfaceFactory::makeTextureFromCMSampleBuffer(CMSampleBufferRef sampleBuffer) {
+sk_sp<SkImage> SkiaMetalSurfaceFactory::makeTextureFromCMSampleBuffer(
+    CMSampleBufferRef sampleBuffer) {
   if (!SkiaMetalSurfaceFactory::createSkiaDirectContextIfNecessary(
           &ThreadContextHolder::ThreadSkiaMetalContext)) [[unlikely]] {
     throw std::runtime_error("Failed to create Skia Context for this Thread!");
@@ -122,8 +122,10 @@ SkiaMetalSurfaceFactory::makeTextureFromCMSampleBuffer(CMSampleBufferRef sampleB
   CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
 
   // Assume the CMSampleBuffer is in RGB.
-  SkiaCVPixelBufferUtils::RGB::FormatInfo rgbInfo = SkiaCVPixelBufferUtils::RGB::getCVPixelBufferFormatInfo(pixelBuffer);
-  GrBackendTexture texture = SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(pixelBuffer);
+  SkiaCVPixelBufferUtils::RGB::FormatInfo rgbInfo =
+      SkiaCVPixelBufferUtils::RGB::getCVPixelBufferFormatInfo(pixelBuffer);
+  GrBackendTexture texture =
+      SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(pixelBuffer);
   return SkImages::AdoptTextureFrom(context.skContext.get(), texture,
                                     kTopLeft_GrSurfaceOrigin,
                                     rgbInfo.skiaFormat, kOpaque_SkAlphaType);


### PR DESCRIPTION
Changes the implementation of `MakeImageFromPlatformBuffer` (which currently uses `SkData`) to use Metal instead (`MTLTexture`).

In theory, this should be more efficient as it is operating on the GPU, whereas the previous approach (`SkData`) uses CPU-shared memory (IOSurface), but I haven't tested the performance yet.

Either way, this PR also reorganizes the code a bit to be more flexible around the PixelBuffer formats and should allow YUV buffers as well (future PR).

I added `getCVPixelBufferBaseFormat(..)` which returns an enum, currently only `rgb`. In the next follow-up PR that will be extended to also support `yuv`, and I will add `CVPixelBufferUtils::YUV` utils.