### PR TITLE
fix: add missing dispose to skparagraph

### DIFF
--- a/package/cpp/api/JsiSkParagraph.h
+++ b/package/cpp/api/JsiSkParagraph.h
@@ -121,6 +121,12 @@ public:
     }
     return returnValue;
   }
+  
+  JSI_HOST_FUNCTION(dispose) {
+    _paragraph = nullptr;
+    
+    return jsi::Value::undefined();
+  }
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkParagraph, layout),
                        JSI_EXPORT_FUNC(JsiSkParagraph, paint),
@@ -133,7 +139,8 @@ public:
                        JSI_EXPORT_FUNC(JsiSkParagraph,
                                        getGlyphPositionAtCoordinate),
                        JSI_EXPORT_FUNC(JsiSkParagraph, getRectsForRange),
-                       JSI_EXPORT_FUNC(JsiSkParagraph, getLineMetrics))
+                       JSI_EXPORT_FUNC(JsiSkParagraph, getLineMetrics),
+                       JSI_EXPORT_FUNC(JsiSkParagraph, dispose))
 
   explicit JsiSkParagraph(std::shared_ptr<RNSkPlatformContext> context,
                           para::ParagraphBuilder *paragraphBuilder)


### PR DESCRIPTION
Since there is no dispose method on `JsiSkHostObject` i had to add my own. Tested it on a project with huge paragraph usage - no crashes.