### PR TITLE
Add missing ColorType members in Typescript, fixing Gray_8 images on Android/iOS

### DIFF
--- a/packages/skia/src/skia/__tests__/Enums.spec.ts
+++ b/packages/skia/src/skia/__tests__/Enums.spec.ts
@@ -4,7 +4,6 @@ import {
   AlphaType,
   BlurStyle,
   ClipOp,
-  ColorType,
   FillType,
   FilterMode,
   FontEdging,
@@ -71,7 +70,6 @@ describe("Enums", () => {
   });
   it("Should match Image enums values with CanvasKit", () => {
     const { CanvasKit } = setupSkia();
-    checkEnum(ColorType, CanvasKit.ColorType);
     checkEnum(AlphaType, CanvasKit.AlphaType);
     checkEnum(ImageFormat, CanvasKit.ImageFormat);
     checkEnum(MipmapMode, CanvasKit.MipmapMode);

--- a/packages/skia/src/skia/types/Image/ImageFactory.ts
+++ b/packages/skia/src/skia/types/Image/ImageFactory.ts
@@ -10,6 +10,7 @@ export enum AlphaType {
   Unpremul,
 }
 
+// the ordering must match the C++ enum SkColorType in skia/include/core/SkColorType.h
 export enum ColorType {
   Unknown, // uninitialized
   Alpha_8, // pixel with alpha in 8-bit byte
@@ -23,10 +24,12 @@ export enum ColorType {
   RGB_101010x, // pixel with 10 bits each for red, green, blue; in 32-bit word
   BGR_101010x, // pixel with 10 bits each for blue, green, red; in 32-bit word
   BGR_101010x_XR, // pixel with 10 bits each for blue, green, red; in 32-bit word, extended range
+  BGRA_10101010_XR, // pixel with 10 bits each for blue, green, red, alpha; in 64-bit word, extended range
   RGBA_10x6, // pixel with 10 used bits (most significant) followed by 6 unused
   Gray_8, // pixel with grayscale level in 8-bit byte
   RGBA_F16Norm, // pixel with half floats in [0,1] for red, green, blue, alpha; in 64-bit word
   RGBA_F16, // pixel with half floats for red, green, blue, alpha; in 64-bit word
+  RGB_F16F16F16x, // pixel with half floats for red, green, blue; in 64-bit word
   RGBA_F32, // pixel using C float for red, green, blue, alpha; in 128-bit word
 }
 


### PR DESCRIPTION
**Gray_8 does not work when passed to Skia.Image.MakeImage in @shopify/react-native-skia@1.5.10.**

I noticed a bug where the later members of the ColorType enum were mapped incorrectly in the native code (specifically, Gray_8). This was causing me failures when using MakeImage as the data provided had the incorrect number of bytes for the assumed image format.

If you check the native implementation for `MakeImage`:

https://github.com/Shopify/react-native-skia/blob/b6a848f55e50470292d16a40cbadf01ca496d37f/packages/skia/cpp/api/JsiSkImageFactory.h#L42-L46

It calls `JsiSkImageInfo::fromValue`:

https://github.com/Shopify/react-native-skia/blob/b6a848f55e50470292d16a40cbadf01ca496d37f/packages/skia/cpp/api/JsiSkImageInfo.h#L31-L47

Which **takes the ColorType from Javascript as a number and reinterprets it as SkColorType**. This means the Typescript enum and the C++ enum must be kept in sync for the implementation to work correctly.

As an example, if you try to call `Skia.Image.MakeImage` with `ColorType.Gray_8`, this gives the constant value 13. However, in C++, 13 is the enum value for RGBA_10x6. See [SkColorType in the upstream](https://github.com/google/skia/blame/667639e7d993e49531ce1617207b21eaa189ff2f/include/core/SkColorType.h#L33). For me, this was preventing me from creating Gray_8 images since the number of bytes mismatched (understandably).

# How did we get here?

It seems like the missing ColorTypes were added recently in the upstream commits:
- [Adds support for BGRA10_XR.](https://github.com/google/skia/commit/a0bbf72581f07fafa9705a88a34d5eab8db53148)
- [CPU support of F16F16F16x SkColorType.](https://github.com/google/skia/commit/52f391e1165fe8ca2ea6ef4e3a769c68881b6185)

These were added in the middle of the enum, and pulled into this repo without warning when updating skia, breaking the previous Typescript definition.

# The fix

Copied the missing enum members from the C++ enum SkColorType in the upstream.

There is probably a way to write an integration test to stop regressions (maybe we could just assert the _last_ renderable ColorType gives the same value in both JS/C++) -- but this is left as an exercise for someone smarter than I. A low tech solution is manually checking on this when updating skia.