### PR TITLE
chore(🏗️): update copy-headers for parallel builds

### DIFF
--- a/packages/skia/scripts/skia-configuration.ts
+++ b/packages/skia/scripts/skia-configuration.ts
@@ -263,30 +263,21 @@ const copyModule = (module: string) => [
   `cp -a ../../externals/skia/modules/${module}/include/. ./cpp/skia/modules/${module}/include`,
 ];
 
-const findDawnIncludePath = () => {
-  const fs = require('fs');
-  const path = require('path');
+const getFirstAvailableTarget = () => {
+  // Use the same logic as build-skia.ts to get the first available target
+  const platforms = Object.keys(configurations) as PlatformName[];
   
-  const outDir = path.join(SkiaSrc, 'out');
-  const dawnIncludePath = 'gen/third_party/externals/dawn/include';
-  
-  // Search in both android and apple platforms
-  const platforms = ['android', 'apple'];
-  
-  for (const platform of platforms) {
-    const platformDir = path.join(outDir, platform);
-    if (!fs.existsSync(platformDir)) continue;
+  for (const platformName of platforms) {
+    const configuration = configurations[platformName];
+    const targetNames = Object.keys(configuration.targets);
     
-    const targets = fs.readdirSync(platformDir);
-    for (const target of targets) {
-      const targetPath = path.join(platformDir, target, dawnIncludePath);
-      if (fs.existsSync(targetPath)) {
-        return path.join(platform, target);
-      }
+    if (targetNames.length > 0) {
+      return `${platformName}/${targetNames[0]}`;
     }
   }
   
-  throw new Error('Dawn include directory not found in any build target. Make sure Skia is built with Graphite/Dawn support.');
+  // Fallback to a sensible default
+  return 'android/arm64';
 };
 
 export const copyHeaders = () => {
@@ -307,7 +298,7 @@ export const copyHeaders = () => {
           "cp -a ../../externals/skia/src/gpu/graphite/ResourceTypes.h ./cpp/skia/src/gpu/graphite/.",
           "cp -a ../../externals/skia/src/gpu/graphite/TextureProxyView.h ./cpp/skia/src/gpu/graphite/.",
 
-          `cp -a ../../externals/skia/out/${findDawnIncludePath()}/gen/third_party/externals/dawn/include/. ./cpp/dawn/include`,
+          `cp -a ../../externals/skia/out/${getFirstAvailableTarget()}/gen/third_party/externals/dawn/include/. ./cpp/dawn/include`,
           "cp -a ../../externals/skia/third_party/externals/dawn/include/. ./cpp/dawn/include",
           "cp -a ../../externals/skia/third_party/externals/dawn/include/. ./cpp/dawn/include",
 


### PR DESCRIPTION
For Graphite we need the build output but we don't know which target has been built.