### PR TITLE
fix: consistent std::move semantics

### DIFF
--- a/packages/skia/cpp/api/JsiSkPictureFactory.h
+++ b/packages/skia/cpp/api/JsiSkPictureFactory.h
@@ -45,7 +45,7 @@ public:
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkPictureFactory, MakePicture))
 
   explicit JsiSkPictureFactory(std::shared_ptr<RNSkPlatformContext> context)
-      : JsiSkHostObject(context) {}
+      : JsiSkHostObject(std::move(context)) {}
 };
 
 } // namespace RNSkia


### PR DESCRIPTION
std::move semantics where refactored in https://github.com/Shopify/react-native-skia/pull/340
SkPicture was added in https://github.com/Shopify/react-native-skia/pull/327

The SkPicture PR was created earlier than the std::move semantics PR but merged later, which explains why it's missing here
