### PR TITLE
Remove redundant log line

### DIFF
--- a/packages/skia/android/cpp/rnskia-android/RNSkOpenGLCanvasProvider.cpp
+++ b/packages/skia/android/cpp/rnskia-android/RNSkOpenGLCanvasProvider.cpp
@@ -5,8 +5,6 @@
 #include <jni.h>
 #include <memory>
 
-#include "RNSkLog.h"
-
 #if defined(SK_GRAPHITE)
 #include "RNDawnContext.h"
 #else
@@ -56,9 +54,6 @@ bool RNSkOpenGLCanvasProvider::renderToCanvas(
 
       // Check for exceptions
       if (env->ExceptionCheck()) {
-        RNSkLogger::logToConsole(
-            "updateAndRelease() failed. The exception above "
-            "can safely be ignored");
         env->ExceptionClear();
       }
     }


### PR DESCRIPTION
I'm getting a lot of these redundant logs which are spamming logcat and make it harder to find exceptions that shouldn't be ignored.