### PR TITLE
prevent crash in `ViewScreenshotService` when image data is `null`

### DIFF
--- a/packages/skia/apple/ViewScreenshotService.mm
+++ b/packages/skia/apple/ViewScreenshotService.mm
@@ -50,6 +50,9 @@
 
   // Convert from UIImage -> CGImage -> SkImage
   CGImageRef cgImage = image.CGImage;
+  if (!cgImage) {
+    return nullptr;
+  }
 
   // Get some info about the image
   auto width = CGImageGetWidth(cgImage);
@@ -59,6 +62,9 @@
   // Convert from UIImage -> SkImage, start by getting the pixels directly from
   // the CGImage:
   auto dataRef = CGDataProviderCopyData(CGImageGetDataProvider(cgImage));
+  if (!dataRef) {
+    return nullptr;
+  }
   auto length = CFDataGetLength(dataRef);
   void *data = CFDataGetMutableBytePtr((CFMutableDataRef)dataRef);
 


### PR DESCRIPTION
## Description
This PR fixes a crash in `ViewScreenshotService` occurring on iOS.

## The Issue
When `screenshotOfViewWithTag:` is called on a view that cannot be rendered (e.g. it has a frame of {0,0}, is not currently visible, or the app is in the background), the `UIGraphicsImageRenderer` may return a valid `UIImage` object but with a `NULL CGImage` or empty data.

Attempting to call `CGDataProviderCopyData` on a null provider, or subsequently `CFDataGetLength` on a null `dataRef`, results in a hard crash (typically `EXC_BAD_ACCESS` or `CF_IS_OBJC` inside CoreFoundation).

## The Fix
Added explicit null checks for:
1. `image.CGImage`
2. The `dataRef` returned by `CGDataProviderCopyData`

If either is `null`, the method now safely returns `nullptr`, allowing the JS side to handle the failure gracefully, instead of crashing the native runtime.