### PR TITLE
fix(📏): crash on initial view size request, avoid negative size values

### DIFF
--- a/packages/skia/cpp/jsi/JsiHostObject.h
+++ b/packages/skia/cpp/jsi/JsiHostObject.h
@@ -47,7 +47,7 @@
  * Creates a JSI export function declaration
  */
 #define JSI_EXPORT_FUNC(CLASS, FUNCTION)                                       \
-  {#FUNCTION, (jsi::Value(JsiHostObject::*)(                                   \
+  {#FUNCTION, (jsi::Value (JsiHostObject::*)(                                  \
                   jsi::Runtime & runtime, const jsi::Value &thisValue,         \
                   const jsi::Value *arguments, size_t)) &                      \
                   CLASS::FUNCTION}
@@ -65,7 +65,7 @@
  * Creates a JSI export getter declaration
  */
 #define JSI_EXPORT_PROP_GET(CLASS, FUNCTION)                                   \
-  {#FUNCTION, (jsi::Value(JsiHostObject::*)(jsi::Runtime & runtime)) &         \
+  {#FUNCTION, (jsi::Value (JsiHostObject::*)(jsi::Runtime & runtime)) &        \
                   CLASS::STR_CAT(STR_GET, FUNCTION)}
 
 /**
@@ -83,7 +83,7 @@
  */
 #define JSI_EXPORT_PROP_SET(CLASS, FUNCTION)                                   \
   {#FUNCTION,                                                                  \
-   (void(JsiHostObject::*)(jsi::Runtime & runtime, const jsi::Value &)) &      \
+   (void (JsiHostObject::*)(jsi::Runtime & runtime, const jsi::Value &)) &     \
        CLASS::STR_CAT(STR_SET, FUNCTION)}
 
 /**

--- a/packages/skia/cpp/rnskia/RNSkJsiViewApi.h
+++ b/packages/skia/cpp/rnskia/RNSkJsiViewApi.h
@@ -105,10 +105,15 @@ public:
           if (name == "onSize" && isSharedValue(runtime, arguments[2])) {
             jsi::Object size(runtime);
             auto pd = _platformContext->getPixelDensity();
-            size.setProperty(runtime, "width",
-                             info->view->getScaledWidth() / pd);
-            size.setProperty(runtime, "height",
-                             info->view->getScaledHeight() / pd);
+            auto w = info->view != nullptr
+                         ? std::max(info->view->getScaledWidth(), 0)
+                         : 0;
+            auto h = info->view != nullptr
+                         ? std::max(info->view->getScaledHeight(), 0)
+                         : 0;
+
+            size.setProperty(runtime, "width", w / pd);
+            size.setProperty(runtime, "height", h / pd);
             arguments[2].asObject(runtime).setProperty(runtime, "value", size);
           } else {
             info->props.insert_or_assign(


### PR DESCRIPTION
Fix crashes when info->view == nullptr on size request. Avoid negative size values, bringing values to 0.

#3315
