### PR TITLE
fix(📹): fix video framerate

### DIFF
--- a/package/src/external/reanimated/useVideo.ts
+++ b/package/src/external/reanimated/useVideo.ts
@@ -84,11 +84,11 @@ export const useVideo = (
     }
 
     // Update frame only if the elapsed time since last update is greater than the frame duration
-    const currentFrameDuration = frameDuration / playbackSpeed.value;
-    if (
-      lastTimestamp.value === -1 ||
-      timestamp - lastTimestamp.value >= currentFrameDuration
-    ) {
+    const currentFrameDuration = Math.floor(
+      frameDuration / playbackSpeed.value
+    );
+    const delta = Math.floor(timestamp - lastTimestamp.value);
+    if (lastTimestamp.value === -1 || delta >= currentFrameDuration) {
       const img = video.nextImage();
       if (img) {
         if (currentFrame.value) {

--- a/package/src/renderer/__tests__/e2e/Snapshot.spec.tsx
+++ b/package/src/renderer/__tests__/e2e/Snapshot.spec.tsx
@@ -15,7 +15,7 @@ describe("Snapshot", () => {
   });
   itRunsE2eOnly("should capture a somewhat complex snapshot", async () => {
     // text spacing on the fabric example app is slightly different
-    await testSnapshot("Snapshot2", 1000);
+    await testSnapshot("Snapshot2", 4000);
   });
   itRunsE2eOnly("should respect overflow: hidden", async () => {
     await testSnapshot("Snapshot3");

--- a/scripts/build-skia.ts
+++ b/scripts/build-skia.ts
@@ -5,7 +5,7 @@ import { cpus } from "os";
 import { existsSync, mkdirSync } from "fs";
 
 const typedKeys = <T extends object>(obj: T) => Object.keys(obj) as (keyof T)[];
-const cores = cpus().length;
+const cores = Math.max(1, cpus().length - 2);
 
 /**
  * This build script builds the Skia Binaries from the Skia repositories


### PR DESCRIPTION
The issue was that if the video framerate is 16.7 and the screen framerate is 16.66, it would be twice as slow (next frame would be at 33.32)