### PR TITLE
disable android build test

### DIFF
--- a/.github/workflows/android-ubuntu.yml
+++ b/.github/workflows/android-ubuntu.yml
@@ -1,10 +1,10 @@
 name: Android Ubuntu
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+# on:
+#   push:
+#     branches:
+#       - main
+#   pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
This has been failing due to not enough disk space. We have a plan to fix this but it will take a bit of time. In the meantime we can disable it. Android builds are still tested on macos.