### PR TITLE
fix(🐎): minor improvement to the reanimated package detection

### DIFF
--- a/packages/skia/scripts/skia-configuration.ts
+++ b/packages/skia/scripts/skia-configuration.ts
@@ -155,9 +155,7 @@ export const configurations = {
       "arm64-iphoneos": {
         cpu: "arm64",
         platform: "ios",
-        args: [
-          ["ios_min_target", iosMinTarget]
-        ],
+        args: [["ios_min_target", iosMinTarget]],
       },
       "arm64-iphonesimulator": {
         cpu: "arm64",
@@ -170,9 +168,7 @@ export const configurations = {
       "x64-iphonesimulator": {
         cpu: "x64",
         platform: "ios",
-        args: [
-          ["ios_min_target", iosMinTarget]
-        ],
+        args: [["ios_min_target", iosMinTarget]],
       },
       "arm64-macosx": {
         platformGroup: "macosx",

--- a/packages/skia/src/external/reanimated/renderHelpers.ts
+++ b/packages/skia/src/external/reanimated/renderHelpers.ts
@@ -6,13 +6,12 @@ import type { Node } from "../../dom/types";
 
 import Rea from "./ReanimatedProxy";
 
-export let HAS_REANIMATED = false;
-export let HAS_REANIMATED_3 = false;
+let HAS_REANIMATED = false;
+let HAS_REANIMATED_3 = false;
 try {
-  require("react-native-reanimated");
-  HAS_REANIMATED = true;
   const reanimatedVersion =
     require("react-native-reanimated/package.json").version;
+  HAS_REANIMATED = !!reanimatedVersion;
   if (
     reanimatedVersion &&
     (reanimatedVersion >= "3.0.0" || reanimatedVersion.includes("3.0.0-"))

--- a/packages/skia/src/external/reanimated/renderHelpers.ts
+++ b/packages/skia/src/external/reanimated/renderHelpers.ts
@@ -6,8 +6,8 @@ import type { Node } from "../../dom/types";
 
 import Rea from "./ReanimatedProxy";
 
-let HAS_REANIMATED = false;
-let HAS_REANIMATED_3 = false;
+export let HAS_REANIMATED = false;
+export let HAS_REANIMATED_3 = false;
 try {
   const reanimatedVersion =
     require("react-native-reanimated/package.json").version;

--- a/packages/skia/src/external/reanimated/renderHelpers.ts
+++ b/packages/skia/src/external/reanimated/renderHelpers.ts
@@ -9,8 +9,13 @@ import Rea from "./ReanimatedProxy";
 export let HAS_REANIMATED = false;
 export let HAS_REANIMATED_3 = false;
 try {
+  // This logic is convoluted but necessary
+  // In most systems, `require("react-native-reanimated")` throws an error, all is well.
+  // In webpack, in some configuration it will return an empty object.
+  // So it will not throw an error and we need to check the version to know if it's there.
   const reanimatedVersion =
     require("react-native-reanimated/package.json").version;
+  require("react-native-reanimated");
   HAS_REANIMATED = !!reanimatedVersion;
   if (
     reanimatedVersion &&


### PR DESCRIPTION
this is a minor improvement to the package detection where a webpack config may not throw an exception for `require('react-native-reanimated')` but rather return an empty object instead.