### PR TITLE
fix: Refactor `thread_local SkiaMetalContext` to use DispatchQueue specific storage

### DIFF
--- a/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
+++ b/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
@@ -92,9 +92,8 @@ bool RNSkMetalCanvasProvider::renderToCanvas(
       dContext->flushAndSubmit();
     }
 
-    id<MTLCommandBuffer> commandBuffer(
-        [ThreadContextHolder::ThreadSkiaMetalContext
-                .commandQueue commandBuffer]);
+    auto &context = SkiaMetalSurfaceFactory::getSkiaContext();
+    id<MTLCommandBuffer> commandBuffer = context.commandQueue.commandBuffer;
     [commandBuffer presentDrawable:currentDrawable];
     [commandBuffer commit];
   }

--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
@@ -72,10 +72,11 @@ void RNSkiOSPlatformContext::releaseNativeBuffer(uint64_t pointer) {
 uint64_t RNSkiOSPlatformContext::makeNativeBuffer(sk_sp<SkImage> image) {
   // 0. If Image is not in BGRA, convert to BGRA as only BGRA is supported.
   if (image->colorType() != kBGRA_8888_SkColorType) {
+    auto &context = SkiaMetalSurfaceFactory::getSkiaContext();
     // on iOS, 32_BGRA is the only supported RGB format for CVPixelBuffers.
-    image = image->makeColorTypeAndColorSpace(
-        ThreadContextHolder::ThreadSkiaMetalContext.skContext.get(),
-        kBGRA_8888_SkColorType, SkColorSpace::MakeSRGB());
+    image = image->makeColorTypeAndColorSpace(context.skContext.get(),
+                                              kBGRA_8888_SkColorType,
+                                              SkColorSpace::MakeSRGB());
     if (image == nullptr) {
       throw std::runtime_error(
           "Failed to convert image to BGRA_8888 colortype! Only BGRA_8888 "

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.h
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.h
@@ -11,13 +11,9 @@
 #pragma clang diagnostic pop
 
 using SkiaMetalContext = struct SkiaMetalContext {
-  id<MTLCommandQueue> commandQueue = nullptr;
+  id<MTLDevice> device = nil;
+  id<MTLCommandQueue> commandQueue = nil;
   sk_sp<GrDirectContext> skContext = nullptr;
-};
-
-class ThreadContextHolder {
-public:
-  static thread_local SkiaMetalContext ThreadSkiaMetalContext;
 };
 
 class SkiaMetalSurfaceFactory {
@@ -29,8 +25,5 @@ public:
   static sk_sp<SkImage>
   makeTextureFromCMSampleBuffer(CMSampleBufferRef sampleBuffer);
 
-private:
-  static id<MTLDevice> device;
-  static bool
-  createSkiaDirectContextIfNecessary(SkiaMetalContext *threadContext);
+  static const SkiaMetalContext &getSkiaContext();
 };

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -125,7 +125,7 @@ sk_sp<SkImage> SkiaMetalSurfaceFactory::makeTextureFromCMSampleBuffer(
       SkiaCVPixelBufferUtils::getCVPixelBufferBaseFormat(pixelBuffer);
   switch (format) {
   case SkiaCVPixelBufferUtils::CVPixelBufferBaseFormat::rgb: {
-    // CVPixelBuffer is in any RGB format, single-plane
+    // CVPixelBuffer is in any RGB format
     SkColorType colorType =
         SkiaCVPixelBufferUtils::RGB::getCVPixelBufferColorType(pixelBuffer);
     GrBackendTexture texture =
@@ -134,13 +134,6 @@ sk_sp<SkImage> SkiaMetalSurfaceFactory::makeTextureFromCMSampleBuffer(
     return SkImages::AdoptTextureFrom(context.skContext.get(), texture,
                                       kTopLeft_GrSurfaceOrigin, colorType,
                                       kOpaque_SkAlphaType);
-  }
-  case SkiaCVPixelBufferUtils::CVPixelBufferBaseFormat::yuv: {
-    // CVPixelBuffer is in any YUV format, multi-plane
-    GrYUVABackendTextures textures =
-        SkiaCVPixelBufferUtils::YUV::getSkiaTextureForCVPixelBuffer(
-            pixelBuffer);
-    return SkImages::TextureFromYUVATextures(context.skContext.get(), textures);
   }
   default:
     [[unlikely]] {

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -125,7 +125,7 @@ sk_sp<SkImage> SkiaMetalSurfaceFactory::makeTextureFromCMSampleBuffer(
       SkiaCVPixelBufferUtils::getCVPixelBufferBaseFormat(pixelBuffer);
   switch (format) {
   case SkiaCVPixelBufferUtils::CVPixelBufferBaseFormat::rgb: {
-    // CVPixelBuffer is in any RGB format
+    // CVPixelBuffer is in any RGB format.
     SkColorType colorType =
         SkiaCVPixelBufferUtils::RGB::getCVPixelBufferColorType(pixelBuffer);
     GrBackendTexture texture =

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -38,9 +38,10 @@ struct OffscreenRenderContext {
 };
 
 const SkiaMetalContext &SkiaMetalSurfaceFactory::getSkiaContext() {
-  static const auto key = "SkiaContext";
+  // this key is just used as a pointer reference.
+  static const auto key = 1;
 
-  void *state = dispatch_get_specific(key);
+  void *state = dispatch_get_specific(&key);
   if (state == nullptr) {
     NSLog(@"Re-creating SkiaContext...");
     SkiaMetalContext *context = new SkiaMetalContext();
@@ -67,7 +68,7 @@ const SkiaMetalContext &SkiaMetalSurfaceFactory::getSkiaContext() {
     // in NativeBuffer() APIs (e.g. VisionCamera or Video)
     dispatch_queue_t currentQueue = dispatch_get_current_queue();
 #pragma clang diagnostic pop
-    dispatch_queue_set_specific(currentQueue, key, state, [](void *data) {
+    dispatch_queue_set_specific(currentQueue, &key, state, [](void *data) {
       delete reinterpret_cast<SkiaMetalContext *>(data);
     });
   }


### PR DESCRIPTION
@wcandillon this PR fixes the "flickering" issue we saw where some frames just rendered black, even though the `SkImage` itself is valid.

The issue was caused by our `createSkiaDirectContextIfNecessary` function which used a `static thread_local` variable.

The problem with `thread_local` is that on iOS you are mostly using Dispatch Queues (`dispatch_queue_t`), which - by design - uses multiple Threads. Even if you configure it to run serially, it still internally isn't thread-confined, causing our code to re-initialize and override the Skia context each time.

So instead, with this PR we now use `dispatch_queue_set_specific(..)` and `dispatch_queue_get_specific(..)` to store a global static variable.
For RNSkia this doesn't change anything since the UI Thread always uses a single-thread, but for other rendering contexts (e.g. Video or react-native-vision-camera), DispatchQueues are used, which might be serial (so non-concurrent), but still use multiple Threads from the pool.
In those cases, we want to share the SkiaContext between threads (so make it not `thread_local`), but not share it between DispatchQueues.

This PR currently uses `dispatch_get_current_queue()` which is deprecated since iOS 6.0 - it should only be used for debugging per their documentation.
Our use-case is a bit different though (because we are not making any assumptions about the caller's thread as it comes from JS/Worklets) and we might actually need this. So I think it's fine.

The only alternative I can see now is to always pass the context along and hold it somewhere globally (e.g. a global JS value) which is thread-specific, but that sucks.