### PR TITLE
fix(macOS): continue rendering while app is not in focus

### DIFF
--- a/packages/skia/apple/RNSkMetalCanvasProvider.mm
+++ b/packages/skia/apple/RNSkMetalCanvasProvider.mm
@@ -68,7 +68,7 @@ bool RNSkMetalCanvasProvider::renderToCanvas(
     auto state = UIApplication.sharedApplication.applicationState;
     bool appIsBackgrounded = (state == UIApplicationStateBackground);
 #else
-    bool appIsBackgrounded = !NSApplication.sharedApplication.isActive;
+    bool appIsBackgrounded = NSApplication.sharedApplication.isHidden;
 #endif // !TARGET_OS_OSX
     if (appIsBackgrounded) {
       // Request a redraw in the next run loop callback


### PR DESCRIPTION
On macOS we only want to pause rendering if the app is hidden.
Focusing another app causes the isActive app state to be false, pausing the rendering, while we still have a valid context and are visually present on the screen.

This PR follows the same logic that is used in `RTCAppState.mm` for determining if the app is in the background:
https://github.com/microsoft/react-native-macos/blob/0ee9be8de36189ef34dbee174b423b9816c4c809/packages/react-native/React/CoreModules/RCTAppState.mm#L37-L41

https://github.com/user-attachments/assets/9bea81cb-97c2-4fbf-8bde-f491098a429c