### PR TITLE
fix(⏺️): fix memory error with rounded rectangles

### DIFF
--- a/packages/skia/cpp/api/JsiSkRRect.h
+++ b/packages/skia/cpp/api/JsiSkRRect.h
@@ -115,7 +115,7 @@ public:
   createCtor(std::shared_ptr<RNSkPlatformContext> context) {
     return JSI_HOST_FUNCTION_LAMBDA {
       // Set up the rect
-      auto rect = JsiSkRect::fromValue(runtime, arguments[0]).get();
+      auto rect = JsiSkRect::fromValue(runtime, arguments[0]);
       auto rx = arguments[1].asNumber();
       auto ry = arguments[2].asNumber();
       auto rrect = SkRRect::MakeRectXY(*rect, rx, ry);


### PR DESCRIPTION
This fixes an issue with the rrect constructor if the rectangle is not an host object.