### PR TITLE
fix: remove currentBridge

### DIFF
--- a/package/ios/RNSkiaModule.mm
+++ b/package/ios/RNSkiaModule.mm
@@ -39,7 +39,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
   if (!jsInvoker) {
     jsInvoker = cxxBridge.jsCallInvoker;
   }
-  skiaManager = [[SkiaManager alloc] initWithBridge:cxxBridge jsInvoker:jsInvoker];
+  skiaManager = [[SkiaManager alloc] initWithBridge:cxxBridge
+                                          jsInvoker:jsInvoker];
   return @true;
 }
 

--- a/package/ios/RNSkiaModule.mm
+++ b/package/ios/RNSkiaModule.mm
@@ -9,6 +9,7 @@
 }
 
 RCT_EXPORT_MODULE()
+@synthesize bridge = _bridge;
 
 #pragma Accessors
 
@@ -34,11 +35,11 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
     // Already initialized, ignore call.
     return @true;
   }
-  RCTBridge *bridge = [RCTBridge currentBridge];
+  RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
   if (!jsInvoker) {
-    jsInvoker = bridge.jsCallInvoker;
+    jsInvoker = cxxBridge.jsCallInvoker;
   }
-  skiaManager = [[SkiaManager alloc] initWithBridge:bridge jsInvoker:jsInvoker];
+  skiaManager = [[SkiaManager alloc] initWithBridge:cxxBridge jsInvoker:jsInvoker];
   return @true;
 }
 


### PR DESCRIPTION
PR changing the occurence of `currentBridge` to properly retrieved `self.bridge`. If not applying this, on `bridgeless` mode the wrong instance of bridge is acquired, leading to adding JSI bindings to wrong runtime. It is possible that it only occurs when using `expo` in the project. See https://github.com/natedevxyz/rn-skia-test for reproduction.