### PR TITLE
chore(🐙): remove npm update step from GitHub action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,10 +25,6 @@ runs:
         cache-dependency-path: yarn.lock
         registry-url: 'https://registry.npmjs.org'
 
-    - name: Update npm to latest
-      run: npm install -g npm@latest
-      shell: bash
-
     - name: Install dependencies
       run: yarn install --immutable
       shell: bash


### PR DESCRIPTION
Removed step to update npm to the latest version.