### PR TITLE
fix: Fix `makeImageFromHardwareBuffer` memory leak

### DIFF
--- a/package/android/cpp/rnskia-android/SkiaOpenGLSurfaceFactory.cpp
+++ b/package/android/cpp/rnskia-android/SkiaOpenGLSurfaceFactory.cpp
@@ -51,7 +51,7 @@ SkiaOpenGLSurfaceFactory::makeImageFromHardwareBuffer(void *buffer) {
   sk_sp<SkImage> image = SkImages::BorrowTextureFrom(
       ThreadContextHolder::ThreadSkiaOpenGLContext.directContext.get(),
       backendTex, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType,
-      kOpaque_SkAlphaType, nullptr);
+      kOpaque_SkAlphaType, nullptr, deleteImageProc, deleteImageCtx);
   return image;
 #else
   throw std::runtime_error(


### PR DESCRIPTION
Fixes an issue where the memory of the HardwareBuffer OpenGL texture was never freed.

We need to pass the deleter to the `SkImage`'s releaseProc. 

cc @rodgomesc