### PR TITLE
Fixing React not defined bug

### DIFF
--- a/packages/skia/src/renderer/Canvas.tsx
+++ b/packages/skia/src/renderer/Canvas.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import {
+import React, {
   forwardRef,
   useCallback,
   useEffect,


### PR DESCRIPTION
Same issue as #2941. Seems like this import got dropped in the migration from `Canvas.web.tsx`->`Canvas.tsx`. 