### PR TITLE
feat: Create `Context`

### DIFF
--- a/package/cpp/api/JsiSkApi.h
+++ b/package/cpp/api/JsiSkApi.h
@@ -50,6 +50,8 @@
 #include "JsiSkTypefaceFactory.h"
 #include "JsiSkTypefaceFontProviderFactory.h"
 #include "JsiSkVertices.h"
+#include "JsiSkContext.h"
+#include "JsiSkContextFactory.h"
 
 namespace RNSkia {
 
@@ -85,6 +87,7 @@ public:
                     JsiSkPictureRecorder::createCtor(context));
     installFunction("Color", JsiSkColor::createCtor());
 
+    installReadonlyProperty("Context", std::make_shared<JsiSkContextFactory>(context));
     installReadonlyProperty("SVG", std::make_shared<JsiSkSVGFactory>(context));
     installReadonlyProperty("Image",
                             std::make_shared<JsiSkImageFactory>(context));

--- a/package/cpp/api/JsiSkContext.h
+++ b/package/cpp/api/JsiSkContext.h
@@ -15,11 +15,11 @@ namespace jsi = facebook::jsi;
 class JsiSkContext : public JsiSkWrappingSharedPtrHostObject<RNSkContext> {
 public:
   JsiSkContext(std::shared_ptr<RNSkPlatformContext> platformContext, std::shared_ptr<RNSkContext> skiaContext)
-      : JsiSkHostObject(std::move(context), std::move(skiaContext)) {}
+      : JsiSkWrappingSharedPtrHostObject(std::move(platformContext), std::move(skiaContext)) {}
 
   EXPORT_JSI_API_TYPENAME(JsiSkContext, Context)
 
-  JSI_HOST_FUNCTION(isValid) { return skiaContext->isValid(); }
+  JSI_HOST_FUNCTION(isValid) { return getObject()->isValid(); }
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkContext, isValid))
 };

--- a/package/cpp/api/JsiSkContext.h
+++ b/package/cpp/api/JsiSkContext.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <jsi/jsi.h>
+
+#include "JsiSkHostObjects.h"
+#include "../rnskia/RNSkContext.h"
+
+namespace RNSkia {
+
+namespace jsi = facebook::jsi;
+
+class JsiSkContext : public JsiSkWrappingSharedPtrHostObject<RNSkContext> {
+public:
+  JsiSkContext(std::shared_ptr<RNSkPlatformContext> platformContext, std::shared_ptr<RNSkContext> skiaContext)
+      : JsiSkHostObject(std::move(context), std::move(skiaContext)) {}
+
+  EXPORT_JSI_API_TYPENAME(JsiSkContext, Context)
+
+  JSI_HOST_FUNCTION(isValid) { return skiaContext->isValid(); }
+
+  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkContext, isValid))
+};
+
+} // namespace RNSkia

--- a/package/cpp/api/JsiSkContext.h
+++ b/package/cpp/api/JsiSkContext.h
@@ -6,16 +6,20 @@
 #include <jsi/jsi.h>
 
 #include "JsiSkHostObjects.h"
