### PR TITLE
feat(🍏, 🤖): Realtime snapshotting

### DIFF
--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -1327,7 +1327,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-slider (4.5.6):
+  - react-native-slider (4.5.7):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1340,7 +1340,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-slider/common (= 4.5.6)
+    - react-native-slider/common (= 4.5.7)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1349,7 +1349,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-slider/common (4.5.6):
+  - react-native-slider/common (4.5.7):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2194,7 +2194,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: 843f352b32aacbe13a9c750190d34df44c3e6c2c
   react-native-safe-area-context: 0f14bce545abcdfbff79ce2e3c78c109f0be283e
   react-native-skia: d696b43cb1a6560ec3902856cdc8f0838cc25b64
-  react-native-slider: bb7eb4732940fab78217e1c096bb647d8b0d1cf3
+  react-native-slider: 310d3f89edd6ca8344a974bfe83a29a3fbb60e5a
   React-NativeModulesApple: 88433b6946778bea9c153e27b671de15411bf225
   React-perflogger: 9e8d3c0dc0194eb932162812a168aa5dc662f418
   React-performancetimeline: 5a2d6efef52bdcefac079c7baa30934978acd023

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -107,7 +107,7 @@ const App = () => {
             screenOptions={{
               headerLeft: HeaderLeft,
             }}
-            initialRouteName={CI ? "Tests" : "Home"}
+            initialRouteName={CI ? "Tests" : "LiquidGlass"}
           >
             <Stack.Screen
               name="Home"

--- a/apps/example/src/Examples/API/Snapshot.tsx
+++ b/apps/example/src/Examples/API/Snapshot.tsx
@@ -54,7 +54,7 @@ export const Snapshot = () => {
 
   return (
     <View style={{ flex: 1 }}>
-      <View ref={viewRef} style={styles.view}>
+      <View ref={viewRef} style={styles.view} collapsable={false}>
         <Component />
       </View>
       <Button title="Take snapshot" onPress={takeSnapshot} />

--- a/apps/example/src/Examples/API/Snapshot.tsx
+++ b/apps/example/src/Examples/API/Snapshot.tsx
@@ -48,7 +48,10 @@ export const Snapshot = () => {
   const image = useSharedValue<SkImage | null>(null);
   const takeSnapshot = useCallback(async () => {
     if (viewRef.current != null) {
+      const start = performance.now();
       image.value = await makeImageFromView(viewRef as RefObject<View>);
+      const end = performance.now();
+      console.log("Performance: " + Math.round(end - start) + " ms");
     }
   }, [image]);
 

--- a/apps/example/src/Examples/LiquidGlass/List.tsx
+++ b/apps/example/src/Examples/LiquidGlass/List.tsx
@@ -26,6 +26,10 @@ export const examples = [
     screen: "Shader2",
     title: "🎨 Shader 2",
   },
+  {
+    screen: "NativeView",
+    title: "📱 Native View",
+  },
 ] as const;
 
 const styles = StyleSheet.create({

--- a/apps/example/src/Examples/LiquidGlass/NativeView.tsx
+++ b/apps/example/src/Examples/LiquidGlass/NativeView.tsx
@@ -1,0 +1,86 @@
+import {
+  Canvas,
+  Skia,
+  useClock,
+  Image as SkImage,
+} from "@shopify/react-native-skia";
+import React, { useLayoutEffect, useRef } from "react";
+import { View, PixelRatio, StyleSheet, findNodeHandle } from "react-native";
+import Animated, {
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+} from "react-native-reanimated";
+
+const style = {
+  flex: 1,
+  overflow: "hidden" as const,
+};
+
+export const NativeView = () => {
+  const canvasSize = useSharedValue({ width: 0, height: 0 });
+  const viewTag = useRef(-1);
+  const image = useSharedValue(Skia.Image.MakeNull());
+  const ref = useRef<View>(null);
+  const clock = useClock();
+  const imageHeight = 1920 / PixelRatio.get();
+
+  const translateY = useDerivedValue(() => clock.value / 10);
+
+  useLayoutEffect(() => {
+    viewTag.current = findNodeHandle(ref.current)!;
+  }, []);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      transform: [{ translateY: -translateY.value % imageHeight }],
+    };
+  });
+
+  useAnimatedReaction(
+    () => clock.value,
+    () => {
+      Skia.Image.MakeImageFromViewTagSync(viewTag.current, image.value);
+    }
+  );
+
+  const rect = useDerivedValue(() => ({
+    x: 0,
+    y: 0,
+    width: canvasSize.value.width,
+    height: canvasSize.value.height,
+  }));
+
+  return (
+    <View style={{ flex: 1 }}>
+      <View style={style} collapsable={false} ref={ref}>
+        <Animated.Image
+          style={[
+            {
+              resizeMode: "repeat",
+              width: "100%",
+              height: imageHeight * 2,
+            },
+            animatedStyle,
+          ]}
+          source={require("./assets/flowers.jpg")}
+        />
+        <Animated.Image
+          style={[
+            {
+              resizeMode: "repeat",
+              width: "100%",
+              height: imageHeight * 2,
+            },
+            animatedStyle,
+          ]}
+          source={require("./assets/flowers.jpg")}
+        />
+      </View>
+      <Canvas style={StyleSheet.absoluteFillObject} onSize={canvasSize}>
+        <SkImage image={image} rect={rect} />
+      </Canvas>
+    </View>
+  );
+};

--- a/apps/example/src/Examples/LiquidGlass/NativeView.tsx
+++ b/apps/example/src/Examples/LiquidGlass/NativeView.tsx
@@ -3,9 +3,17 @@ import {
   Skia,
   useClock,
   Image as SkImage,
+  Fill,
+  ColorMatrix,
 } from "@shopify/react-native-skia";
 import React, { useLayoutEffect, useRef } from "react";
-import { View, PixelRatio, StyleSheet, findNodeHandle } from "react-native";
+import {
+  View,
+  PixelRatio,
+  StyleSheet,
+  findNodeHandle,
+  Platform,
+} from "react-native";
 import Animated, {
   useAnimatedReaction,
   useAnimatedStyle,
@@ -38,12 +46,20 @@ export const NativeView = () => {
     };
   });
 
-  useAnimatedReaction(
-    () => clock.value,
-    () => {
-      Skia.Image.MakeImageFromViewTagSync(viewTag.current, image.value);
-    }
-  );
+  // useAnimatedReaction(
+  //   () => clock.value,
+  //   () => {
+  //     console.log("take snapshot on " + Platform.OS + " at " + new Date());
+  //     Skia.Image.MakeImageFromViewTagSync(viewTag.current, image.value);
+  //   }
+  // );
+  const result = useDerivedValue(() => {
+    console.log(clock.value);
+    return Skia.Image.MakeImageFromViewTagSync(
+      viewTag.current,
+      image.value
+    ) as SkImage;
+  });
 
   const rect = useDerivedValue(() => ({
     x: 0,
@@ -79,7 +95,14 @@ export const NativeView = () => {
         />
       </View>
       <Canvas style={StyleSheet.absoluteFillObject} onSize={canvasSize}>
-        <SkImage image={image} rect={rect} />
+        <SkImage image={result} rect={rect}>
+          <ColorMatrix
+            matrix={[
+              -0.578, 0.99, 0.588, 0, 0, 0.469, 0.535, -0.003, 0, 0, 0.015,
+              1.69, -0.703, 0, 0, 0, 0, 0, 1, 0,
+            ]}
+          />
+        </SkImage>
       </Canvas>
     </View>
   );

--- a/apps/example/src/Examples/LiquidGlass/Routes.ts
+++ b/apps/example/src/Examples/LiquidGlass/Routes.ts
@@ -5,4 +5,5 @@ export type Routes = {
   DisplacementMap2: undefined;
   Shader1: undefined;
   Shader2: undefined;
+  NativeView: undefined;
 };

--- a/apps/example/src/Examples/LiquidGlass/index.tsx
+++ b/apps/example/src/Examples/LiquidGlass/index.tsx
@@ -8,11 +8,12 @@ import { DisplacementMap1 } from "./DisplacementMap1";
 import { DisplacementMap2 } from "./DisplacementMap2";
 import { Shader1 } from "./Shader1";
 import { Shader2 } from "./Shader2";
+import { NativeView } from "./NativeView";
 
 const Stack = createNativeStackNavigator<Routes>();
 export const LiquidGlass = () => {
   return (
-    <Stack.Navigator>
+    <Stack.Navigator initialRouteName="NativeView">
       <Stack.Screen
         name="List"
         component={List}
@@ -54,6 +55,13 @@ export const LiquidGlass = () => {
         component={Shader2}
         options={{
           title: "🎨 Shader 2",
+        }}
+      />
+      <Stack.Screen
+        name="NativeView"
+        component={NativeView}
+        options={{
+          title: "📱 Native View",
         }}
       />
     </Stack.Navigator>

--- a/packages/skia/apple/ViewScreenshotService.mm
+++ b/packages/skia/apple/ViewScreenshotService.mm
@@ -44,8 +44,11 @@
   // up in the profiler!
   UIImage *image = [renderer
       imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull context) {
+        //CFTimeInterval startTime = CACurrentMediaTime();
         [view drawViewHierarchyInRect:(CGRect){CGPointZero, size}
-                   afterScreenUpdates:YES];
+                   afterScreenUpdates:NO];
+        //CFTimeInterval endTime = CACurrentMediaTime();
+        //NSLog(@"drawViewHierarchyInRect took %.2f ms", (endTime - startTime) * 1000.0);
       }];
 
   // Convert from UIImage -> CGImage -> SkImage

--- a/packages/skia/cpp/api/JsiSkImageFactory.h
+++ b/packages/skia/cpp/api/JsiSkImageFactory.h
@@ -83,6 +83,18 @@ public:
         });
   }
 
+  JSI_HOST_FUNCTION(MakeImageFromViewTagSync) {
+    // TODO: add safety checks on args[0] and args[1]
+    auto viewTag = arguments[0].asNumber();
+    auto image = JsiSkImage::fromValue(runtime, arguments[1]);
+    auto context = getContext();
+    // TODO: check we are on the main thread
+    if (viewTag != -1) {
+
+    }
+    return jsi::Value::undefined();
+  }
+
   JSI_HOST_FUNCTION(MakeImageFromNativeTextureUnstable) {
     auto texInfo = JsiTextureInfo::fromValue(runtime, arguments[0]);
     auto image = getContext()->makeImageFromNativeTexture(
@@ -104,6 +116,7 @@ public:
 
   JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkImageFactory, MakeImageFromEncoded),
                        JSI_EXPORT_FUNC(JsiSkImageFactory, MakeImageFromViewTag),
+                       JSI_EXPORT_FUNC(JsiSkImageFactory, MakeImageFromViewTagSync),
                        JSI_EXPORT_FUNC(JsiSkImageFactory,
                                        MakeImageFromNativeBuffer),
                        JSI_EXPORT_FUNC(JsiSkImageFactory,

--- a/packages/skia/cpp/api/JsiSkImageFactory.h
+++ b/packages/skia/cpp/api/JsiSkImageFactory.h
@@ -86,11 +86,20 @@ public:
   JSI_HOST_FUNCTION(MakeImageFromViewTagSync) {
     // TODO: add safety checks on args[0] and args[1]
     auto viewTag = arguments[0].asNumber();
-    auto image = JsiSkImage::fromValue(runtime, arguments[1]);
+    auto jsiImage = arguments[1].asObject(runtime).asHostObject<JsiSkImage>(runtime);
     auto context = getContext();
     // TODO: check we are on the main thread
     if (viewTag != -1) {
-
+      auto result = context->makeViewScreenshotSync(viewTag);
+      SkDebugf("MakeImageFromViewTagSync: viewTag=%d, result=%s\n", 
+               static_cast<int>(viewTag), 
+               result != nullptr ? "not null" : "null");
+      jsiImage->setObject(result);
+      return jsi::Object::createFromHostObject(
+            runtime, std::make_shared<JsiSkImage>(getContext(), std::move(result)));
+    } else {
+            SkDebugf("MakeImageFromViewTagSync failed: viewTag=%d\n", 
+               static_cast<int>(viewTag));
     }
     return jsi::Value::undefined();
   }

--- a/packages/skia/cpp/api/recorder/Drawings.h
+++ b/packages/skia/cpp/api/recorder/Drawings.h
@@ -496,22 +496,24 @@ public:
     auto [x, y, width, height, rect, fit, image, sampling] = props;
     if (image.has_value()) {
       auto img = image.value();
-      auto hasRect =
-          rect.has_value() || (width.has_value() && height.has_value());
-      if (hasRect) {
-        auto src = SkRect::MakeXYWH(0, 0, img->width(), img->height());
-        auto dst = rect.has_value()
-                       ? rect.value()
-                       : SkRect::MakeXYWH(x, y, width.value(), height.value());
-        auto rects = RNSkiaImage::fitRects(fit, src, dst);
-        ctx->canvas->drawImageRect(
-            img, rects.src, rects.dst,
-            sampling.value_or(SkSamplingOptions(SkFilterMode::kLinear)),
-            &(ctx->getPaint()), SkCanvas::kStrict_SrcRectConstraint);
-      } else {
-        throw std::runtime_error(
-            "Image node could not resolve image dimension props.");
-      }
+        if (img != nullptr) {
+            auto hasRect =
+            rect.has_value() || (width.has_value() && height.has_value());
+            if (hasRect) {
+                auto src = SkRect::MakeXYWH(0, 0, img->width(), img->height());
+                auto dst = rect.has_value()
+                ? rect.value()
+                : SkRect::MakeXYWH(x, y, width.value(), height.value());
+                auto rects = RNSkiaImage::fitRects(fit, src, dst);
+                ctx->canvas->drawImageRect(
+                                           img, rects.src, rects.dst,
+                                           sampling.value_or(SkSamplingOptions(SkFilterMode::kLinear)),
+                                           &(ctx->getPaint()), SkCanvas::kStrict_SrcRectConstraint);
+            } else {
+                throw std::runtime_error(
+                                         "Image node could not resolve image dimension props.");
+            }
+        }
     }
   }
 };

--- a/packages/skia/cpp/rnskia/RNSkPlatformContext.h
+++ b/packages/skia/cpp/rnskia/RNSkPlatformContext.h
@@ -161,6 +161,16 @@ public:
   }
 
   /**
+   * Creates an skImage containing the screenshot of a native view and its
+   * children. This method assumes it's already running on the main thread.
+   * @param viewTag React viewtag
+   * @return sk_sp<SkImage> The screenshot image or nullptr if failed
+   */
+  virtual sk_sp<SkImage> makeViewScreenshotSync(int viewTag) {
+    return takeScreenshotFromViewTag(viewTag);
+  }
+
+  /**
    * Raises an exception on the platform. This function does not necessarily
    * throw an exception and stop execution, so it is important to stop execution
    * by returning after calling the function


### PR DESCRIPTION
The goal of this PR is to provide snapshotting of native views for Skia.
On iOS this is done by making the feature faster and offering a shortcut if the snapshot is directly made on the main thread via Reanimated.
On Android, we will use setRenderEffect() (`API level >= 31`) which somewhat a completely different feature but since it is using the same shader syntax as Skia (because it is Skia) we think it's too good of an opportunity to pass.

* [x] iOS
* [ ] Android
* [ ] Finish demo
* [ ] Document