### PR TITLE
fix: runtime error typo

### DIFF
--- a/packages/skia/cpp/rnskia/dom/base/ConcatablePaint.cpp
+++ b/packages/skia/cpp/rnskia/dom/base/ConcatablePaint.cpp
@@ -73,7 +73,7 @@ void ConcatablePaint::concatTo(std::shared_ptr<SkPaint> paint) {
       paint->setStyle(SkPaint::Style::kFill_Style);
     } else {
       throw std::runtime_error(styleValue +
-                               " is not a valud value for the style property.");
+                               " is not a valid value for the style property.");
     }
   }
 

--- a/packages/skia/cpp/rnskia/dom/nodes/JsiPaintNode.h
+++ b/packages/skia/cpp/rnskia/dom/nodes/JsiPaintNode.h
@@ -46,7 +46,7 @@ public:
         paint->setStyle(SkPaint::Style::kFill_Style);
       } else {
         throw std::runtime_error(
-            styleValue + " is not a valud value for the style property.");
+            styleValue + " is not a valid value for the style property.");
       }
     }
 


### PR DESCRIPTION
Fixes a small runtime error typo `valud -> valid`