### PR TITLE
fix(🐛): fix reconciler regression due to mismatching types

### DIFF
--- a/packages/skia/src/sksg/HostConfig.ts
+++ b/packages/skia/src/sksg/HostConfig.ts
@@ -177,10 +177,8 @@ export const sksgHostConfig: SkiaHostConfig = {
     _type,
     _oldProps,
     newProps,
-    _updatePayload,
-    _internalInstanceHandle,
-    keepChildren: boolean,
-    _recyclableInstance: null | Instance
+    keepChildren,
+    _newChildSet
   ) {
     debug("cloneInstance");
     return {


### PR DESCRIPTION
fixes #3159

The TypeScript type of the HostConfig were mismatching the actually implementation. As a result, `keepChildren` was always undefined