### PR TITLE
chore(📦): Update release script to support NPM Provenance

### DIFF
--- a/packages/skia/.releaserc
+++ b/packages/skia/.releaserc
@@ -1,16 +1,34 @@
 {
-  "branches": ["main"],
+  "branches": [
+    "main",
+    {
+      "name": "next",
+      "prerelease": "next"
+    }
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     [
-        "semantic-release-yarn",
-        {
-          "npmPublish": true
-        }
-      ],
-      [
-        "@semantic-release/github"
-      ]
+      "semantic-release-yarn",
+      {
+        "npmPublish": false,
+        "tarballDir": "dist"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {"path": "dist/*.tgz", "label": "Package tarball"}
+        ]
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "publishCmd": "npm publish dist/*.tgz --provenance --access public --tag ${nextRelease.channel || 'latest'}"
+      }
+    ]
   ]
 }

--- a/packages/skia/package.json
+++ b/packages/skia/package.json
@@ -91,6 +91,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "7.18.6",
     "@semantic-release/commit-analyzer": "^13.0.0",
+    "@semantic-release/exec": "^7.0.3",
     "@semantic-release/github": "^10.3.3",
     "@semantic-release/release-notes-generator": "^14.0.1",
     "@types/jest": "29.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4686,6 +4686,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@semantic-release/exec@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "@semantic-release/exec@npm:7.0.3"
+  dependencies:
+    "@semantic-release/error": ^4.0.0
+    aggregate-error: ^3.0.0
+    debug: ^4.0.0
+    execa: ^9.0.0
+    lodash-es: ^4.17.21
+    parse-json: ^8.0.0
+  peerDependencies:
+    semantic-release: ">=24.1.0"
+  checksum: 38674b927f123499be80c0eb54edeb7826204268df1df6f7df27f667a966ef873cbd2cc89eb5397f04493708cde114a076cee137f1bb65ce1d4e6a13d326ca2b
+  languageName: node
+  linkType: hard
+
 "@semantic-release/github@npm:^10.3.3":
   version: 10.3.5
   resolution: "@semantic-release/github@npm:10.3.5"
@@ -4787,6 +4803,7 @@ __metadata:
   dependencies:
     "@babel/plugin-proposal-nullish-coalescing-operator": 7.18.6
     "@semantic-release/commit-analyzer": ^13.0.0
+    "@semantic-release/exec": ^7.0.3
     "@semantic-release/github": ^10.3.3
     "@semantic-release/release-notes-generator": ^14.0.1
     "@types/jest": 29.5.6


### PR DESCRIPTION
The goal of this PR is for the release script to support NPM provenance. This is achieved by not using yarn publish (which doesn't support NPM provenance: https://docs.npmjs.com/generating-provenance-statements) but instead use yarn to create the tarball (due to monorepo support) and then execute npm publish on that tarball.