### PR TITLE
Add font mock to Skia Jest setup

### DIFF
--- a/packages/skia/jestSetup.js
+++ b/packages/skia/jestSetup.js
@@ -12,6 +12,14 @@ jest.mock("@shopify/react-native-skia", () => {
       View: Noop,
     };
   });
+  jest.mock("@shopify/react-native-skia/lib/commonjs/skia/core/Font", () => {
+    return {
+      useFont: () => null,
+      matchFont: () => null,
+      listFontFamilies: () => [],
+      useFonts: () => null,
+    }
+  });
   return require("@shopify/react-native-skia/lib/commonjs/mock").Mock(
     global.CanvasKit
   );

--- a/packages/skia/jestSetup.mjs
+++ b/packages/skia/jestSetup.mjs
@@ -18,5 +18,13 @@ jest.mock("@shopify/react-native-skia", () => {
       View: Noop,
     };
   });
+  jest.mock("@shopify/react-native-skia/lib/commonjs/skia/core/Font", () => {
+    return {
+      useFont: () => null,
+      matchFont: () => null,
+      listFontFamilies: () => [],
+      useFonts: () => null,
+    }
+  });
   return Mock(global.CanvasKit);
 });


### PR DESCRIPTION
Introduce a mock for the Font module in the Skia Jest setup to facilitate testing without actual font dependencies.

This fixes error such as:

```
          Not implemented on React Native Web
      
             8 |
          >  9 | export const font = matchFont({
               |                              ^
      
            at JsiSkFontMgr.matchFamilyStyle (../../node_modules/@shopify/react-native-skia/lib/commonjs/skia/web/JsiSkFontMgr.ts:24:11)
            at matchFamilyStyle (../../node_modules/@shopify/react-native-skia/lib/commonjs/skia/core/Font.ts:94:28)
```