### PR TITLE
⬆️ Fix bogus requirements

### DIFF
--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -10,7 +10,7 @@ Skia serves as the graphics engine for Google Chrome and Chrome OS, Android, Flu
 
 **Version compatibility:**  
 `react-native@>=0.71` and `react@>=18` are required. <br />
-In addition you should make sure you're on at least `iOS 13` and `Android API level 16` or above. <br />
+In addition you should make sure you're on at least `iOS 13` and `Android API level 21` or above. <br />
 To use React Native Skia with the new architecture, `react-native@>=0.72` is required. <br />
 To use React Native Skia with video support, `Android API level 26` or above is required.
 


### PR DESCRIPTION
Since v1, Skia prebuilt binaries where only supporting API Level 21 and above.