### PR TITLE
fix(🐛): fix concurrency issue with surface events

### DIFF
--- a/package/android/src/main/java/com/shopify/reactnative/skia/SkiaBaseViewManager.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/SkiaBaseViewManager.java
@@ -29,7 +29,6 @@ public abstract class SkiaBaseViewManager<T extends SkiaBaseView> extends ReactV
     @Override
     public void onDropViewInstance(@NonNull ReactViewGroup view) {
         super.onDropViewInstance(view);
-        ((SkiaBaseView)view).destroySurface();
-        ((SkiaBaseView)view).unregisterView();
+        ((SkiaBaseView)view).dropInstance();
     }
 }


### PR DESCRIPTION
To handle react-native-screens, we always recreate the SurfaceTexture when a destroy event happens (because RN screens keep the parent view alive). We believe that there is currently a race condition where a surface event like onSurfaceSizeChange may happen when we have already manually destroyed the surface (via the onDropViewInstance event).

This PR:
1. Cleans up the logic around the RN Screen handling.
2. Fixes that potential race condition.

@kmagiera does this rational make sense here?

@hannojg @Nodonisko, I think I will release this patch regardless, as it provides better handling for RN Screens, even if it doesn't completely fix the race condition. I'm looking forward to reading your thoughts on this.