### PR TITLE
fix(🤖): fix thread issue with notifyTaskReadyExternal (#3547)

### DIFF
--- a/packages/skia/android/cpp/jni/JniPlatformContext.cpp
+++ b/packages/skia/android/cpp/jni/JniPlatformContext.cpp
@@ -204,11 +204,11 @@ void JniPlatformContext::runTaskOnMainThread(std::function<void()> task) {
 }
 
 void JniPlatformContext::notifyTaskReadyExternal() {
-    jni::ThreadScope ts;
+  jni::ThreadScope ts;
 
-    static auto method =
-        javaPart_->getClass()->getMethod<void()>("notifyTaskReady");
-    method(javaPart_.get());
+  static auto method =
+    javaPart_->getClass()->getMethod<void()>("notifyTaskReady");
+  method(javaPart_.get());
 }
 
 void JniPlatformContext::notifyTaskReadyNative() {


### PR DESCRIPTION
I've had a bunch of crashing and this definitely resolved it :)

Thanks for the great library and I'm glad I could contribute something back

The issue is: this can be called from non-Java threads (e.g. Hermes "hades" GC thread) via Recorder::~Recorder -> runTaskOnMainThread(). We must ensure the current thread is attached to the JVM before using fbjni / Java refs.