### PR TITLE
fix: always seperate type imports from normal imports

### DIFF
--- a/packages/skia/src/sksg/Recorder/Player.ts
+++ b/packages/skia/src/sksg/Recorder/Player.ts
@@ -45,8 +45,8 @@ import {
   isDrawCommand,
   isGroup,
   materializeCommand,
-  type Command,
 } from "./Core";
+import type { Command } from "./Core";
 import type { DrawingContext } from "./DrawingContext";
 
 function play(ctx: DrawingContext, _command: Command) {


### PR DESCRIPTION
Some buggy AST parsers don't like mixed type vs real imports inside a single statement.