### PR TITLE
feat(🍏): add tvOS build support

### DIFF
--- a/packages/skia/react-native-skia.podspec
+++ b/packages/skia/react-native-skia.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
     "Christian Falch" => "christian.falch@gmail.com",
     "William Candillon" => "wcandillon@gmail.com"
   }
-  s.platforms    = { :ios => "13.0" }
+  s.platforms    = { :ios => "13.0", :tvos => "13.0" }
   s.source       = { :git => "https://github.com/shopify/react-native-skia/react-native-skia.git", :tag => "#{s.version}" }
 
   s.requires_arc = true
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
 
   s.frameworks = 'MetalKit'
 
-  s.ios.vendored_frameworks = use_graphite ? 
+  s.vendored_frameworks = use_graphite ?
   base_frameworks + graphite_frameworks :
   base_frameworks
 

--- a/packages/skia/scripts/build-skia.ts
+++ b/packages/skia/scripts/build-skia.ts
@@ -123,6 +123,12 @@ const buildXCFrameworks = () => {
   outputNames.forEach((name) => {
     console.log("Building XCFramework for " + name);
     const prefix = `${OutFolder}/${os}`;
+    $(`mkdir -p ${OutFolder}/${os}/tvsimulator`);
+    $(`rm -rf ${OutFolder}/${os}/tvsimulator/${name}`);
+    $(
+      // eslint-disable-next-line max-len
+      `lipo -create ${OutFolder}/${os}/x64-tvsimulator/${name} ${OutFolder}/${os}/arm64-tvsimulator/${name} -output ${OutFolder}/${os}/tvsimulator/${name}`
+    );
     $(`mkdir -p ${OutFolder}/${os}/iphonesimulator`);
     $(`rm -rf ${OutFolder}/${os}/iphonesimulator/${name}`);
     $(
@@ -141,6 +147,8 @@ const buildXCFrameworks = () => {
       "xcodebuild -create-xcframework " +
         `-library ${prefix}/arm64-iphoneos/${name} ` +
         `-library ${prefix}/iphonesimulator/${name} ` +
+        `-library ${prefix}/arm64-tvos/${name} ` +
+        `-library ${prefix}/tvsimulator/${name} ` +
         `-library ${prefix}/macosx/${name} ` +
         ` -output ${dstPath}`
     );

--- a/packages/skia/scripts/skia-configuration.ts
+++ b/packages/skia/scripts/skia-configuration.ts
@@ -100,7 +100,8 @@ export type Platform = {
   options?: Arg[];
 };
 
-const iosMinTarget = GRAPHITE ? '"15.1"' : '"13.0"';
+const appleMinTarget = GRAPHITE ? '15.1' : '13.0';
+const iosMinTarget = `"${appleMinTarget}"`;
 
 export const configurations = {
   android: {
@@ -169,6 +170,35 @@ export const configurations = {
         cpu: "x64",
         platform: "ios",
         args: [["ios_min_target", iosMinTarget]],
+      },
+      "arm64-tvos": {
+        cpu: "arm64",
+        platform: "tvos",
+        args: [
+          ["extra_cflags", `["-target", "arm64-apple-tvos", "-mappletvos-version-min=${appleMinTarget}"]`],
+          ["extra_asmflags", `["-target", "arm64-apple-tvos", "-mappletvos-version-min=${appleMinTarget}"]`],
+          ["extra_ldflags", `["-target", "arm64-apple-tvos", "-mappletvos-version-min=${appleMinTarget}"]`],
+        ],
+      },
+      "arm64-tvsimulator": {
+        cpu: "arm64",
+        platform: "tvos",
+        args: [
+          ["ios_use_simulator", true],
+          ["extra_cflags", `["-target", "arm64-apple-tvos-simulator", "-mappletvsimulator-version-min=${appleMinTarget}"]`],
+          ["extra_asmflags", `["-target", "arm64-apple-tvos-simulator", "-mappletvsimulator-version-min=${appleMinTarget}"]`],
+          ["extra_ldflags", `["-target", "arm64-apple-tvos-simulator", "-mappletvsimulator-version-min=${appleMinTarget}"]`],
+        ],
+      },
+      "x64-tvsimulator": {
+        cpu: "x64",
+        platform: "tvos",
+        args: [
+          ["ios_use_simulator", true],
+          ["extra_cflags", `["-target", "arm64-apple-tvos-simulator", "-mappletvsimulator-version-min=${appleMinTarget}"]`],
+          ["extra_asmflags", `["-target", "arm64-apple-tvos-simulator", "-mappletvsimulator-version-min=${appleMinTarget}"]`],
+          ["extra_ldflags", `["-target", "arm64-apple-tvos-simulator", "-mappletvsimulator-version-min=${appleMinTarget}"]`],
+        ],
       },
       "arm64-macosx": {
         platformGroup: "macosx",


### PR DESCRIPTION
Keeping this one simple. So skipping the example projects for now.
Added build for tvOS, which we started using internally and thought I push back the config file so other people might be able to use it. Saw #1959 but that one hasn't been updated to the latest configuration files.

We only use a subset for some test currently, so I think it might be good to add a notice somewhere about tvOS not being 100% tested?