### PR TITLE
fix: canvas debug information not showing

### DIFF
--- a/packages/skia/cpp/rnskia/RNSkDomView.cpp
+++ b/packages/skia/cpp/rnskia/RNSkDomView.cpp
@@ -17,7 +17,13 @@ RNSkDomRenderer::RNSkDomRenderer(std::function<void()> requestRedraw,
                                  std::shared_ptr<RNSkPlatformContext> context)
     : RNSkRenderer(requestRedraw), _platformContext(std::move(context)),
       _renderLock(std::make_shared<std::timed_mutex>()),
-      _renderTimingInfo("SKIA/RENDER") {}
+      _renderTimingInfo("SKIA/RENDER") {
+
+  auto style = SkFontStyle::Normal();
+  auto fontMgr = _platformContext->createFontMgr();
+  auto _typeface = fontMgr->matchFamilyStyle("Arial", style);
+  _font = SkFont(_typeface, 14);
+}
 
 RNSkDomRenderer::~RNSkDomRenderer() {
   if (_root != nullptr) {
@@ -130,12 +136,10 @@ void RNSkDomRenderer::renderDebugOverlays(SkCanvas *canvas) {
   std::string debugString = stream.str();
 
   // Set up debug font/paints
-  auto font = SkFont();
-  font.setSize(14);
   auto paint = SkPaint();
   paint.setColor(SkColors::kRed);
   canvas->drawSimpleText(debugString.c_str(), debugString.size(),
-                         SkTextEncoding::kUTF8, 8, 18, font, paint);
+                         SkTextEncoding::kUTF8, 8, 18, _font, paint);
 }
 
 } // namespace RNSkia

--- a/packages/skia/cpp/rnskia/RNSkDomView.h
+++ b/packages/skia/cpp/rnskia/RNSkDomView.h
@@ -23,6 +23,7 @@
 #include "include/core/SkBBHFactory.h"
 #include "include/core/SkCanvas.h"
 #include "include/core/SkPictureRecorder.h"
+#include "include/core/SkFont.h"
 
 #pragma clang diagnostic pop
 
@@ -63,6 +64,7 @@ private:
   RNSkTimingInfo _renderTimingInfo;
 
   std::mutex _rootLock;
+  SkFont _font;
 };
 
 class RNSkDomView : public RNSkView {


### PR DESCRIPTION
I've tried to measure the rendering performance of the `<Canvas />` component and enabled the debug option by setting `debug` to `true`:
```js
export default function App() {
	const paint = Skia.Paint();
	paint.setColor(Skia.Color("rgb(255,0,0)"));

	return (
		<Canvas mode="continuous" style={{ flex: 1, margin: 50, borderWidth: 1 }} debug={true}>
			{new Array(100).fill(0).map((_, i) => (
				<Rect key={i} x={i * 10} y={i * 10 + 200} width={100} height={100} paint={paint} />
			))}
		</Canvas>
	);
```
and in early versions this worked and displayed the render time and average fps, however not anymore in the latest version `1.4.2`. (I unfortunately don't know when this bug got introduced)

### Before

| Android    | iOS |
| -------- | ------- |
| <img width="200" src="https://github.com/user-attachments/assets/69562dea-e97b-4917-b0f8-dbd1d7b507a9" /> | <img width="200" src="https://github.com/user-attachments/assets/bcd137cb-e652-4ea1-820f-3cd896f68fc5" />    |

https://github.com/Shopify/react-native-skia/blob/ddfa6eb2eafb125d713d013e5dd249959564c922/packages/skia/cpp/rnskia/RNSkDomView.cpp#L133-L138

To find the issue I've called measureText in RNSkDomView.cpp and found out that it returned 0.
This means the text won't be rendered, probably because no valid font was registered/found.
I've fixed this issue by getting the system font manager and initializing the font in the constructor: 

```cpp
auto style = SkFontStyle::Normal();
auto fontMgr = _platformContext->createFontMgr();
auto _typeface = fontMgr->matchFamilyStyle("Arial", style);
_font = SkFont(_typeface, 14);
```

and just reuse the `_font` when rendering the debug overlay:
```cpp
canvas->drawSimpleText(debugString.c_str(), debugString.size(), SkTextEncoding::kUTF8, 8, 18, _font, paint);
```


### After

| Android | iOS |
| ------ | ----- |
| <img width="200" src="https://github.com/user-attachments/assets/ca5d9c32-a400-438f-b794-7a757adbc80a" /> | <img width="200" src="https://github.com/user-attachments/assets/77001557-4888-4eac-b6f0-ae2c94670eb5" /> |
