### PR TITLE
fix(🚤): fix bug on first frame

### DIFF
--- a/packages/skia/cpp/rnskia/RNSkJsiViewApi.h
+++ b/packages/skia/cpp/rnskia/RNSkJsiViewApi.h
@@ -246,9 +246,6 @@ public:
    */
   void setSkiaView(size_t nativeId, std::shared_ptr<RNSkView> view) {
     std::lock_guard<std::mutex> lock(_mutex);
-    if (_viewInfos.find(nativeId) == _viewInfos.end()) {
-      return;
-    }
     auto info = getEnsuredViewInfo(nativeId);
     if (view != nullptr) {
       info->view = view;


### PR DESCRIPTION
Because the view is created after a drawing (SkPicture for instance), setting the picture would fail because no view info would be existing for that picture. Hence the drawing would go to waste.

In current examples, this would lead to an unnecessary frame computation + slower time to first frame.
The only reason that current example works is the following:
* Non animated example have spaghetti code that will request the drawing more than once (hence it will be correct eventually).
* Animated example will of course also request the drawing more than once, but it will be correct eventually.

In more modern examples this bug is obvious: nothing is drawn because we ask for a redraw only once and the drawing is available because the native view is.