### PR TITLE
chore(🐙): install compatible worklets version in expo workflow

### DIFF
--- a/.github/workflows/test-skia-package.yml
+++ b/.github/workflows/test-skia-package.yml
@@ -113,8 +113,8 @@ jobs:
       - name: Install compatible Worklets version
         working-directory: /Users/runner/skia-test-app/my-app
         run: |
-          echo "Installing compatible react-native-worklets-core..."
-          yarn add react-native-worklets-core@^0.7.0
+          echo "Installing compatible react-native-worklets..."
+          yarn add react-native-worklets@^0.7.0
 
       - name: Show installed Skia version
         working-directory: /Users/runner/skia-test-app/my-app


### PR DESCRIPTION
Add step to install compatible react-native-worklets-core version.