### PR TITLE
fix: Throw a more helpful error when ColorType or AlphaType is not found in canvaskit

### DIFF
--- a/packages/skia/src/skia/web/JsiSkImageFactory.ts
+++ b/packages/skia/src/skia/web/JsiSkImageFactory.ts
@@ -77,11 +77,20 @@ export class JsiSkImageFactory extends Host implements ImageFactory {
 
   MakeImage(info: ImageInfo, data: SkData, bytesPerRow: number) {
     // see toSkImageInfo() from canvaskit
+    const alphaType = getEnum(this.CanvasKit.AlphaType, info.alphaType);
+    if (alphaType === undefined) {
+      throw new Error(`AlphaType not found in CanvasKit: ${info.alphaType}`);
+    }
+    const colorType = getEnum(this.CanvasKit.ColorType, info.colorType);
+    if (colorType === undefined) {
+      throw new Error(`ColorType not found in CanvasKit: ${info.colorType}`);
+    }
+
     const image = this.CanvasKit.MakeImage(
       {
-        alphaType: getEnum(this.CanvasKit.AlphaType, info.alphaType),
+        alphaType,
         colorSpace: this.CanvasKit.ColorSpace.SRGB,
-        colorType: getEnum(this.CanvasKit.ColorType, info.colorType),
+        colorType,
         height: info.height,
         width: info.width,
       },


### PR DESCRIPTION
Partially addresses https://github.com/Shopify/react-native-skia/issues/3060. (At least, it makes the error message more helpful. But it's still very awkward that an enum member can have different values in different environments).

Maybe getEnum should always throw if it doesn't find the provided value? That's probably sensible. Open to suggestions.

Maybe we should just be passing around the enum keys (names) rather than the numeric values. Not the first time I've been hurt by this.