### PR TITLE
chore(🔥): remove bogus console.log

### DIFF
--- a/packages/skia/src/skia/web/JsiSkCanvas.ts
+++ b/packages/skia/src/skia/web/JsiSkCanvas.ts
@@ -312,8 +312,7 @@ export class JsiSkCanvas
     );
   }
 
-  drawSvg(svg: SkSVG, width?: number, height?: number) {
-    const ctm = this.ref.getLocalToDevice();
+  drawSvg(svg: SkSVG, _width?: number, _height?: number) {
     const image = this.CanvasKit.MakeImageFromCanvasImageSource(
       (svg as JsiSkSVG).ref
     );


### PR DESCRIPTION
Remove console log statement for ctm, width, and height.