### PR TITLE
Fix performance regression on iOS

### DIFF
--- a/packages/skia/cpp/rnskia/DawnContext.h
+++ b/packages/skia/cpp/rnskia/DawnContext.h
@@ -36,8 +36,8 @@ struct AsyncContext {
 };
 
 struct SharedTextureContext {
-    wgpu::SharedTextureMemory sharedTextureMemory;
-    wgpu::Texture texture;
+  wgpu::SharedTextureMemory sharedTextureMemory;
+  wgpu::Texture texture;
 };
 
 static void
@@ -111,7 +111,7 @@ public:
     int height = static_cast<int>(IOSurfaceGetHeight(ioSurface));
 #else
     wgpu::SharedTextureMemoryAHardwareBufferDescriptor platformDesc;
-    auto ahb = (AHardwareBuffer*)buffer;
+    auto ahb = (AHardwareBuffer *)buffer;
     platformDesc.handle = ahb;
     platformDesc.useExternalFormat = true;
     AHardwareBuffer_Desc adesc;
@@ -122,13 +122,16 @@ public:
 
     wgpu::SharedTextureMemoryDescriptor desc = {};
     desc.nextInChain = &platformDesc;
-    wgpu::SharedTextureMemory memory = backendContext.fDevice.ImportSharedTextureMemory(&desc);
+    wgpu::SharedTextureMemory memory =
+        backendContext.fDevice.ImportSharedTextureMemory(&desc);
 
     wgpu::TextureDescriptor textureDesc;
     textureDesc.format = DawnUtils::PreferredTextureFormat;
     textureDesc.dimension = wgpu::TextureDimension::e2D;
-    textureDesc.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopySrc;
-    textureDesc.size = {static_cast<uint32_t>(width), static_cast<uint32_t>(height), 1};
+    textureDesc.usage =
+        wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopySrc;
+    textureDesc.size = {static_cast<uint32_t>(width),
+                        static_cast<uint32_t>(height), 1};
 
     wgpu::Texture texture = memory.CreateTexture(&textureDesc);
 
@@ -137,26 +140,23 @@ public:
     beginAccessDesc.fenceCount = 0;
     bool success = memory.BeginAccess(texture, &beginAccessDesc);
 
-      if (success) {
-    skgpu::graphite::BackendTexture betFromView = skgpu::graphite::BackendTextures::MakeDawn(texture.Get());
-    auto result = SkImages::WrapTexture(
-        getRecorder(), 
-        betFromView, 
-        DawnUtils::PreferedColorType, 
-        kPremul_SkAlphaType, 
-        nullptr, 
-        [](void* context) {
+    if (success) {
+      skgpu::graphite::BackendTexture betFromView =
+          skgpu::graphite::BackendTextures::MakeDawn(texture.Get());
+      auto result = SkImages::WrapTexture(
+          getRecorder(), betFromView, DawnUtils::PreferedColorType,
+          kPremul_SkAlphaType, nullptr,
+          [](void *context) {
             auto ctx = static_cast<SharedTextureContext *>(context);
             wgpu::SharedTextureMemoryEndAccessState endState = {};
             ctx->sharedTextureMemory.EndAccess(ctx->texture, &endState);
             delete ctx;
-        },
-        new SharedTextureContext{memory, texture}
-    );
-    return result;
-      }
+          },
+          new SharedTextureContext{memory, texture});
+      return result;
+    }
     if (!success) {
-        return nullptr;
+      return nullptr;
     }
     return nullptr;
   }

--- a/packages/skia/cpp/rnskia/DawnUtils.h
+++ b/packages/skia/cpp/rnskia/DawnUtils.h
@@ -90,7 +90,8 @@ createDawnBackendContext(dawn::native::Instance *instance) {
     features.push_back(wgpu::FeatureName::SharedTextureMemoryIOSurface);
   }
 #else
-  if (adapter.HasFeature(wgpu::FeatureName::SharedTextureMemoryAHardwareBuffer)) {
+  if (adapter.HasFeature(
+          wgpu::FeatureName::SharedTextureMemoryAHardwareBuffer)) {
     features.push_back(wgpu::FeatureName::SharedTextureMemoryAHardwareBuffer);
   }
 #endif

--- a/packages/skia/ios/RNSkia-iOS/RNSkMetalCanvasProvider.h
+++ b/packages/skia/ios/RNSkia-iOS/RNSkMetalCanvasProvider.h
@@ -30,8 +30,7 @@ public:
 
 private:
   std::shared_ptr<RNSkia::RNSkPlatformContext> _context;
-  float _width = -1;
-  float _height = -1;
+  std::unique_ptr<RNSkia::WindowContext> _ctx = nullptr;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
   CAMetalLayer *_layer;

--- a/packages/skia/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
+++ b/packages/skia/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
@@ -36,19 +36,23 @@ RNSkMetalCanvasProvider::~RNSkMetalCanvasProvider() {}
 /**
  Returns the scaled width of the view
  */
-float RNSkMetalCanvasProvider::getScaledWidth() { return _width; };
+float RNSkMetalCanvasProvider::getScaledWidth() {
+  return _ctx ? _ctx->getWidth() : -1;
+};
 
 /**
  Returns the scaled height of the view
  */
-float RNSkMetalCanvasProvider::getScaledHeight() { return _height; };
+float RNSkMetalCanvasProvider::getScaledHeight() {
+  return _ctx ? _ctx->getHeight() : -1;
+};
 
 /**
  Render to a canvas
  */
 bool RNSkMetalCanvasProvider::renderToCanvas(
     const std::function<void(SkCanvas *)> &cb) {
-  if (_width <= 0 || _height <= 0) {
+  if (!_ctx) {
     return false;
   }
 
@@ -72,33 +76,24 @@ bool RNSkMetalCanvasProvider::renderToCanvas(
   // rendering and not wait until later - we've seen some example of memory
   // usage growing very fast in the simulator without this.
   @autoreleasepool {
-    id<CAMetalDrawable> currentDrawable = [_layer nextDrawable];
-    if (currentDrawable == nullptr) {
-      return false;
-    }
-#if defined(SK_GRAPHITE)
-    auto ctx = RNSkia::DawnContext::getInstance().MakeWindow(
-        (__bridge void *)_layer, _width, _height);
-#else
-    auto ctx = MetalContext::getInstance().MakeWindow(_layer, _width, _height);
-#endif
-    auto skSurface = ctx->getSurface();
-    SkCanvas *canvas = skSurface->getCanvas();
+    auto surface = _ctx->getSurface();
+    auto canvas = surface->getCanvas();
     cb(canvas);
-
-    if (auto dContext = GrAsDirectContext(skSurface->recordingContext())) {
-      dContext->flushAndSubmit();
-    }
-
-    ctx->present();
+    _ctx->present();
   }
   return true;
 };
 
 void RNSkMetalCanvasProvider::setSize(int width, int height) {
   _layer.frame = CGRectMake(0, 0, width, height);
-  _width = width * _context->getPixelDensity();
-  _height = height * _context->getPixelDensity();
+  auto w = width * _context->getPixelDensity();
+  auto h = height * _context->getPixelDensity();
+#if defined(SK_GRAPHITE)
+  _ctx = RNSkia::DawnContext::getInstance().MakeWindow((__bridge void *)_layer,
+                                                       _width, _height);
+#else
+  _ctx = MetalContext::getInstance().MakeWindow(_layer, w, h);
+#endif
   _requestRedraw();
 }
 


### PR DESCRIPTION
fixes #2743

In v1.5.3, we introduced a regression where we would request the next frame twice leading to frame drop in half.