-#include "../rnskia/RNSkContext.h"
+#include "RNSkContext.h"
 
 namespace RNSkia {
 
 namespace jsi = facebook::jsi;
 
+class RNSkPlatformContext;
+
 class JsiSkContext : public JsiSkWrappingSharedPtrHostObject<RNSkContext> {
 public:
   JsiSkContext(std::shared_ptr<RNSkPlatformContext> platformContext, std::shared_ptr<RNSkContext> skiaContext)
       : JsiSkWrappingSharedPtrHostObject(std::move(platformContext), std::move(skiaContext)) {}
+  
+  std::shared_ptr<RNSkContext> getSkiaContext() { return getObject(); }
 
   EXPORT_JSI_API_TYPENAME(JsiSkContext, Context)
 

--- a/package/cpp/api/JsiSkContextFactory.h
+++ b/package/cpp/api/JsiSkContextFactory.h
@@ -18,6 +18,27 @@ public:
     return jsi::Object::createFromHostObject(
         runtime, std::make_shared<JsiSkContext>(getContext(), skiaContext));
   }
+  
+  JSI_HOST_FUNCTION(GetCurrent) {
+    std::shared_ptr<RNSkContext> skiaContext = getGlobalSkiaContext(getContext(), runtime);
+    return jsi::Object::createFromHostObject(
+        runtime, std::make_shared<JsiSkContext>(getContext(), skiaContext));
+  }
+  
+  static std::shared_ptr<RNSkContext> getGlobalSkiaContext(std::shared_ptr<RNSkPlatformContext> platformContext, jsi::Runtime& runtime) {
+    static constexpr auto NAME = "__skiaContext";
+    if (!runtime.global().hasProperty(runtime, NAME)) {
+      // create and inject Skia context into this Runtime's global for the first time
+      std::shared_ptr<RNSkContext> context = platformContext->createSkiaContext();
+      std::shared_ptr<JsiSkContext> jsiContext = std::make_shared<JsiSkContext>(platformContext, context);
+      runtime.global().setProperty(runtime, NAME, jsi::Object::createFromHostObject(runtime, jsiContext));
+      return context;
+    }
+    // lookup Skia context from global
+    jsi::Object object = runtime.global().getPropertyAsObject(runtime, NAME);
+    std::shared_ptr<JsiSkContext> hostObject = object.asHostObject<JsiSkContext>(runtime);
+    return hostObject->getContext();
+  }
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkContextFactory, Make))
 

--- a/package/cpp/api/JsiSkContextFactory.h
+++ b/package/cpp/api/JsiSkContextFactory.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <jsi/jsi.h>
+
+#include "JsiSkContext.h"
+
+namespace RNSkia {
+
+namespace jsi = facebook::jsi;
+
+class JsiSkContextFactory : public JsiSkHostObject {
+public:
+  JSI_HOST_FUNCTION(Make) {
+    std::shared_ptr<RNSkContext> skiaContext = getContext()->createSkiaContext();
+    return jsi::Object::createFromHostObject(
+        runtime, std::make_shared<JsiSkContext>(getContext(), skiaContext));
+  }
+
+  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkContextFactory, Make))
+
+  explicit JsiSkContextFactory(
+      std::shared_ptr<RNSkPlatformContext> context)
+      : JsiSkHostObject(std::move(context)) {}
+};
+
+} // namespace RNSkia

--- a/package/cpp/rnskia/RNSkContext.h
+++ b/package/cpp/rnskia/RNSkContext.h
@@ -1,0 +1,18 @@
+
+#pragma once
+
+#include <memory>
+#include "include/gpu/GrDirectContext.h"
+
+namespace RNSkia {
+
+/**
+ * Skia context for the platform-specific graphics API.
+ */
+class RNSkContext {
+public:
+  virtual std::shared_ptr<GrDirectContext> getDirectContext() = 0;
+  virtual bool isValid() = 0;
+};
+
+} // namespace RNSkia

