### PR TITLE
chore: add docs on how to animate transform properties

### DIFF
--- a/apps/docs/docs/animations/reanimated3.md
+++ b/apps/docs/docs/animations/reanimated3.md
@@ -9,6 +9,8 @@ React Native Skia offers integration with [Reanimated v3 and above](https://docs
 
 React Native Skia supports the direct usage of Reanimated's shared and derived values as properties. There is no need for functions like `createAnimatedComponent` or `useAnimatedProps`; simply pass the Reanimated values directly as properties.
 
+**Note:** For animating `transform` properties, pass the entire transform object instead of individual properties. See section below for details.
+
 ```tsx twoslash
 import {useEffect} from "react";
 import {Canvas, Circle, Group} from "@shopify/react-native-skia";
@@ -112,4 +114,23 @@ export const AnimatedGradient = () => {
     </Canvas>
   );
 };
+```
+
+## Animating Transforms
+
+For animating `transform` properties, create a derived value that returns the array of transforms with each property as a separate object. Passing reanimated values directly will not work.
+
+```tsx
+const transform = useDerivedValue(() => {
+  return [
+    { rotate: rotation.value }, 
+    { scale: scale.value }
+  ];
+});
+
+return (
+  <Canvas>
+    <Group transform={transform}>...</Group>
+  </Canvas>
+);
 ```


### PR DESCRIPTION
## Summary
This PR updates the docs to clarify how to animate transform properties, based on a [common confusion](https://github.com/Shopify/react-native-skia/discussions/1631#discussioncomment-8546606).

## Documentation improvements:

* Added a note explaining that for animating `transform` properties, the entire transform object should be passed, not individual properties.
* Introduced a new section, "Animating Transforms," with an example showing how to use a derived value to construct the transform array for use with Skia components.