### PR TITLE
fix: web paragraph styles not working

### DIFF
--- a/packages/skia/src/skia/web/JsiSkParagraphStyle.ts
+++ b/packages/skia/src/skia/web/JsiSkParagraphStyle.ts
@@ -4,63 +4,89 @@ import { TextDirection } from "../types";
 import type { SkParagraphStyle } from "../types";
 
 export class JsiSkParagraphStyle {
-  static toParagraphStyle(
-    ck: CanvasKit,
-    value: SkParagraphStyle
-  ): ParagraphStyle {
-    // Seems like we need to provide the textStyle.color value, otherwise
-    // the constructor crashes.
-    const ps = new ck.ParagraphStyle({ textStyle: { color: ck.BLACK } });
+	static toParagraphStyle(
+		ck: CanvasKit,
+		value: SkParagraphStyle
+	): ParagraphStyle {
+		// Seems like we need to provide the textStyle.color value, otherwise
+		// the constructor crashes.
+		const ps = new ck.ParagraphStyle({ textStyle: { color: ck.BLACK } });
 
-    ps.disableHinting = value.disableHinting ?? ps.disableHinting;
-    ps.ellipsis = value.ellipsis ?? ps.ellipsis;
-    ps.heightMultiplier = value.heightMultiplier ?? ps.heightMultiplier;
-    ps.maxLines = value.maxLines ?? ps.maxLines;
-    ps.replaceTabCharacters =
-      value.replaceTabCharacters ?? ps.replaceTabCharacters;
-    ps.textAlign =
-      value.textAlign !== undefined
-        ? { value: value.textAlign }
-        : undefined ?? ps.textAlign;
-    ps.textDirection =
-      value.textDirection !== undefined
-        ? { value: value.textDirection === TextDirection.LTR ? 1 : 0 }
-        : ps.textDirection;
-    ps.textHeightBehavior =
-      value.textHeightBehavior !== undefined
-        ? { value: value.textHeightBehavior }
-        : ps.textHeightBehavior;
+		ps.disableHinting = value.disableHinting ?? ps.disableHinting;
+		ps.ellipsis = value.ellipsis ?? ps.ellipsis;
+		ps.heightMultiplier = value.heightMultiplier ?? ps.heightMultiplier;
+		ps.maxLines = value.maxLines ?? ps.maxLines;
+		ps.replaceTabCharacters =
+			value.replaceTabCharacters ?? ps.replaceTabCharacters;
+		ps.textAlign =
+			value.textAlign !== undefined ? { value: value.textAlign } : ps.textAlign;
+		ps.textDirection =
+			value.textDirection !== undefined
+				? { value: value.textDirection === TextDirection.LTR ? 1 : 0 }
+				: ps.textDirection;
+		ps.textHeightBehavior =
+			value.textHeightBehavior !== undefined
+				? { value: value.textHeightBehavior }
+				: ps.textHeightBehavior;
 
-    ps.strutStyle = ps.strutStyle ?? {};
-    ps.strutStyle.fontFamilies =
-      value.strutStyle?.fontFamilies ?? ps.strutStyle.fontFamilies;
-    ps.strutStyle.fontSize =
-      value.strutStyle?.fontSize ?? ps.strutStyle.fontSize;
-    ps.strutStyle.heightMultiplier =
-      value.strutStyle?.heightMultiplier ?? ps.strutStyle.heightMultiplier;
-    ps.strutStyle.leading = value.strutStyle?.leading ?? ps.strutStyle.leading;
-    ps.strutStyle.forceStrutHeight =
-      value.strutStyle?.forceStrutHeight ?? ps.strutStyle.forceStrutHeight;
+		ps.strutStyle = ps.strutStyle ?? {};
+		ps.textStyle = ps.textStyle ?? {};
+		ps.textStyle.color = value.textStyle?.color ?? ps.textStyle.color;
+		ps.textStyle.backgroundColor =
+			value.textStyle?.backgroundColor ?? ps.textStyle.backgroundColor;
+		ps.textStyle.foregroundColor =
+			value.textStyle?.foregroundColor ?? ps.textStyle.foregroundColor;
+		ps.textStyle.decoration =
+			value.textStyle?.decoration ?? ps.textStyle.decoration;
+		ps.textStyle.decorationColor =
+			value.textStyle?.decorationColor ?? ps.textStyle.decorationColor;
+		ps.textStyle.decorationStyle =
+			value.textStyle?.decorationStyle !== undefined
+				? { value: value.textStyle.decorationStyle }
+				: ps.textStyle.decorationStyle;
+		ps.textStyle.letterSpacing =
+			value.textStyle?.letterSpacing ?? ps.textStyle.letterSpacing;
+		ps.textStyle.decorationThickness =
+			value.textStyle?.decorationThickness ?? ps.textStyle.decorationThickness;
+		ps.textStyle.fontFamilies = ps.textStyle.fontFamilies =
+			value.textStyle?.fontFamilies ?? ps.textStyle.fontFamilies;
+		ps.textStyle.fontSize = value.textStyle?.fontSize ?? ps.textStyle.fontSize;
+		ps.textStyle.heightMultiplier =
+			value.textStyle?.heightMultiplier ?? ps.textStyle.heightMultiplier;
+		ps.strutStyle.leading = value.strutStyle?.leading ?? ps.strutStyle.leading;
+		ps.strutStyle.forceStrutHeight =
+			value.strutStyle?.forceStrutHeight ?? ps.strutStyle.forceStrutHeight;
 
-    ps.strutStyle.fontStyle = ps.strutStyle.fontStyle ?? {};
+		ps.textStyle.fontStyle = ps.textStyle.fontStyle ?? {};
 
-    ps.strutStyle.fontStyle.slant =
-      value.strutStyle?.fontStyle?.slant !== undefined
-        ? { value: value.strutStyle.fontStyle.slant }
-        : ps.strutStyle.fontStyle.slant;
-    ps.strutStyle.fontStyle.width =
-      value.strutStyle?.fontStyle?.width !== undefined
-        ? { value: value.strutStyle.fontStyle.width }
-        : ps.strutStyle.fontStyle.width;
-    ps.strutStyle.fontStyle.weight =
-      value.strutStyle?.fontStyle?.weight !== undefined
-        ? { value: value.strutStyle.fontStyle.weight }
-        : ps.strutStyle.fontStyle.weight;
-    ps.strutStyle.halfLeading =
-      value.strutStyle?.halfLeading ?? ps.strutStyle.halfLeading;
-    ps.strutStyle.strutEnabled =
-      value.strutStyle?.strutEnabled ?? ps.strutStyle.strutEnabled;
+		ps.textStyle.fontStyle.slant =
+			value.textStyle?.fontStyle?.slant !== undefined
+				? { value: value.textStyle.fontStyle.slant }
+				: ps.textStyle.fontStyle.slant;
+		ps.textStyle.fontStyle.width =
+			value.textStyle?.fontStyle?.width !== undefined
+				? { value: value.textStyle.fontStyle.width }
+				: ps.textStyle.fontStyle.width;
+		ps.textStyle.fontStyle.weight =
+			value.textStyle?.fontStyle?.weight !== undefined
+				? { value: value.textStyle.fontStyle.weight }
+				: ps.textStyle.fontStyle.weight;
+		ps.textStyle.halfLeading =
+			value.textStyle?.halfLeading ?? ps.textStyle.halfLeading;
+		ps.strutStyle.strutEnabled =
+			value.strutStyle?.strutEnabled ?? ps.strutStyle.strutEnabled;
+		ps.textStyle.shadows =
+			value.textStyle?.shadows?.map(shadow => {
+				return {
+					color: shadow.color,
+					offset: shadow.offset ? [shadow.offset.x, shadow.offset.y] : [0, 0],
+					blurRadius: shadow.blurRadius
+				};
+			}) ?? ps.textStyle.shadows;
+		ps.textStyle.textBaseline = value.textStyle?.textBaseline
+			? { value: value.textStyle.textBaseline }
+			: ps.textStyle.textBaseline;
 
-    return ps;
-  }
+		return ps;
+	}
 }