--- a/package/cpp/rnskia/RNSkContext.h
+++ b/package/cpp/rnskia/RNSkContext.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include "include/gpu/GrDirectContext.h"
+#include "include/core/SkRefCnt.h"
 
 namespace RNSkia {
 
@@ -11,7 +12,7 @@ namespace RNSkia {
  */
 class RNSkContext {
 public:
-  virtual std::shared_ptr<GrDirectContext> getDirectContext() = 0;
+  virtual sk_sp<GrDirectContext> getDirectContext() = 0;
   virtual bool isValid() = 0;
 };
 

--- a/package/cpp/rnskia/RNSkPlatformContext.h
+++ b/package/cpp/rnskia/RNSkPlatformContext.h
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "RNSkDispatchQueue.h"
+#include "RNSkContext.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
@@ -124,6 +125,12 @@ public:
    * @param err Error to raise
    */
   virtual void raiseError(const std::exception &err) = 0;
+
+  /**
+   * Creates a Skia context using the underlying native platform graphics
+   * APIs.
+   */
+  virtual std::shared_ptr<RNSkContext> createSkiaContext() = 0;
 
   /**
    * Creates an offscreen surface

--- a/package/cpp/rnskia/RNSkPlatformContext.h
+++ b/package/cpp/rnskia/RNSkPlatformContext.h
@@ -134,24 +134,26 @@ public:
 
   /**
    * Creates an offscreen surface
+   * @param context The Skia context to use for allocating the surface
    * @param width Width of the offscreen surface
    * @param height Height of the offscreen surface
    * @return sk_sp<SkSurface>
    */
-  virtual sk_sp<SkSurface> makeOffscreenSurface(int width, int height) = 0;
+  virtual sk_sp<SkSurface> makeOffscreenSurface(std::shared_ptr<RNSkContext> context, int width, int height) = 0;
 
   /**
    * Creates an image from a native buffer.
    * - On iOS, this is a `CMSampleBuffer`
    * - On Android, this is a `AHardwareBuffer*`
-   * @param buffer The native platform buffer.
+   * @param context The Skia context to use for allocating textures
+   * @param buffer The native platform buffer
    * @return sk_sp<SkImage>
    */
-  virtual sk_sp<SkImage> makeImageFromNativeBuffer(void *buffer) = 0;
+  virtual sk_sp<SkImage> makeImageFromNativeBuffer(std::shared_ptr<RNSkContext> context, void *buffer) = 0;
 
   virtual void releaseNativeBuffer(uint64_t pointer) = 0;
 
-  virtual uint64_t makeNativeBuffer(sk_sp<SkImage> image) = 0;
+  virtual uint64_t makeNativeBuffer(std::shared_ptr<RNSkContext> skiaContext, sk_sp<SkImage> image) = 0;
 
   /**
    * Return the Platform specific font manager

--- a/package/cpp/rnskia/RNSkView.h
+++ b/package/cpp/rnskia/RNSkView.h
@@ -91,7 +91,12 @@ public:
                               std::function<void()> requestRedraw, float width,
                               float height)
       : RNSkCanvasProvider(requestRedraw), _width(width), _height(height) {
-    _surface = context->makeOffscreenSurface(_width, _height);
+    // TODO: How do we get the Runtime-specific Context here now??
+    std::shared_ptr<RNSkContext> skiaContext = nullptr;
+    if (skiaContext == nullptr) {
+      throw std::runtime_error("Skia Context cannot be null here - how do we get it here?");
+    }
+    _surface = context->makeOffscreenSurface(skiaContext, _width, _height);
     _pd = context->getPixelDensity();
   }
 

--- a/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.h
+++ b/package/ios/RNSkia-iOS/RNSkMetalCanvasProvider.h
@@ -13,21 +13,23 @@
 
 #pragma clang diagnostic pop
 
+namespace RNSkia {
+
 class RNSkMetalCanvasProvider : public RNSkia::RNSkCanvasProvider {
 public:
   RNSkMetalCanvasProvider(std::function<void()> requestRedraw,
                           std::shared_ptr<RNSkia::RNSkPlatformContext> context);
-
+  
   ~RNSkMetalCanvasProvider();
-
+  
   float getScaledWidth() override;
   float getScaledHeight() override;
-
+  
   bool renderToCanvas(const std::function<void(SkCanvas *)> &cb) override;
-
+  
   void setSize(int width, int height);
   CALayer *getLayer();
-
+  
 private:
   std::shared_ptr<RNSkia::RNSkPlatformContext> _context;
   float _width = -1;
@@ -37,3 +39,5 @@ private:
   CAMetalLayer *_layer;
 #pragma clang diagnostic pop
 };
+
+} // namespace RNSkia

--- a/package/ios/RNSkia-iOS/RNSkiOSContext.h
+++ b/package/ios/RNSkia-iOS/RNSkiOSContext.h
@@ -39,6 +39,14 @@ public:
     return skContext;
   }
   
+  id<MTLDevice> getDevice() {
+    return device;
+  }
+  
+  id<MTLCommandQueue> getCommandQueue() {
+    return commandQueue;
+  }
+  
 private:
   id<MTLDevice> device = nil;
   id<MTLCommandQueue> commandQueue = nil;

--- a/package/ios/RNSkia-iOS/RNSkiOSContext.h
+++ b/package/ios/RNSkia-iOS/RNSkiOSContext.h
@@ -35,7 +35,7 @@ public:
     return skContext != nullptr;
   }
   
-  std::shared_ptr<GrDirectContext> getDirectContext() override {
+  sk_sp<GrDirectContext> getDirectContext() override {
     return skContext;
   }
   

--- a/package/ios/RNSkia-iOS/RNSkiOSContext.h
+++ b/package/ios/RNSkia-iOS/RNSkiOSContext.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "RNSkContext.h"
+
+#include <jsi/jsi.h>
+#import <Metal/Metal.h>
+
+namespace facebook {
+namespace react {
+class CallInvoker;
+}
+} // namespace facebook
+
+namespace RNSkia {
+
+namespace jsi = facebook::jsi;
+
+class RNSkiOSContext: public RNSkContext {
+public:
+  RNSkiOSContext() {
+    device = MTLCreateSystemDefaultDevice();
+    commandQueue = [device newCommandQueue];
+    skContext = GrDirectContext::MakeMetal((__bridge void *)device,
+                                           (__bridge void *)commandQueue);
+    if (skContext == nullptr) {
+      throw std::runtime_error("Failed to create Metal Skia Context!");
+    }
+  }
+  
+  bool isValid() override {
+    return skContext != nullptr;
+  }
+  
+  std::shared_ptr<GrDirectContext> getDirectContext() override {
+    return skContext;
+  }
+  
+private:
+  id<MTLDevice> device = nil;
+  id<MTLCommandQueue> commandQueue = nil;
+  sk_sp<GrDirectContext> skContext = nullptr;
+};
+
+} // namespace RNSkia

--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
@@ -10,6 +10,7 @@
 #include "DisplayLink.h"
 #include "RNSkPlatformContext.h"
 #include "ViewScreenshotService.h"
+#include "RNSkContext.h"
 
 #include <jsi/jsi.h>
 
@@ -61,9 +62,9 @@ public:
 
   sk_sp<SkImage> takeScreenshotFromViewTag(size_t tag) override;
 
-  sk_sp<SkImage> makeImageFromNativeBuffer(void *buffer) override;
+  sk_sp<SkImage> makeImageFromNativeBuffer(std::shared_ptr<RNSkContext> context, void *buffer) override;
 
-  uint64_t makeNativeBuffer(sk_sp<SkImage> image) override;
+  uint64_t makeNativeBuffer(std::shared_ptr<RNSkContext> skiaContext, sk_sp<SkImage> image) override;
 
   void releaseNativeBuffer(uint64_t pointer) override;
 
@@ -72,7 +73,7 @@ public:
       const std::function<void(std::unique_ptr<SkStreamAsset>)> &op) override;
 
   void raiseError(const std::exception &err) override;
-  sk_sp<SkSurface> makeOffscreenSurface(int width, int height) override;
+  sk_sp<SkSurface> makeOffscreenSurface(std::shared_ptr<RNSkContext> context, int width, int height) override;
   sk_sp<SkFontMgr> createFontMgr() override;
 
   void willInvalidateModules() {

--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.h
@@ -57,6 +57,8 @@ public:
 
   void runOnMainThread(std::function<void()>) override;
 
+  std::shared_ptr<RNSkContext> createSkiaContext() override;
+
   sk_sp<SkImage> takeScreenshotFromViewTag(size_t tag) override;
 
   sk_sp<SkImage> makeImageFromNativeBuffer(void *buffer) override;

--- a/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
+++ b/package/ios/RNSkia-iOS/RNSkiOSPlatformContext.mm
@@ -7,6 +7,7 @@
 
 #import "SkiaCVPixelBufferUtils.h"
 #import "SkiaMetalSurfaceFactory.h"
+#import "RNSkiOSContext.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
@@ -56,6 +57,11 @@ void RNSkiOSPlatformContext::performStreamOperation(
 
   // Fire and forget the thread - will be resolved on completion
   std::thread(loader).detach();
+}
+
+
+std::shared_ptr<RNSkContext> RNSkiOSPlatformContext::createSkiaContext() {
+  return std::make_shared<RNSkiOSContext>();
 }
 
 void RNSkiOSPlatformContext::releaseNativeBuffer(uint64_t pointer) {

--- a/package/ios/RNSkia-iOS/RNSkiOSView.h
+++ b/package/ios/RNSkia-iOS/RNSkiOSView.h
@@ -17,17 +17,17 @@ template <class T> class RNSkiOSView : public RNSkBaseiOSView, public T {
 public:
   RNSkiOSView(std::shared_ptr<RNSkia::RNSkPlatformContext> context)
       : T(context,
-          std::make_shared<RNSkMetalCanvasProvider>(
+          std::make_shared<RNSkia::RNSkMetalCanvasProvider>(
               std::bind(&RNSkia::RNSkView::requestRedraw, this), context)) {}
 
   CALayer *getLayer() override {
-    return std::static_pointer_cast<RNSkMetalCanvasProvider>(
+    return std::static_pointer_cast<RNSkia::RNSkMetalCanvasProvider>(
                this->getCanvasProvider())
         ->getLayer();
   }
 
   void setSize(int width, int height) override {
-    std::static_pointer_cast<RNSkMetalCanvasProvider>(this->getCanvasProvider())
+    std::static_pointer_cast<RNSkia::RNSkMetalCanvasProvider>(this->getCanvasProvider())
         ->setSize(width, height);
   }
 

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.h
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.h
@@ -1,36 +1,29 @@
 #import <MetalKit/MetalKit.h>
+#import <CoreMedia/CMSampleBuffer.h>
+#import <CoreVideo/CVMetalTextureCache.h>
+#import "RNSkiOSContext.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
 
 #import "include/core/SkCanvas.h"
-#import <CoreMedia/CMSampleBuffer.h>
-#import <CoreVideo/CVMetalTextureCache.h>
-#import <include/gpu/GrDirectContext.h>
+#import "include/gpu/GrDirectContext.h"
 
 #pragma clang diagnostic pop
 
-using SkiaMetalContext = struct SkiaMetalContext {
-  id<MTLCommandQueue> commandQueue = nullptr;
-  sk_sp<GrDirectContext> skContext = nullptr;
-};
-
-class ThreadContextHolder {
-public:
-  static thread_local SkiaMetalContext ThreadSkiaMetalContext;
-};
+namespace RNSkia {
 
 class SkiaMetalSurfaceFactory {
 public:
-  static sk_sp<SkSurface> makeWindowedSurface(id<MTLTexture> texture, int width,
+  static sk_sp<SkSurface> makeWindowedSurface(std::shared_ptr<RNSkiOSContext> skiaContext,
+                                              id<MTLTexture> texture, int width,
                                               int height);
-  static sk_sp<SkSurface> makeOffscreenSurface(int width, int height);
-
+  static sk_sp<SkSurface> makeOffscreenSurface(std::shared_ptr<RNSkiOSContext> skiaContext,
+                                               int width, int height);
+  
   static sk_sp<SkImage>
-  makeTextureFromCMSampleBuffer(CMSampleBufferRef sampleBuffer);
-
-private:
-  static id<MTLDevice> device;
-  static bool
-  createSkiaDirectContextIfNecessary(SkiaMetalContext *threadContext);
+  makeTextureFromCMSampleBuffer(std::shared_ptr<RNSkiOSContext> skiaContext,
+                                CMSampleBufferRef sampleBuffer);
 };
+
+} // namespace RNSkia

--- a/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
+++ b/package/ios/RNSkia-iOS/SkiaMetalSurfaceFactory.mm
@@ -18,128 +18,96 @@
 
 #pragma clang diagnostic pop
 
-thread_local SkiaMetalContext ThreadContextHolder::ThreadSkiaMetalContext;
+namespace RNSkia {
 
 struct OffscreenRenderContext {
   id<MTLTexture> texture;
-
+  
   OffscreenRenderContext(id<MTLDevice> device,
                          sk_sp<GrDirectContext> skiaContext,
                          id<MTLCommandQueue> commandQueue, int width,
                          int height) {
     // Create a Metal texture descriptor
     MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor
-        texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
-                                     width:width
-                                    height:height
-                                 mipmapped:NO];
+                                               texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
+                                               width:width
+                                               height:height
+                                               mipmapped:NO];
     textureDescriptor.usage =
-        MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+    MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
     texture = [device newTextureWithDescriptor:textureDescriptor];
   }
 };
 
-id<MTLDevice> SkiaMetalSurfaceFactory::device = MTLCreateSystemDefaultDevice();
-
-bool SkiaMetalSurfaceFactory::createSkiaDirectContextIfNecessary(
-    SkiaMetalContext *skiaMetalContext) {
-  if (skiaMetalContext->skContext == nullptr) {
-    skiaMetalContext->commandQueue =
-        id<MTLCommandQueue>(CFRetain((GrMTLHandle)[device newCommandQueue]));
-    skiaMetalContext->skContext = GrDirectContext::MakeMetal(
-        (__bridge void *)device,
-        (__bridge void *)skiaMetalContext->commandQueue);
-    if (skiaMetalContext->skContext == nullptr) {
-      RNSkia::RNSkLogger::logToConsole("Couldn't create a Skia Metal Context");
-      return false;
-    }
-  }
-  return true;
-}
-
 sk_sp<SkSurface>
-SkiaMetalSurfaceFactory::makeWindowedSurface(id<MTLTexture> texture, int width,
+SkiaMetalSurfaceFactory::makeWindowedSurface(std::shared_ptr<RNSkiOSContext> skiaContext,
+                                             id<MTLTexture> texture, int width,
                                              int height) {
-  // Get render context for current thread
-  if (!SkiaMetalSurfaceFactory::createSkiaDirectContextIfNecessary(
-          &ThreadContextHolder::ThreadSkiaMetalContext)) {
-    return nullptr;
-  }
   GrMtlTextureInfo fbInfo;
   fbInfo.fTexture.retain((__bridge void *)texture);
-
+  
   GrBackendRenderTarget backendRT(width, height, fbInfo);
-
-  auto skSurface = SkSurfaces::WrapBackendRenderTarget(
-      ThreadContextHolder::ThreadSkiaMetalContext.skContext.get(), backendRT,
-      kTopLeft_GrSurfaceOrigin, kBGRA_8888_SkColorType, nullptr, nullptr);
-
+  
+  auto skSurface = SkSurfaces::WrapBackendRenderTarget(skiaContext->getDirectContext().get(), backendRT,
+                                                       kTopLeft_GrSurfaceOrigin, kBGRA_8888_SkColorType, nullptr, nullptr);
+  
   if (skSurface == nullptr || skSurface->getCanvas() == nullptr) {
     RNSkia::RNSkLogger::logToConsole(
-        "Skia surface could not be created from parameters.");
+                                     "Skia surface could not be created from parameters.");
     return nullptr;
   }
   return skSurface;
 }
 
-sk_sp<SkSurface> SkiaMetalSurfaceFactory::makeOffscreenSurface(int width,
+sk_sp<SkSurface> SkiaMetalSurfaceFactory::makeOffscreenSurface(std::shared_ptr<RNSkiOSContext> skiaContext,
+                                                               int width,
                                                                int height) {
-  if (!SkiaMetalSurfaceFactory::createSkiaDirectContextIfNecessary(
-          &ThreadContextHolder::ThreadSkiaMetalContext)) {
-    return nullptr;
-  }
-  auto ctx = new OffscreenRenderContext(
-      device, ThreadContextHolder::ThreadSkiaMetalContext.skContext,
-      ThreadContextHolder::ThreadSkiaMetalContext.commandQueue, width, height);
-
+  auto ctx = new OffscreenRenderContext(skiaContext->getDevice(), skiaContext->getDirectContext(),
+                                        skiaContext->getCommandQueue(), width, height);
+  
   // Create a GrBackendTexture from the Metal texture
   GrMtlTextureInfo info;
   info.fTexture.retain((__bridge void *)ctx->texture);
   GrBackendTexture backendTexture(width, height, skgpu::Mipmapped::kNo, info);
-
+  
   // Create a SkSurface from the GrBackendTexture
-  auto surface = SkSurfaces::WrapBackendTexture(
-      ThreadContextHolder::ThreadSkiaMetalContext.skContext.get(),
-      backendTexture, kTopLeft_GrSurfaceOrigin, 0, kBGRA_8888_SkColorType,
-      nullptr, nullptr,
-      [](void *addr) { delete (OffscreenRenderContext *)addr; }, ctx);
-
+  auto surface = SkSurfaces::WrapBackendTexture(skiaContext->getDirectContext().get(),
+                                                backendTexture, kTopLeft_GrSurfaceOrigin, 0, kBGRA_8888_SkColorType,
+                                                nullptr, nullptr,
+                                                [](void *addr) { delete (OffscreenRenderContext *)addr; }, ctx);
+  
   return surface;
 }
 
-sk_sp<SkImage> SkiaMetalSurfaceFactory::makeTextureFromCMSampleBuffer(
-    CMSampleBufferRef sampleBuffer) {
-  if (!SkiaMetalSurfaceFactory::createSkiaDirectContextIfNecessary(
-          &ThreadContextHolder::ThreadSkiaMetalContext)) [[unlikely]] {
-    throw std::runtime_error("Failed to create Skia Context for this Thread!");
-  }
-  const SkiaMetalContext &context = ThreadContextHolder::ThreadSkiaMetalContext;
-
+sk_sp<SkImage> SkiaMetalSurfaceFactory::makeTextureFromCMSampleBuffer(std::shared_ptr<RNSkiOSContext> skiaContext,
+                                                                      CMSampleBufferRef sampleBuffer) {
   if (!CMSampleBufferIsValid(sampleBuffer)) [[unlikely]] {
     throw std::runtime_error("The given CMSampleBuffer is not valid!");
   }
-
+  
   CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
-
+  
   SkiaCVPixelBufferUtils::CVPixelBufferBaseFormat format =
-      SkiaCVPixelBufferUtils::getCVPixelBufferBaseFormat(pixelBuffer);
+  SkiaCVPixelBufferUtils::getCVPixelBufferBaseFormat(pixelBuffer);
   switch (format) {
-  case SkiaCVPixelBufferUtils::CVPixelBufferBaseFormat::rgb: {
-    // CVPixelBuffer is in any RGB format.
-    SkColorType colorType =
-        SkiaCVPixelBufferUtils::RGB::getCVPixelBufferColorType(pixelBuffer);
-    GrBackendTexture texture =
-        SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(
-            pixelBuffer);
-    return SkImages::AdoptTextureFrom(context.skContext.get(), texture,
-                                      kTopLeft_GrSurfaceOrigin, colorType,
-                                      kOpaque_SkAlphaType);
-  }
-  default:
-    [[unlikely]] {
-      throw std::runtime_error("Failed to convert PlatformBuffer to SkImage - "
-                               "PlatformBuffer has unsupported PixelFormat! " +
-                               std::to_string(static_cast<int>(format)));
+    case SkiaCVPixelBufferUtils::CVPixelBufferBaseFormat::rgb: {
+      // CVPixelBuffer is in any RGB format.
+      SkColorType colorType =
+      SkiaCVPixelBufferUtils::RGB::getCVPixelBufferColorType(pixelBuffer);
+      GrBackendTexture texture =
+      SkiaCVPixelBufferUtils::RGB::getSkiaTextureForCVPixelBuffer(
+                                                                  pixelBuffer);
+      return SkImages::AdoptTextureFrom(skiaContext->getDirectContext().get(), texture,
+                                        kTopLeft_GrSurfaceOrigin, colorType,
+                                        kOpaque_SkAlphaType);
     }
+    default:
+      [[unlikely]] {
+        throw std::runtime_error("Failed to convert PlatformBuffer to SkImage - "
+                                 "PlatformBuffer has unsupported PixelFormat! " +
+                                 std::to_string(static_cast<int>(format)));
+      }
   }
 }
+
+} // namespace RNSkia

--- a/package/src/skia/types/Context.ts
+++ b/package/src/skia/types/Context.ts
@@ -1,0 +1,12 @@
+import type { SkJSIInstance } from "./JsiInstance";
+
+/**
+ * Represents a Skia Context for the native graphics API.
+ * The context acts as an opaque pointer.
+ */
+export interface SkContext extends SkJSIInstance<"Context"> {
+  /**
+   * Returns `true` when the Skia Context is valid and can be used for rendering.
+   */
+  isValid(): boolean
+}

--- a/package/src/skia/types/Context/Context.ts
+++ b/package/src/skia/types/Context/Context.ts
@@ -1,4 +1,4 @@
-import type { SkJSIInstance } from "./JsiInstance";
+import type { SkJSIInstance } from "../JsiInstance";
 
 /**
  * Represents a Skia Context for the native graphics API.

--- a/package/src/skia/types/Context/ContextFactory.ts
+++ b/package/src/skia/types/Context/ContextFactory.ts
@@ -5,4 +5,9 @@ export interface ContextFactory {
    * Creates a new Skia Context.
    */
   Make: () => SkContext;
+  /**
+   * Gets the global Skia Context for this JS Runtime.
+   * Different JS Runtimes have different global Skia Contexts.
+   */
+  GetCurrent: () => SkContext;
 }

--- a/package/src/skia/types/Context/ContextFactory.ts
+++ b/package/src/skia/types/Context/ContextFactory.ts
@@ -1,0 +1,8 @@
+import type { SkContext } from "./Context";
+
+export interface ContextFactory {
+  /**
+   * Creates a new Skia Context.
+   */
+  Make: () => SkContext;
+}

--- a/package/src/skia/types/Context/index.ts
+++ b/package/src/skia/types/Context/index.ts
@@ -1,0 +1,2 @@
+export * from "./Context"
+export * from "./ContextFactory"

--- a/package/src/skia/types/Skia.ts
+++ b/package/src/skia/types/Skia.ts
@@ -31,6 +31,7 @@ import type { TypefaceFontProviderFactory } from "./Paragraph/TypefaceFontProvid
 import type { AnimatedImageFactory } from "./AnimatedImage";
 import type { ParagraphBuilderFactory } from "./Paragraph/ParagraphBuilder";
 import type { NativeBufferFactory } from "./NativeBuffer";
+import { ContextFactory } from "./Context";
 
 /**
  * Declares the interface for the native Skia API
@@ -70,6 +71,7 @@ export interface Skia {
   ImageFilter: ImageFilterFactory;
   Shader: ShaderFactory;
   PathEffect: PathEffectFactory;
+  Context: ContextFactory;
   /**
    * Returns an Vertices based on the given positions and optional parameters.
    * See SkVertices.h (especially the Builder) for more details.


### PR DESCRIPTION
(draft PR because we mainly use it for discussing things with better examples (code))

Creates a `Context` API for Skia to create and manage Skia contexts.

In most apps, there should only be two Skia contexts:

1. One for the React-JS Thread
2. One for the UI Thread

In some apps (e.g. when rendering offscreen using a separate Worker from [react-native-worklets-core](https://github.com/margelo/react-native-worklets-core), or when rendering in VisionCamera Frame Processors) you need a different Skia context.

This PR aims to create the concepts of Skia contexts.
