### PR TITLE
fix(📼): add seek playback option

### DIFF
--- a/docs/docs/video.md
+++ b/docs/docs/video.md
@@ -34,7 +34,7 @@ interface VideoExampleProps {
     localVideoFile: string;
 }
 
-// The URL needs to be a local path, we usually use expo-asset for that.
+// The URL needs to be a local path; we usually use expo-asset for that.
 export const VideoExample = ({ localVideoFile }: VideoExampleProps) => {
   const paused = useSharedValue(false);
   const { width, height } = useWindowDimensions();
@@ -74,7 +74,7 @@ export const VideoExample = ({ localVideoFile }: VideoExampleProps) => {
 
 ## Using expo-asset
 
-Below is an example where we use [expo-asset](https://docs.expo.dev/versions/latest/sdk/asset/) to load the video.
+Below is an example of how to use [expo-asset](https://docs.expo.dev/versions/latest/sdk/asset/) to load the video.
 
 ```tsx twoslash
 import { useVideo } from "@shopify/react-native-skia";
@@ -98,9 +98,9 @@ export const useVideoFromAsset = (
 
 You can seek a video via the `seek` playback option. By default, the seek option is null. If you set a value in milliseconds, it will seek to that point in the video and then set the option value to null again.
 
-There are also the `currentTime` option which is a Reanimated value that contains the current playback time of the video.
+There is also the `currentTime` option, which is a Reanimated value that contains the current playback time of the video.
 
-`looping` indicates if the video should be looped or not.
+`looping` indicates whether the video should be looped or not.
 
 `playbackSpeed` indicates the playback speed of the video (default is 1).
 
@@ -110,7 +110,6 @@ In the example below, every time we tap on the video, we set the video to 2 seco
 import React from "react";
 import {
   Canvas,
-  ColorMatrix,
   Fill,
   Image,
   useVideo

--- a/package/src/external/reanimated/useVideo.ts
+++ b/package/src/external/reanimated/useVideo.ts
@@ -47,7 +47,9 @@ export const useVideo = (
   const isPaused = useOption(userOptions?.paused ?? defaultOptions.paused);
   const looping = useOption(userOptions?.looping ?? defaultOptions.looping);
   const seek = useOption(userOptions?.seek ?? defaultOptions.seek);
-  const currentTime = useOption(userOptions?.currentTime ?? defaultOptions.currentTime);
+  const currentTime = useOption(
+    userOptions?.currentTime ?? defaultOptions.currentTime
+  );
   const playbackSpeed = useOption(
     userOptions?.playbackSpeed ?? defaultOptions.playbackSpeed
   );


### PR DESCRIPTION
fixes #2442

This is an API to seek into a video.

@mrEuler would you like us to add a `currentTime` option where we would write the current time of the video in ms?