### PR TITLE
chore(📚): Mention TV support on installation page

### DIFF
--- a/apps/docs/docs/getting-started/bundle-size.md
+++ b/apps/docs/docs/getting-started/bundle-size.md
@@ -7,9 +7,9 @@ slug: /getting-started/bundle-size
 
 Below is the app size increase to be expected when adding React Native Skia to your project.
 
-| iOS  | Android | Web      |
-| ---- | ------- | -------- |
-| 6 MB | 4 MB    | 2.9 MB\* |
+| iOS/tvOS | Android (TV) | Web      |
+|----------|--------------| -------- |
+| 6 MB     | 4 MB         | 2.9 MB\* |
 
 \*This figure is the size of the gzipped file served through a CDN ([learn more](web)).
 

--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -73,6 +73,17 @@ Find `CMake` and click _Show Package Details_ and download compatiable version *
 
 To use this library in the browser, see [these instructions](/docs/getting-started/web).
 
+## TV
+
+Starting from version [1.9.0](https://github.com/Shopify/react-native-skia/releases/tag/v1.9.0) React Native Skia supports running on TV devices using [React Native TVOS](https://github.com/react-native-tvos/react-native-tvos).
+Currently both Android TV and Apple TV are supported.
+
+:::info
+
+Not all features have been tested yet, so please [report](https://github.com/Shopify/react-native-skia/issues) any issues you encounter when using React Native Skia on TV devices.
+
+:::
+
 ## Playground
 
 We have an example project you can play with [here](https://github.com/Shopify/react-native-skia/tree/main/example).


### PR DESCRIPTION
You were a bit ahead of me, but wanted to mention it in the install docs, maybe that's to much?

Draft as the linked version 1.9.0 might not be the version that includes it?