### PR TITLE
fix: Fix bridge to access halfLeading as boolean

### DIFF
--- a/packages/skia/cpp/api/JsiSkTextStyle.h
+++ b/packages/skia/cpp/api/JsiSkTextStyle.h
@@ -137,7 +137,7 @@ public:
     }
     if (object.hasProperty(runtime, "halfLeading")) {
       auto propValue = object.getProperty(runtime, "halfLeading");
-      retVal.setHalfLeading(propValue.asNumber());
+      retVal.setHalfLeading(propValue.getBool());
     }
     if (object.hasProperty(runtime, "letterSpacing")) {
       auto propValue = object.getProperty(runtime, "letterSpacing");


### PR DESCRIPTION
Fixes incorrect prop type access for `halfLeading`. Currently, passing a boolean for this prop causes a crash. 

- Align the native `JsiSkTextStyle` bridge with the documented API by reading `halfLeading` via `getBool()` instead of `asNumber()`.