### PR TITLE
chore: gitignore lib folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,4 @@ buck-out/
 
 # Build
 dist
-package/lib
+packages/*/lib/*


### PR DESCRIPTION
It seems the gitignore wasn’t ignoring generated `lib/` folders after conversion to a monorepo. This change updates the `.gitignore` so it does so.