### PR TITLE
Adds breaking web code for example

### DIFF
--- a/external-apps/expo-router-app/components/AnimatedSquareCanvas.tsx
+++ b/external-apps/expo-router-app/components/AnimatedSquareCanvas.tsx
@@ -1,4 +1,4 @@
-import { Canvas, RoundedRect } from "@shopify/react-native-skia/src";
+import { Canvas, Rect } from "@shopify/react-native-skia/src";
 import { useCallback, useEffect, useState } from "react";
 import { runOnJS, useAnimatedReaction, useSharedValue, withRepeat, withSequence, withTiming } from "react-native-reanimated";
 
@@ -26,7 +26,7 @@ const AnimatedSquareCanvas = () => {
 
     return (
         <Canvas style={{ width: "100%", height: "100%" }}>
-            <RoundedRect x={x} y={0} width={100} height={100} color="blue" r={8} />
+            <Rect x={x} y={0} width={100} height={100} color="blue" />
         </Canvas>
     );
 };

--- a/external-apps/expo-router-app/components/AnimatedSquareCanvas.tsx
+++ b/external-apps/expo-router-app/components/AnimatedSquareCanvas.tsx
@@ -1,28 +1,33 @@
-import { Canvas, Rect } from "@shopify/react-native-skia/src";
-import { useEffect } from "react";
-import {
-	useSharedValue,
-	withRepeat,
-	withSequence,
-	withTiming,
-} from "react-native-reanimated";
+import { Canvas, RoundedRect } from "@shopify/react-native-skia/src";
+import { useCallback, useEffect, useState } from "react";
+import { runOnJS, useAnimatedReaction, useSharedValue, withRepeat, withSequence, withTiming } from "react-native-reanimated";
 
 const AnimatedSquareCanvas = () => {
-	const x = useSharedValue(0);
-	useEffect(() => {
-		x.value = withRepeat(
-			withSequence(
-				withTiming(100, { duration: 1000 }),
-				withTiming(0, { duration: 1000 }),
-			),
-			-1,
-		);
-	}, [x]);
+    const isActive = useSharedValue(false);
 
-	return (
-		<Canvas style={{ width: "100%", height: "100%" }}>
-			<Rect x={x} y={0} width={100} height={100} color="blue" />
-		</Canvas>
-	);
+    const [, setFirstRenderFinished] = useState(false);
+
+    const setIsActive = useCallback(() => {
+        runOnJS(setFirstRenderFinished)(true);
+    }, []);
+
+    useAnimatedReaction(
+        () => isActive.value,
+        () => {
+            runOnJS(setIsActive)();
+        },
+        [isActive, setIsActive]
+    );
+
+    const x = useSharedValue(0);
+    useEffect(() => {
+        x.value = withRepeat(withSequence(withTiming(100, { duration: 1000 }), withTiming(0, { duration: 1000 })), -1);
+    }, [x]);
+
+    return (
+        <Canvas style={{ width: "100%", height: "100%" }}>
+            <RoundedRect x={x} y={0} width={100} height={100} color="blue" r={8} />
+        </Canvas>
+    );
 };
 export default AnimatedSquareCanvas;

--- a/external-apps/expo-router-app/components/AnimatedSquareCanvas.tsx
+++ b/external-apps/expo-router-app/components/AnimatedSquareCanvas.tsx
@@ -8,7 +8,7 @@ const AnimatedSquareCanvas = () => {
     const [, setFirstRenderFinished] = useState(false);
 
     const setIsActive = useCallback(() => {
-        runOnJS(setFirstRenderFinished)(true);
+        setFirstRenderFinished(true);
     }, []);
 
     useAnimatedReaction(


### PR DESCRIPTION
After #2998, most of the web animation issues seem to be fixed, but there is still this weird case where if you convine a shared value + reaction + callback that sets state, then the animation does not run.

Also noticed that I'm getting this error even when the animation runs (without the new code):
```
Uncaught TypeError: Cannot read properties of undefined (reading 'setPicture')
    at Object.setJsiProperty (NativeSkiaModule.web.ts:20:33)
    at shopify_ContainerTs1 (Container.ts:28:15)
    at shopify_ContainerTs4 (Container.ts:119:7)
    at threads.js:115:13
    at Array.forEach (<anonymous>)
    at reactNativeReanimated_threadsJs5 (threads.js:114:17)
```

This animation works correctly on iOS and also works correctly with v1.7.6