### PR TITLE
fix: Fix Metal NativeBuffer flickering issue

### DIFF
--- a/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
+++ b/package/ios/RNSkia-iOS/SkiaCVPixelBufferUtils.h
@@ -16,6 +16,16 @@
 #import <include/gpu/GrBackendSurface.h>
 #pragma clang diagnostic pop
 
+class TextureHolder {
+public:
+  explicit TextureHolder(CVMetalTextureRef texture);
+  ~TextureHolder();
+  
+  GrBackendTexture toGrBackendTexture();
+private:
+  CVMetalTextureRef _texture;
+};
+
 class SkiaCVPixelBufferUtils {
 public:
   enum class CVPixelBufferBaseFormat { rgb };
@@ -37,13 +47,13 @@ public:
     /**
      Gets a GPU-backed Skia Texture for the given RGB CVPixelBuffer.
      */
-    static GrBackendTexture
+    static TextureHolder*
     getSkiaTextureForCVPixelBuffer(CVPixelBufferRef pixelBuffer);
   };
 
 private:
   static CVMetalTextureCacheRef getTextureCache();
-  static GrBackendTexture
+  static TextureHolder*
   getSkiaTextureForCVPixelBufferPlane(CVPixelBufferRef pixelBuffer,
                                       size_t planeIndex);
   static MTLPixelFormat

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -128,12 +128,12 @@ sk_sp<SkImage> SkiaMetalSurfaceFactory::makeTextureFromCMSampleBuffer(
     // CVPixelBuffer is in any RGB format.
     SkColorType colorType =
         SkiaCVPixelBufferUtils::RGB::getCVPixelBufferColorType(pixelBuffer);
-    GrBackendTexture texture =
-        SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(
-            pixelBuffer);
-    return SkImages::AdoptTextureFrom(context.skContext.get(), texture,
-                                      kTopLeft_GrSurfaceOrigin, colorType,
-                                      kOpaque_SkAlphaType);
+    TextureHolder* texture = SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(pixelBuffer);
+    return SkImages::BorrowTextureFrom(context.skContext.get(), texture->toGrBackendTexture(),
+                                       kTopLeft_GrSurfaceOrigin, colorType,
+                                       kOpaque_SkAlphaType, nullptr, [](void* texture) {
+      delete (TextureHolder*)texture;
+    }, (void*)texture);
   }
   default:
     [[unlikely]] {


### PR DESCRIPTION
William and I experienced a flickering issue that appeared after a while when playing back a video using the NativeBuffer APIs.
After 5 hours of debugging and countless of print statements and renderer code rewrites, I figured out that the `CVMetalTextureCacheRef` apparently felt free to overwrite old MTLTexture buffers after a while **because we didn't hold a strong reference to the texture holder!**

In our case `CVMetalTextureCacheCreateTextureFromImage` gave us a `CVMetalTextureRef`, which we only used for the lifetime of the `getSkiaTextureForCVPixelBufferPlane` method, when in reality we should've held a reference on this for longer.

Effectively this `CFRelease` was the reason our metal texture cache pool felt free to overwrite old buffers:

```diff
  // 1. Get Metal Texture from Sample Buffer
  CVMetalTextureRef textureHolder;
  CVReturn result = CVMetalTextureCacheCreateTextureFromImage(
      kCFAllocatorDefault, textureCache, pixelBuffer, nil, pixelFormat, width,
      height, planeIndex, &textureHolder);

  // 2. Unwrap the underlying MTLTexture
  id<MTLTexture> mtlTexture = CVMetalTextureGetTexture(textureHolder);
  if (mtlTexture == nil) [[unlikely]] {
    throw std::runtime_error(
        "Failed to get MTLTexture from CVMetalTextureRef!");
  }

  // 3. Wrap MTLTexture in Skia's GrBackendTexture
  GrMtlTextureInfo textureInfo;
  textureInfo.fTexture.retain((__bridge void *)mtlTexture);
  GrBackendTexture texture =
      GrBackendTexture((int)mtlTexture.width, (int)mtlTexture.height,
                       skgpu::Mipmapped::kNo, textureInfo);
- CFRelease(textureHolder);
  return texture;
```

With this PR this is now fixed, and `CFRelease(textureHolder)` is now only called when the `SkImage` is destroyed.

cc @wcandillon 