### PR TITLE
fix(🍏): enable C++ exceptions and RTTI in podspec

### DIFF
--- a/packages/skia/react-native-skia.podspec
+++ b/packages/skia/react-native-skia.podspec
@@ -66,7 +66,9 @@ Pod::Spec.new do |s|
     'GCC_PREPROCESSOR_DEFINITIONS' => preprocessor_defs,
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
     'DEFINES_MODULE' => 'YES',
-    "HEADER_SEARCH_PATHS" => '"$(PODS_TARGET_SRCROOT)/cpp/"/**'
+    "HEADER_SEARCH_PATHS" => '"$(PODS_TARGET_SRCROOT)/cpp/"/**',
+    'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES',
+    'GCC_ENABLE_CPP_RTTI' => 'YES'
   }
 
   s.frameworks = ['MetalKit', 'AVFoundation', 'AVKit', 'CoreMedia']


### PR DESCRIPTION
fixes #3635

- Adds `GCC_ENABLE_CPP_EXCEPTIONS` and `GCC_ENABLE_CPP_RTTI` to the podspec's `pod_target_xcconfig`

On Android, `CMakeLists.txt` explicitly adds `-fexceptions -frtti` to `CMAKE_CXX_FLAGS` (line 302-303), but the iOS podspec was missing equivalent settings.

The Skia prebuilt binaries are already compiled with these flags on iOS and Android