### PR TITLE
Add missing Android import

### DIFF
--- a/packages/skia/android/src/paper/java/com/facebook/react/viewmanagers/SkiaPictureViewManagerInterface.java
+++ b/packages/skia/android/src/paper/java/com/facebook/react/viewmanagers/SkiaPictureViewManagerInterface.java
@@ -12,6 +12,8 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 
+import com.shopify.reactnative.skia.SkiaPictureView;
+
 public interface SkiaPictureViewManagerInterface<T extends View> {
   void setDebug(T view, boolean value);
   void setOpaque(T view, boolean value);


### PR DESCRIPTION
With https://github.com/Shopify/react-native-skia/pull/3258, Android no longer builds successfully as there is an import missing. This PR fixes the issue.

Error log:
> .../node_modules/@shopify/react-native-skia/android/src/paper/java/com/facebook/react/viewmanagers/SkiaPictureViewManagerInterface.java:18: error: cannot find symbol
    void setColorSpace(SkiaPictureView view, @Nullable String value);
                       ^
    symbol:   class SkiaPictureView
    location: interface SkiaPictureViewManagerInterface<T>