### PR TITLE
fix(🍏): fix reparenting of View on iOS

### DIFF
--- a/packages/skia/ios/RNSkia-iOS/MetalWindowContext.h
+++ b/packages/skia/ios/RNSkia-iOS/MetalWindowContext.h
@@ -8,8 +8,7 @@ class SkiaMetalContext;
 
 class MetalWindowContext : public RNSkia::WindowContext {
 public:
-  MetalWindowContext(GrDirectContext *directContext,
-					 id<MTLDevice> device,
+  MetalWindowContext(GrDirectContext *directContext, id<MTLDevice> device,
                      id<MTLCommandQueue> commandQueue, CALayer *layer,
                      int width, int height);
   ~MetalWindowContext() = default;

--- a/packages/skia/ios/RNSkia-iOS/SkiaUIView.mm
+++ b/packages/skia/ios/RNSkia-iOS/SkiaUIView.mm
@@ -62,18 +62,7 @@
 #pragma mark Lifecycle
 
 - (void)willMoveToSuperview:(UIView *)newWindow {
-  if (newWindow == NULL) {
-    // Remove implementation view when the parent view is not set
-    if (_impl != nullptr) {
-      [_impl->getLayer() removeFromSuperlayer];
-
-      if (_nativeId != 0 && _manager != nullptr) {
-        _manager->setSkiaView(_nativeId, nullptr);
-      }
-
-      _impl = nullptr;
-    }
-  } else {
+  if (newWindow != nullptr) {
     // Create implementation view when the parent view is set
     if (_impl == nullptr && _manager != nullptr) {
       _impl = _factory(_manager->getPlatformContext());
@@ -88,6 +77,21 @@
       _impl->getDrawView()->setShowDebugOverlays(_debugMode);
     }
   }
+}
+
+- (void)removeFromSuperview {
+  // Cleanup when removed from view hierarchy
+  if (_impl != nullptr) {
+	[_impl->getLayer() removeFromSuperlayer];
+	
+	if (_nativeId != 0 && _manager != nullptr) {
+	  _manager->setSkiaView(_nativeId, nullptr);
+	}
+	
+	_impl = nullptr;
+  }
+  
+  [super removeFromSuperview];
 }
 
 - (void)dealloc {
@@ -119,8 +123,6 @@
   if (_manager != nullptr && _nativeId != 0) {
     _manager->unregisterSkiaView(_nativeId);
   }
-
-  assert(_impl == nullptr);
 }
 
 #pragma Render

--- a/packages/skia/ios/RNSkia-iOS/SkiaUIView.mm
+++ b/packages/skia/ios/RNSkia-iOS/SkiaUIView.mm
@@ -82,15 +82,15 @@
 - (void)removeFromSuperview {
   // Cleanup when removed from view hierarchy
   if (_impl != nullptr) {
-	[_impl->getLayer() removeFromSuperlayer];
-	
-	if (_nativeId != 0 && _manager != nullptr) {
-	  _manager->setSkiaView(_nativeId, nullptr);
-	}
-	
-	_impl = nullptr;
+    [_impl->getLayer() removeFromSuperlayer];
+
+    if (_nativeId != 0 && _manager != nullptr) {
+      _manager->setSkiaView(_nativeId, nullptr);
+    }
+
+    _impl = nullptr;
   }
-  
+
   [super removeFromSuperview];
 }
 


### PR DESCRIPTION
fixes #2732 
fixes #2636

View reparenting on iOS was always broken but this never came up until more people started to use fabric where some layout changes (e.g. pointer events) are reparenting the view.