### PR DESCRIPTION
I've tried to use the paragraph api on the web, however the paragraph didn't render and show up on the canvas.
After debugging I found out that `paragraph.getHeight()` returned `0` and the `style.textStyle.fontSize` was `-1` and `style.textStyle.fontFamilies` was undefined.

I've tried to directly create the style using `new CanvasKit.ParagraphStyle(...)` and that returned a style object with correct fontSize/fontFamily and when used also returned the correct paragraph height.

That means the issue lies in the `JsiSkParagraphStyle.toParagraphStyle()` function:

https://github.com/Shopify/react-native-skia/blob/4a2d7afc0fa547aee9938a0339594b88c3618d20/packages/skia/src/skia/web/JsiSkParagraphStyle.ts#L7-L65

Inside of the `toParagraphStyle()` function I've changed the assignments from strutStyle to textStyle (except for `leading`, `forceStrutHeight` and `strutEnabled`) and also added some properties like `textDecoration`, `backgroundColor` and `shadows`.

This fixed the issue and now the paragraph correctly renders:

<img width="378" alt="image" src="https://github.com/user-attachments/assets/5815750d-b871-4985-b98a-f61057b8009b">

```ts

const paragraphBuilder = Skia.ParagraphBuilder.Make(
	{
		textStyle: {
			color: Skia.Color("red"),
			fontSize: 50,
			fontFamilies: ["Roboto"],
			decoration: TextDecoration.Underline,
			decorationColor: Skia.Color("green"),
			decorationStyle: TextDecorationStyle.Wavy,
			decorationThickness: 1,
			letterSpacing: 1,
			fontStyle: {
				slant: FontSlant.Italic,
				weight: FontWeight.Normal,
				width: FontWidth.Normal,
			},
			shadows: [
				{
					blurRadius: 10,
					color: Skia.Color("blue"),
					offset: { x: 10, y: 10 },
				},
			],
			textBaseline: TextBaseline.Ideographic,
		},
	},
    fontManager
)
```