### PR TITLE
Feat/webgl context attributes

### DIFF
--- a/packages/skia/src/renderer/Canvas.tsx
+++ b/packages/skia/src/renderer/Canvas.tsx
@@ -14,6 +14,7 @@ import type {
   ViewProps,
 } from "react-native";
 import { type SharedValue } from "react-native-reanimated";
+import type { WebGLOptions } from "canvaskit-wasm";
 
 import { SkiaViewNativeId } from "../views/SkiaViewNativeId";
 import SkiaPictureViewNativeComponent from "../specs/SkiaPictureViewNativeComponent";
@@ -60,24 +61,9 @@ export interface CanvasProps extends Omit<ViewProps, "onLayout"> {
    * WebGL context attributes for web platform.
    * Allows configuration of the WebGL rendering context.
    * Only applicable when running on web platform.
-   * 
-   * Note: Boolean values will be automatically converted to 0/1 for CanvasKit compatibility.
+   * Uses CanvasKit's WebGLOptions type directly - all values must be numeric (0 or 1 for boolean flags).
    */
-  webglContextAttributes?: {
-    alpha?: boolean;
-    depth?: boolean;
-    stencil?: boolean;
-    antialias?: boolean;
-    premultipliedAlpha?: boolean;
-    preserveDrawingBuffer?: boolean;
-    preferLowPowerToHighPerformance?: boolean;
-    failIfMajorPerformanceCaveat?: boolean;
-    enableExtensionsByDefault?: boolean;
-    explicitSwapControl?: boolean;
-    renderViaOffscreenBackBuffer?: boolean;
-    majorVersion?: number;
-    minorVersion?: number;
-  };
+  webglContextAttributes?: WebGLOptions;
 }
 
 export const Canvas = ({

--- a/packages/skia/src/specs/SkiaPictureViewNativeComponent.web.ts
+++ b/packages/skia/src/specs/SkiaPictureViewNativeComponent.web.ts
@@ -1,5 +1,6 @@
 import type { ViewProps } from "react-native";
 import { createElement } from "react";
+import type { WebGLOptions } from "canvaskit-wasm";
 
 import { SkiaPictureView } from "../views/SkiaPictureView.web";
 
@@ -7,21 +8,7 @@ export interface NativeProps extends ViewProps {
   debug?: boolean;
   opaque?: boolean;
   nativeID: string;
-  webglContextAttributes?: {
-    alpha?: boolean;
-    depth?: boolean;
-    stencil?: boolean;
-    antialias?: boolean;
-    premultipliedAlpha?: boolean;
-    preserveDrawingBuffer?: boolean;
-    preferLowPowerToHighPerformance?: boolean;
-    failIfMajorPerformanceCaveat?: boolean;
-    enableExtensionsByDefault?: boolean;
-    explicitSwapControl?: boolean;
-    renderViaOffscreenBackBuffer?: boolean;
-    majorVersion?: number;
-    minorVersion?: number;
-  };
+  webglContextAttributes?: WebGLOptions;
 }
 
 const SkiaPictureViewNativeComponent = ({

--- a/packages/skia/src/views/SkiaBaseWebView.tsx
+++ b/packages/skia/src/views/SkiaBaseWebView.tsx
@@ -42,29 +42,10 @@ export abstract class SkiaBaseWebView<
       canvas.width = this.width * pd;
       canvas.height = this.height * pd;
 
-      // Convert WebGL context attributes from boolean to numeric for CanvasKit
-      let contextAttributes: Record<string, number> | undefined;
-      if (this.props.webglContextAttributes) {
-        contextAttributes = {};
-        const attrs = this.props.webglContextAttributes;
-
-        // Iterate through all attributes and convert booleans to 0/1
-        for (const [key, value] of Object.entries(attrs)) {
-          if (value !== undefined) {
-            // Convert boolean to number (0/1), pass through numbers as-is
-            if (typeof value === "boolean") {
-              contextAttributes[key] = value ? 1 : 0;
-            } else {
-              contextAttributes[key] = value;
-            }
-          }
-        }
-      }
-
       const surface = CanvasKit.MakeWebGLCanvasSurface(
         canvas,
         undefined, // colorSpace - using undefined to maintain default
-        contextAttributes
+        this.props.webglContextAttributes // undefined if not explicitly provided
       );
       const ctx = canvas.getContext("webgl2");
       if (ctx) {

--- a/packages/skia/src/views/types.ts
+++ b/packages/skia/src/views/types.ts
@@ -1,5 +1,6 @@
 import type { ViewProps } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
+import type { WebGLOptions } from "canvaskit-wasm";
 
 import type { Node } from "../dom/types";
 import type { SkImage, SkPicture, SkRect, SkSize } from "../skia/types";
@@ -31,29 +32,14 @@ export interface SkiaBaseViewProps extends ViewProps {
   onSize?: SharedValue<SkSize>;
 
   opaque?: boolean;
-  
+
   /**
    * WebGL context attributes for web platform.
    * Allows configuration of the WebGL rendering context.
    * Only applicable when running on web platform.
-   * 
-   * Note: Boolean values will be automatically converted to 0/1 for CanvasKit compatibility.
+   * Uses CanvasKit's WebGLOptions type directly - all values must be numeric (0 or 1 for boolean flags).
    */
-  webglContextAttributes?: {
-    alpha?: boolean;
-    depth?: boolean;
-    stencil?: boolean;
-    antialias?: boolean;
-    premultipliedAlpha?: boolean;
-    preserveDrawingBuffer?: boolean;
-    preferLowPowerToHighPerformance?: boolean;
-    failIfMajorPerformanceCaveat?: boolean;
-    enableExtensionsByDefault?: boolean;
-    explicitSwapControl?: boolean;
-    renderViaOffscreenBackBuffer?: boolean;
-    majorVersion?: number;
-    minorVersion?: number;
-  };
+  webglContextAttributes?: WebGLOptions;
 }
 
 export interface SkiaPictureViewNativeProps extends SkiaBaseViewProps {


### PR DESCRIPTION
# Description

Add webglContextAttributes prop for Canvas (web platform)

This PR adds support for configuring WebGL context attributes on the web platform, enabling features like `preserveDrawingBuffer` which is essential for canvas capture/screenshot functionality.

## Motivation

Currently, it's not possible to capture/screenshot canvas content on web because the WebGL context is created without `preserveDrawingBuffer: true`. This PR allows developers to configure WebGL context attributes to enable this and other WebGL-specific features.

## Changes

- Added `webglContextAttributes` prop to `CanvasProps` and `SkiaBaseViewProps`
- Use WebGLOptions directly for typing
- Added prop to web-specific native component spec
- Follows existing platform-specific patterns (`.web.ts` files)

## Implementation Details

The implementation converts boolean values to numbers as required by CanvasKit's WebGLOptions interface:
- all attributes use original typing from WebGLOptions

## Usage

```tsx
<Canvas 
  style={{ width: 256, height: 256 }}
  webglContextAttributes={{ 
    preserveDrawingBuffer: 1,
    antialias: 1,
    alpha: 1
  }}
>
  <Fill color="blue" />
  <Circle cx={128} cy={128} r={50} color="red" />
</Canvas>
```

## Testing

### Visual Example

You can view a quick demo of this feature (not included in the PR) at this [link](https://www.loom.com/share/790a3df2a7b8485597ba414ab081372c?sid=a3260d03-03ce-4afd-996e-38a1795ead01)


## Platform Impact

- **Web**: ✅ Fully supported - enables WebGL context configuration
- **iOS/Android**: No impact - prop is ignored on native platforms
- **Breaking changes**: None - new optional prop with no effect on existing code

## Checklist

- [x] TypeScript compilation passes
- [x] Linting passes
- [x] Follows existing codebase patterns
- [x] Web-only implementation (doesn't affect native)
- [x] Tested locally with canvas capture functionality

## Other notes

If you'd like some extra context on why I ran into this problem and what I am trying to accomplish you can contact me gabe@novig.co, first time contributing to open source so please let me know if I am missing anything important in the contribution guidelines here. Great package that has made our work life and native apps render graphs fast and awesome! While porting our existing application to web we encountered this webGL edge case (react native for web)

