### PR TITLE
fix: make apple builds deterministic

### DIFF
--- a/.github/workflows/build-skia.yml
+++ b/.github/workflows/build-skia.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
           GIT_SYNC_DEPS_SKIP_EMSDK: 'true'
+          ZERO_AR_DATE: 1
         run: yarn build-skia
 
       - name: Upload artifacts - Android arm


### PR DESCRIPTION
This PR sets ZERO_AR_DATE in env of build command, so that the shipped static libraries do no contain build timestamps. This allows to build the static libraries deterministically such that the code published in the npm package can be validated by by third parties.