### PR TITLE
Align Android HB formats handling

### DIFF
--- a/package/android/cpp/rnskia-android/SkiaOpenGLSurfaceFactory.cpp
+++ b/package/android/cpp/rnskia-android/SkiaOpenGLSurfaceFactory.cpp
@@ -15,8 +15,9 @@ namespace RNSkia {
 
 thread_local SkiaOpenGLContext ThreadContextHolder::ThreadSkiaOpenGLContext;
 
-sk_sp<SkImage> SkiaOpenGLSurfaceFactory::makeImageFromHardwareBuffer(
-    void *buffer, bool requireKnownFormat) {
+sk_sp<SkImage>
+SkiaOpenGLSurfaceFactory::makeImageFromHardwareBuffer(void *buffer,
+                                                      bool requireKnownFormat) {
 #if __ANDROID_API__ >= 26
   // Setup OpenGL and Skia:
   if (!SkiaOpenGLHelper::createSkiaDirectContextIfNecessary(

--- a/package/android/cpp/rnskia-android/SkiaOpenGLSurfaceFactory.h
+++ b/package/android/cpp/rnskia-android/SkiaOpenGLSurfaceFactory.h
@@ -149,7 +149,8 @@ public:
    */
   static sk_sp<SkSurface> makeOffscreenSurface(int width, int height);
 
-  static sk_sp<SkImage> makeImageFromHardwareBuffer(void *buffer, bool requireKnownFormat = false);
+  static sk_sp<SkImage>
+  makeImageFromHardwareBuffer(void *buffer, bool requireKnownFormat = false);
 
   /**
    * Creates a windowed Skia Surface holder.


### PR DESCRIPTION
The goal of this PR is to align the HB format handling to be symmetric with Skia: https://github.com/google/skia/blob/main/src/gpu/ganesh/gl/AHardwareBufferGL.cpp#L33
This is important because in a not so distant future we will directly use the `SkImages::MakeFromAHBuffer()` function from Skia (once minSdk=26).

cc @mrousavy @fdecampredon