### PR TITLE
alter monorepo the name, to avoid conflict with the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-skia",
+  "name": "react-native-skia-monorepo",
   "version": "1.0.0",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
# Why & How

After the latests rearrangement of repository, there is a conflict between monorepo and package name, which errors out when fetching data for React Native Directory.

Alternate approach might be removing the `name` completely from `private` monorepo root.