### PR TITLE
fix(docs): drawOffscreen is async

### DIFF
--- a/apps/docs/docs/getting-started/headless.md
+++ b/apps/docs/docs/getting-started/headless.md
@@ -27,7 +27,7 @@ import { Circle, drawOffscreen, getSkiaExports, Group, makeOffscreenSurface } fr
   // Alternatively you can do const {Skia} = require("@shopify/react-native-skia")
   const {Skia} = getSkiaExports();
   const surface = makeOffscreenSurface(width, height);
-  const image = drawOffscreen(surface,
+  const image = await drawOffscreen(surface,
     <Group blendMode="multiply">
       <Circle cx={r} cy={r} r={r} color="cyan" />
       <Circle cx={size - r} cy={r} r={r} color="magenta" />


### PR DESCRIPTION
I was messing around with running skia headless mode. I copied [the sample](https://shopify.github.io/react-native-skia/docs/getting-started/headless#hello-world) from the docs but that didn't work cause `drawOffscreen` is async now. See: https://github.com/Shopify/react-native-skia/blob/f89a73027d354a33eaefac65ffc0a1cb2cf542d2/apps/headless/src/helloWorld.tsx#L22