### PR TITLE
Fix incorrect duration value on android that comes from an audio stream

### DIFF
--- a/package/android/src/main/java/com/shopify/reactnative/skia/RNSkVideo.java
+++ b/package/android/src/main/java/com/shopify/reactnative/skia/RNSkVideo.java
@@ -64,7 +64,6 @@ public class RNSkVideo {
             mediaPlayer.setDataSource(context, uri);
             mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
             mediaPlayer.setOnPreparedListener(mp -> {
-                durationMs = mp.getDuration();
                 mp.start();
                 isPlaying = true;
             });
@@ -72,7 +71,7 @@ public class RNSkVideo {
 
             // Retrieve and store video properties
             if (format.containsKey(MediaFormat.KEY_DURATION)) {
-                durationMs = format.getLong(MediaFormat.KEY_DURATION) / 1000;  // Convert microseconds to milliseconds
+                durationMs = (double) format.getLong(MediaFormat.KEY_DURATION) / 1000;  // Convert microseconds to milliseconds
             }
             if (format.containsKey(MediaFormat.KEY_FRAME_RATE)) {
                 frameRate = format.getInteger(MediaFormat.KEY_FRAME_RATE);


### PR DESCRIPTION
I didn't have this issue, when there was no audio playback in SkVideo. Now in some videos, the duration is totally incorrect (for example instead of 210'000 ms, it could be 78'123 ms, so no logic or dependency). That caused the issue of video interruption, that was caused, when the current playback time was larger than a "fake duration".
Fixed this locally and tested a lot, works fine.

Issue was (is) only on Android.