### PR TITLE
fix(👋): deprecate onTouch property

### DIFF
--- a/package/src/views/SkiaDomView.tsx
+++ b/package/src/views/SkiaDomView.tsx
@@ -26,6 +26,10 @@ export class SkiaDomView extends React.Component<SkiaDomViewProps> {
     }
     if (onTouch) {
       assertSkiaViewApi();
+      console.warn(
+        `The onTouch property is deprecated and will be removed in the next Skia release.
+See: https://shopify.github.io/react-native-skia/docs/animations/gestures`
+      );
       SkiaViewApi.setJsiProperty(this._nativeId, "onTouch", onTouch);
     }
     if (onSize) {

--- a/package/src/views/SkiaDomView.web.tsx
+++ b/package/src/views/SkiaDomView.web.tsx
@@ -12,6 +12,10 @@ export class SkiaDomView extends SkiaBaseWebView<SkiaDomViewProps> {
 
   protected renderInCanvas(canvas: SkCanvas, touches: TouchInfo[]): void {
     if (this.props.onTouch) {
+      console.warn(
+        `The onTouch property is deprecated and will be removed in the next Skia release.
+See: https://shopify.github.io/react-native-skia/docs/animations/gestures`
+      );
       this.props.onTouch([touches]);
     }
     if (this.props.onSize) {

--- a/package/src/views/SkiaJSDomView.tsx
+++ b/package/src/views/SkiaJSDomView.tsx
@@ -29,6 +29,10 @@ export class SkiaJSDomView extends React.Component<
     }
     if (onTouch) {
       assertSkiaViewApi();
+      console.warn(
+        `The onTouch property is deprecated and will be removed in the next Skia release.
+See: https://shopify.github.io/react-native-skia/docs/animations/gestures`
+      );
       SkiaViewApi.setJsiProperty(this._nativeId, "onTouch", onTouch);
     }
     if (onSize) {


### PR DESCRIPTION
Going forward Skia views are treated as regular React Native and therefore use the same gesture systems than regular views (gesture handler, gesture responder system).

We are also looking at improvements in the Skia infrastructure that wouldn't be able to support such property.