### PR TITLE
fix(🐎): Fix regression with Reanimated

### DIFF
--- a/package/src/external/reanimated/useAnimatedImageValue.ts
+++ b/package/src/external/reanimated/useAnimatedImageValue.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { type FrameInfo, type SharedValue } from "react-native-reanimated";
+import type { FrameInfo, SharedValue } from "react-native-reanimated";
 
 import { useAnimatedImage } from "../../skia/core/AnimatedImage";
 import type { DataSourceParam, SkImage } from "../../skia/types";

--- a/package/src/external/reanimated/useVideoLoading.ts
+++ b/package/src/external/reanimated/useVideoLoading.ts
@@ -1,14 +1,11 @@
 import { useEffect, useState } from "react";
-import {
-  createWorkletRuntime,
-  runOnJS,
-  runOnRuntime,
-} from "react-native-reanimated";
 
 import type { Video } from "../../skia/types";
 import { Skia } from "../../skia";
 
-const runtime = createWorkletRuntime("video-metadata-runtime");
+import Rea from "./ReanimatedProxy";
+
+const runtime = Rea.createWorkletRuntime("video-metadata-runtime");
 
 type VideoSource = string | null;
 
@@ -17,11 +14,11 @@ export const useVideoLoading = (source: VideoSource) => {
   const cb = (src: string) => {
     "worklet";
     const vid = Skia.Video(src) as Video;
-    runOnJS(setVideo)(vid);
+    Rea.runOnJS(setVideo)(vid);
   };
   useEffect(() => {
     if (source) {
-      runOnRuntime(runtime, cb)(source);
+      Rea.runOnRuntime(runtime, cb)(source);
     }
   }, [source]);
   return video;


### PR DESCRIPTION
In `1.3.4`, we introduced a regression where Reanimated had become an hardcoded dependency. This fixes that.
Thank you @kmagiera for catching this.