### PR TITLE
BUGFIX `setup-skia-web` script not picking up the custom folder param

### DIFF
--- a/package/scripts/setup-canvaskit.js
+++ b/package/scripts/setup-canvaskit.js
@@ -73,7 +73,7 @@ function getWasmFilePath() {
 
 function getOutputFilePath(isAnExpoProjectWithMetro) {
   // Default to using `web` public path.
-  const publicFolder = path.resolve(args[0] || (isAnExpoProjectWithMetro) ? "public" : "web/static/js");
+  const publicFolder = path.resolve(args[0] || ((isAnExpoProjectWithMetro) ? "public" : "web/static/js"));
   const publicLocation = "./canvaskit.wasm";
   const output = path.join(publicFolder, publicLocation);
 


### PR DESCRIPTION
After doing more testing with the `setup-skia-web` script, I realized that it wasn't picking up the custom folder parameter. => Just needed some parenthesis on the ternary condition to apply the proper value. 😬🤦🏼‍♂️

Use case: `yarn public/my/custom/path` should copy to the location specified in the first parameter.