### PR TITLE
Improve unmount behavior

### DIFF
--- a/packages/skia/src/renderer/Container.tsx
+++ b/packages/skia/src/renderer/Container.tsx
@@ -10,6 +10,7 @@ import type { Skia } from "../skia/types";
 export class Container {
   private _root: RenderNode<GroupProps>;
   public Sk: SkDOM;
+  public unmounted = false;
   constructor(
     Skia: Skia,
     public redraw: () => void = () => {},

--- a/packages/skia/src/renderer/HostConfig.ts
+++ b/packages/skia/src/renderer/HostConfig.ts
@@ -53,9 +53,13 @@ const appendNode = (parent: Node<unknown>, child: Node<unknown>) => {
   parent.addChild(child);
 };
 
-const removeNode = (parent: Node<unknown>, child: Node<unknown>) => {
+const removeNode = (parent: Node<unknown>, child: Node<unknown>, unmounted = false) => {
+  // If the drawing is unmounted we don't want to update it.
+  // We can just stop the reanimated mappers
   unbindReanimatedNode(child);
-  return parent.removeChild(child);
+  if (!unmounted) {
+    parent.removeChild(child);
+  }
 };
 
 const insertBefore = (
@@ -224,7 +228,7 @@ export const skHostConfig: SkiaHostConfig = {
   },
 
   removeChildFromContainer: (container, child) => {
-    removeNode(container.root, child);
+    removeNode(container.root, child, container.unmounted);
   },
 
   insertInContainerBefore: (container, child, before) => {

--- a/packages/skia/src/renderer/Reconciler.tsx
+++ b/packages/skia/src/renderer/Reconciler.tsx
@@ -46,6 +46,7 @@ export class SkiaRoot {
   }
 
   unmount() {
+    this.container.unmounted = true;
     skiaReconciler.updateContainer(null, this.root, null, () => {
       hostDebug("unmountContainer");
     });

--- a/packages/skia/src/views/SkiaDomView.tsx
+++ b/packages/skia/src/views/SkiaDomView.tsx
@@ -88,14 +88,6 @@ See: https://shopify.github.io/react-native-skia/docs/animations/gestures`
     SkiaViewApi.requestRedraw(this._nativeId);
   }
 
-  /**
-   * Clear up the dom node when unmounting to release resources.
-   */
-  componentWillUnmount(): void {
-    assertSkiaViewApi();
-    SkiaViewApi.setJsiProperty(this._nativeId, "root", null);
-  }
-
   render() {
     const { mode, debug = false, ...viewProps } = this.props;
     return (

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
           "!apps/*/src/app/build"
         ],
         "outputs": [
-          "apps/*/ios/android/**"
+          "apps/*/android/**"
         ]
       },
       "build:ios": {


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/0da844ed-3e8d-4695-95a9-aa8292f69be4


After:

https://github.com/user-attachments/assets/e357e9ea-71f8-4a11-bba4-7cc5d956b597

To achieve this behaviour we needed to do two things:
* Remove root deletion when unmounting (the root is deleted in the view destructor)
* Don't update the drawing if the update is an unmount command

cc @colinta @beardwin 