### PR TITLE
chore(🐙): change build dawn workflow to manual trigger only

### DIFF
--- a/.github/workflows/build-dawn.yml
+++ b/.github/workflows/build-dawn.yml
@@ -1,10 +1,6 @@
 name: Build Dawn
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-  workflow_dispatch:
+on: workflow_dispatch
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Updated workflow triggers to only allow manual dispatch.