### PR TITLE
[0.82] Remove unnecessary `jar*` tasks for library variants

### DIFF
--- a/packages/skia/android/build.gradle
+++ b/packages/skia/android/build.gradle
@@ -286,17 +286,6 @@ dependencies {
     }
 }
 
-afterEvaluate { project ->
-    android.libraryVariants.all { variant ->
-        def name = variant.name.capitalize()
-        def javaCompileTask = variant.javaCompileProvider.get()
-
-        task "jar${name}"(type: Jar, dependsOn: javaCompileTask) {
-            from javaCompileTask.destinationDir
-        }
-    }
-}
-
 def localBuildDir = buildDir
 def headersConfiguration = configurations.extractHeaders
 def jniConfiguration = configurations.extractJNI


### PR DESCRIPTION
This snippet is unnecessary IMHO. It's creating a `jarDebug`, `jarRelease` task. The problem is that:

1. `javaCompileTask.destinationDir` is broken with Gradle 9.0.0 so `react-native-skia` will break with RN 0.82
	1. We discovered this while adding `react-native-skia` to our nightly testing: https://github.com/react-native-community/nightly-tests/pull/4
3. I don't see why you would want to create a `jar` file from an Android library. You'll be missing Android Manifest and a lot of other files that are making this archive usable
4. I searched on git history and I couldn't find the reason why this was added. It seems like it was added by @chrfalch here https://github.com/Shopify/react-native-skia/commit/0c13220631cb1c03b7bcc3fe7f099d0f871e3418 I don't see the reason why though.

IMHO this can be removed.