### PR TITLE
Switch to large instance to build Skia

### DIFF
--- a/.github/workflows/build-skia.yml
+++ b/.github/workflows/build-skia.yml
@@ -2,7 +2,7 @@ name: Build SKIA
 on: workflow_dispatch
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The number of prebuilt binaries Skia ships is getting increasingly bigger.