### PR TITLE
Web "React is not defined" Fix

### DIFF
--- a/packages/skia/src/renderer/Canvas.web.tsx
+++ b/packages/skia/src/renderer/Canvas.web.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   forwardRef,
   useCallback,
   useEffect,


### PR DESCRIPTION
## Issue/Fix
We were running into a `"React is not defined"` error using Skia on web for both Next.js and Storybook. This PR re-introduces the React import that previously existed before the new web reconciler in [Canvas.tsx](https://github.com/Shopify/react-native-skia/blob/v1.7.7/packages/skia/src/renderer/Canvas.tsx). One thing that I'm not sure about is if auto-format will remove this import. I don't have formatting working on my local repository, so I can't test. We don't want to accidentally regress when a developer formats this file. 

## Test Plan
Patch allows for Skia rendering in both Next.js and Storybook. I can't verify full functionality since our web animations are broken in some newer version, but animation issues seem unrelated to this `"React is not defined"` issue. We're at least able to render static screens with this patch.