### PR TITLE
docs: add video tutorials

### DIFF
--- a/apps/docs/docs/tutorials.md
+++ b/apps/docs/docs/tutorials.md
@@ -18,6 +18,8 @@ Please [make a PR](https://github.com/Shopify/react-native-skia/edit/main/docs/d
 * [Pixelated Image with React-Native Skia (youtu.be)](https://www.youtube.com/watch?v=_iU9i9ivTrU)
 * [Typography Metaball with React Native Skia (youtu.be)](https://www.youtube.com/watch?v=B8a8ty54_OI)
 * [Color Pixelated (youtu.be)](https://youtu.be/mc56FIJgDAE)
+* [Animated Loader with React Native Skia (youtu.be)](https://www.youtube.com/watch?v=7pCiGUrJuow)
+* [Animated Blur Cards with React Native Skia (youtu.be)](https://www.youtube.com/watch?v=SveA2QjmEzM)
 
 ## Gestures
 * [Instagram Stickers - “Can it be done in React Native?” (youtu.be)](https://www.youtube.com/watch?v=5yM4NPcTwY4)


### PR DESCRIPTION
Love the package and the work you're doing! 

This PR adds a couple of recent video tutorials to the docs list. 

In the previous months, I wrote a couple of written tutorials: 
- [How to bring your React Native apps to life using sensors](https://expo.dev/blog/how-to-bring-your-react-native-apps-to-life-using-sensors): uses both Reanimated and Skia 
- [Animated Spiral with React Native Skia](https://reactiive.io/articles/animated-spiral). 

I haven’t included these in the PR yet, as I’m unsure if **written** tutorials align with the scope of this list. If you'd like to include them, I’d be happy to update the PR! 😊