### PR TITLE
Allow customizing ndk path and version

### DIFF
--- a/packages/skia/android/build.gradle
+++ b/packages/skia/android/build.gradle
@@ -132,6 +132,16 @@ android {
 
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
+
+    // Used to override the NDK path/version on internal CI or by allowing
+    // users to customize the NDK path/version from their root project.
+    if (rootProject.hasProperty("ndkPath")) {
+        ndkPath rootProject.ext.ndkPath
+    }
+    if (rootProject.hasProperty("ndkVersion")) {
+        ndkVersion rootProject.ext.ndkVersion
+    }
+
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
         targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)


### PR DESCRIPTION
This uses the project ndk version and path if specified. This will make sure only one version of the ndk is used to compile a project. Similar to https://github.com/AppAndFlow/react-native-safe-area-context/blob/main/android/build.gradle#L52.