### PR TITLE
chore(🐙): add workflow to test Skia release on iOS

### DIFF
--- a/.github/workflows/test-skia-release.yml
+++ b/.github/workflows/test-skia-release.yml
@@ -1,0 +1,138 @@
+name: Test Latest Skia Release on iOS
+
+on:
+  workflow_dispatch:
+    inputs:
+      skia_version:
+        description: 'Skia version to test (leave empty for @latest)'
+        required: false
+        default: 'latest'
+        type: string
+      simulator_device:
+        description: 'iOS Simulator device'
+        required: false
+        default: 'iPhone 16 Pro'
+        type: string
+
+jobs:
+  test-skia-ios:
+    runs-on: macos-latest-xlarge
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Yarn
+        run: |
+          corepack enable
+          yarn --version
+
+      - name: Install Expo CLI
+        run: |
+          npm install -g expo-cli eas-cli
+          expo --version
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: List available simulators
+        run: xcrun simctl list devices
+
+      - name: Create test directory
+        run: |
+          mkdir -p ~/skia-test-app
+          cd ~/skia-test-app
+          pwd
+
+      - name: Create Expo app with Skia template
+        working-directory: ~/skia-test-app
+        run: |
+          echo "Creating Expo app with Skia template..."
+          yarn create expo-app my-app -e with-skia
+
+      - name: Install React Native Skia
+        working-directory: ~/skia-test-app/my-app
+        run: |
+          if [ "${{ github.event.inputs.skia_version }}" == "latest" ]; then
+            echo "Installing @shopify/react-native-skia@latest..."
+            yarn add @shopify/react-native-skia@latest
+          else
+            echo "Installing @shopify/react-native-skia@${{ github.event.inputs.skia_version }}..."
+            yarn add @shopify/react-native-skia@${{ github.event.inputs.skia_version }}
+          fi
+
+      - name: Show installed Skia version
+        working-directory: ~/skia-test-app/my-app
+        run: |
+          echo "Installed React Native Skia version:"
+          yarn list @shopify/react-native-skia --depth=0
+
+      - name: Install Expo Dev Client
+        working-directory: ~/skia-test-app/my-app
+        run: |
+          echo "Installing expo-dev-client..."
+          npx expo install expo-dev-client
+
+      - name: Install iOS dependencies
+        working-directory: ~/skia-test-app/my-app
+        run: |
+          echo "Installing iOS dependencies..."
+          cd ios
+          pod install --repo-update
+
+      - name: Start Metro bundler
+        working-directory: ~/skia-test-app/my-app
+        run: |
+          echo "Starting Metro bundler in background..."
+          npx expo start --dev-client &
+          sleep 10
+
+      - name: Build and run iOS app
+        working-directory: ~/skia-test-app/my-app
+        run: |
+          echo "Building and running iOS app on simulator: ${{ github.event.inputs.simulator_device }}..."
+          npx expo run:ios --simulator "${{ github.event.inputs.simulator_device }}"
+
+      - name: Wait for app to launch
+        run: |
+          echo "Waiting for app to launch and stabilize..."
+          sleep 30
+
+      - name: Capture simulator screenshot
+        if: always()
+        run: |
+          SIMULATOR_ID=$(xcrun simctl list devices | grep "${{ github.event.inputs.simulator_device }}" | grep -E 'Booted' | head -n 1 | cut -d '(' -f 2 | cut -d ')' -f 1)
+          if [ -n "$SIMULATOR_ID" ]; then
+            echo "Capturing screenshot from simulator ID: $SIMULATOR_ID"
+            xcrun simctl io $SIMULATOR_ID screenshot ~/skia-test-screenshot.png
+          else
+            echo "No booted simulator found"
+          fi
+
+      - name: Upload screenshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-simulator-screenshot
+          path: ~/skia-test-screenshot.png
+          if-no-files-found: ignore
+
+      - name: Print test summary
+        if: always()
+        run: |
+          echo "================================================================"
+          echo "Test Summary:"
+          echo "================================================================"
+          echo "✓ Created Expo app with Skia template"
+          echo "✓ Installed @shopify/react-native-skia@${{ github.event.inputs.skia_version || 'latest' }}"
+          echo "✓ Installed expo-dev-client"
+          echo "✓ Built and ran iOS app on ${{ github.event.inputs.simulator_device }}"
+          echo "================================================================"


### PR DESCRIPTION
This workflow tests the latest Skia release on iOS by creating an Expo app with the Skia template, installing necessary dependencies, and running the app on a specified simulator.