### PR TITLE
feat: getFrameCount

### DIFF
--- a/docs/docs/animated-images.md
+++ b/docs/docs/animated-images.md
@@ -102,11 +102,13 @@ import {useAnimatedImage} from "@shopify/react-native-skia";
 const bird = useAnimatedImage(
   require("../../assets/birdFlying.gif")
 )!;
-// SkAnimatedImage offers 3 methods: decodeNextFrame(), getCurrentFrame(), and currentFrameDuration()
+// SkAnimatedImage offers 4 methods: decodeNextFrame(), getCurrentFrame(), currentFrameDuration(), and getFrameCount()
 // getCurrentFrame() returns a regular SkImage
 const image = bird.getCurrentFrame();
 // decode the next frame
 bird.decodeNextFrame();
 // fetch the current frame number
 const currentFrame = bird.currentFrameDuration();
+// fetch the total number of frames
+const frameCount = bird.getFrameCount();
 ```

--- a/package/cpp/api/JsiSkAnimatedImage.h
+++ b/package/cpp/api/JsiSkAnimatedImage.h
@@ -35,6 +35,10 @@ public:
         runtime, std::make_shared<JsiSkImage>(getContext(), std::move(image)));
   }
 
+  JSI_HOST_FUNCTION(getFrameCount) {
+    return static_cast<int>(getObject()->getFrameCount());
+  }
+
   JSI_HOST_FUNCTION(currentFrameDuration) {
     return static_cast<int>(getObject()->currentFrameDuration());
   }
@@ -43,9 +47,10 @@ public:
     return static_cast<int>(getObject()->decodeNextFrame());
   }
 
-  EXPORT_JSI_API_TYPENAME(JsiSkAnimatedImage, "AnimatedImage")
+  EXPORT_JSI_API_TYPENAME(JsiSkAnimatedImage, AnimatedImage)
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkAnimatedImage, dispose),
+                       JSI_EXPORT_FUNC(JsiSkAnimatedImage, getFrameCount),
                        JSI_EXPORT_FUNC(JsiSkAnimatedImage, getCurrentFrame),
                        JSI_EXPORT_FUNC(JsiSkAnimatedImage,
                                        currentFrameDuration),

--- a/package/src/renderer/__tests__/e2e/AnimatedImages.spec.tsx
+++ b/package/src/renderer/__tests__/e2e/AnimatedImages.spec.tsx
@@ -15,6 +15,7 @@ describe("Animated Images", () => {
       if (!animatedImage) {
         return false;
       }
+      animatedImage.getFrameCount();
       animatedImage.decodeNextFrame();
       animatedImage.getCurrentFrame();
       animatedImage.currentFrameDuration();

--- a/package/src/renderer/__tests__/e2e/AnimatedImages.spec.tsx
+++ b/package/src/renderer/__tests__/e2e/AnimatedImages.spec.tsx
@@ -15,7 +15,11 @@ describe("Animated Images", () => {
       if (!animatedImage) {
         return false;
       }
-      animatedImage.getFrameCount();
+
+      if (animatedImage.getFrameCount() !== 1) {
+        return false;
+      }
+
       animatedImage.decodeNextFrame();
       animatedImage.getCurrentFrame();
       animatedImage.currentFrameDuration();

--- a/package/src/skia/types/AnimatedImage/AnimatedImage.ts
+++ b/package/src/skia/types/AnimatedImage/AnimatedImage.ts
@@ -25,5 +25,11 @@ export interface SkAnimatedImage extends SkJSIInstance<"AnimatedImage"> {
    */
   currentFrameDuration(): number;
 
+  /**
+   *  Returns the number of frames in the animation.
+   *
+   */
+  getFrameCount(): number;
+
   // TODO - add the rest of the methods from the Skia API (see SkAnimatedImage.h)
 }

--- a/package/src/skia/web/JsiSkAnimatedImage.ts
+++ b/package/src/skia/web/JsiSkAnimatedImage.ts
@@ -21,6 +21,10 @@ export class JsiSkAnimatedImage
     return this.ref.currentFrameDuration();
   }
 
+  getFrameCount() {
+    return this.ref.getFrameCount();
+  }
+
   getCurrentFrame() {
     const image = this.ref.makeImageAtCurrentFrame();
     if (image === null) {


### PR DESCRIPTION
This PR implements a new method on AnimatedImage - `getFrameCount`. It's useful when you want to check how many frames in a gif. Sometimes gifs have only a single frame and you'd want to skip the animation and display just it.

Also, this PR fixes a typo - `animatedImage.__typename__` was returning `"\"AnimatedImage\""`.