### PR TITLE
Fix typo in paragraph component documentation

### DIFF
--- a/docs/docs/text/paragraph.md
+++ b/docs/docs/text/paragraph.md
@@ -123,7 +123,7 @@ const colors = [
 const MyParagraph = () => {
   const paragraph = useMemo(() => {
 
-    // Create a foreground paint.
+    // Create a background paint.
     const backgroundPaint = Skia.Paint();
     backgroundPaint.setShader(
       source.makeShader([0, 0, 256, 256, ...colors])


### PR DESCRIPTION
Fix the typo in the documentation for the paragraph component.

* Update the comment above the `backgroundPaint` initialization to "Create a background paint." in `docs/docs/text/paragraph.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shopify/react-native-skia?shareId=91a2ccde-f91d-495c-9e5b-3323be84d9d1).