### PR TITLE
Fix typo jlong -> jdouble for seek method of the Video (android only)

### DIFF
--- a/package/android/cpp/rnskia-android/RNSkAndroidVideo.cpp
+++ b/package/android/cpp/rnskia-android/RNSkAndroidVideo.cpp
@@ -88,7 +88,7 @@ void RNSkAndroidVideo::seek(double timestamp) {
     RNSkLogger::logToConsole("seek method not found");
     return;
   }
-  env->CallVoidMethod(_jniVideo.get(), mid, static_cast<jlong>(timestamp));
+  env->CallVoidMethod(_jniVideo.get(), mid, static_cast<jdouble>(timestamp));
 }
 
 float RNSkAndroidVideo::getRotationInDegrees() {


### PR DESCRIPTION
fixes #2531


In java native part, the seek method got double parameter instead of long, but in cpp part, the casting wan't changed, what caused the issue of incorrect value.