### PR TITLE
Update CONTRIBUTING.md - mention `gh` dependency

### DIFF
--- a/packages/skia/CONTRIBUTING.md
+++ b/packages/skia/CONTRIBUTING.md
@@ -7,6 +7,7 @@ To develop react-native-skia, you can build the skia libraries on your computer.
 ### Using pre-built binaries
 
 To use the Skia prebuilt binaries from GitHub, use the following commands:
+- Install and authenticate the GitHub CLI, e.g. `brew install gh`, then run `gh auth login`
 - Checkout submodules: `git submodule update --init --recursive`
 - Install dependencies: `yarn`
 - Go to the package folder: `cd packages/skia`


### PR DESCRIPTION
Add line for installing and authenticating GitHub CLI. Without it, `yarn install-skia` won't work

I noticed this while trying to put a reproduction for a potential memory leak together. If I manage that, I'll open an issue for that.