### PR TITLE
fix(🍏): Pass Display P3 color space to Skia surfaces on wide-gamut devices

### DIFF
--- a/packages/skia/apple/MetalContext.h
+++ b/packages/skia/apple/MetalContext.h
@@ -3,6 +3,7 @@
 #include "MetalWindowContext.h"
 #include "SkiaCVPixelBufferUtils.h"
 
+#include "include/core/SkColorSpace.h"
 #include "include/core/SkSurface.h"
 
 #import <include/gpu/ganesh/GrBackendSurface.h>
@@ -58,7 +59,7 @@ public:
     // Create a SkSurface from the GrBackendTexture
     auto surface = SkSurfaces::WrapBackendTexture(
         _directContext.get(), backendTexture, kTopLeft_GrSurfaceOrigin, 0,
-        kBGRA_8888_SkColorType, nullptr, nullptr,
+        kBGRA_8888_SkColorType, _wideColorSpace, nullptr,
         [](void *addr) { delete (OffscreenRenderContext *)addr; }, ctx);
 
     return surface;
@@ -103,6 +104,7 @@ private:
   id<MTLDevice> _device = nullptr;
   id<MTLCommandQueue> _commandQueue = nullptr;
   sk_sp<GrDirectContext> _directContext = nullptr;
+  sk_sp<SkColorSpace> _wideColorSpace = nullptr;
 
   MetalContext();
 };

--- a/packages/skia/apple/MetalContext.mm
+++ b/packages/skia/apple/MetalContext.mm
@@ -35,4 +35,23 @@ MetalContext::MetalContext() {
   if (_directContext == nullptr) {
     RNSkia::RNSkLogger::logToConsole("Couldn't create a Skia Metal Context");
   }
+
+#if !TARGET_OS_OSX
+  if (@available(iOS 10.0, *)) {
+    if ([UIScreen mainScreen].traitCollection.displayGamut == UIDisplayGamutP3) {
+      _wideColorSpace = SkColorSpace::MakeRGB(SkNamedTransferFn::kSRGB,
+                                               SkNamedGamut::kDisplayP3);
+    }
+  }
+#else
+  if (@available(macOS 10.12, *)) {
+    NSScreen *screen = [NSScreen mainScreen];
+    NSColorSpace *displayP3 = [NSColorSpace displayP3ColorSpace];
+    if (screen.colorSpace && displayP3 &&
+        [screen.colorSpace isEqual:displayP3]) {
+      _wideColorSpace = SkColorSpace::MakeRGB(SkNamedTransferFn::kSRGB,
+                                               SkNamedGamut::kDisplayP3);
+    }
+  }
+#endif
 }

--- a/packages/skia/apple/MetalWindowContext.h
+++ b/packages/skia/apple/MetalWindowContext.h
@@ -3,6 +3,7 @@
 #import <MetalKit/MetalKit.h>
 
 #include "RNWindowContext.h"
+#include "include/core/SkColorSpace.h"
 
 class SkiaMetalContext;
 
@@ -31,6 +32,7 @@ private:
   GrDirectContext *_directContext;
   id<MTLCommandQueue> _commandQueue;
   sk_sp<SkSurface> _skSurface = nullptr;
+  sk_sp<SkColorSpace> _colorSpace = nullptr;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
   CAMetalLayer *_layer;

--- a/packages/skia/apple/MetalWindowContext.mm
+++ b/packages/skia/apple/MetalWindowContext.mm
@@ -3,6 +3,8 @@
 #include "MetalContext.h"
 #include "RNSkLog.h"
 
+#include "include/core/SkColorSpace.h"
+
 MetalWindowContext::MetalWindowContext(GrDirectContext *directContext,
                                        id<MTLDevice> device,
                                        id<MTLCommandQueue> commandQueue,
@@ -46,6 +48,8 @@ MetalWindowContext::MetalWindowContext(GrDirectContext *directContext,
         CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3);
     _layer.colorspace = colorSpace;
     CGColorSpaceRelease(colorSpace);
+    _colorSpace = SkColorSpace::MakeRGB(SkNamedTransferFn::kSRGB,
+                                         SkNamedGamut::kDisplayP3);
   }
 }
 
@@ -71,7 +75,7 @@ sk_sp<SkSurface> MetalWindowContext::getSurface() {
 
   _skSurface = SkSurfaces::WrapBackendRenderTarget(
       _directContext, backendRT, kTopLeft_GrSurfaceOrigin,
-      kBGRA_8888_SkColorType, nullptr, nullptr);
+      kBGRA_8888_SkColorType, _colorSpace, nullptr);
 
   return _skSurface;
 }


### PR DESCRIPTION
### Summary

  - Fix desaturated/faded colors when rendering P3 content (e.g., view snapshots via `makeImageFromView`) through Skia Canvas on P3-capable Apple devices
  - The `CAMetalLayer` was already configured with Display P3 color space, but the `SkSurface` wrapping it passed `nullptr` (sRGB) to Skia — causing a color
  space mismatch that washed out colors

  What was wrong

  `MetalWindowContext.mm set _layer.colorspace = kCGColorSpaceDisplayP3` on the Metal layer, but then created the Skia surface with:

```objc
  SkSurfaces::WrapBackendRenderTarget(
      ..., kBGRA_8888_SkColorType, nullptr, nullptr);
  //                                ^^^^^^^ Skia treats this as sRGB
```

  So Skia rendered all colors assuming sRGB, but the Metal layer interpreted the framebuffer as P3 — resulting in washed-out colors for any P3 content.

###  Fix

  Pass `SkColorSpace::MakeRGB(kSRGB, kDisplayP3`) to both `WrapBackendRenderTarget` (canvas surface) and `WrapBackendTexture` (offscreen surfaces) when the
  device supports wide color gamut. Supports both iOS and macOS.

###  Files changed

  - `apple/MetalWindowContext.h` — add `sk_sp<SkColorSpace> _colorSpace` member
  - `apple/MetalWindowContext.mm` — create P3 SkColorSpace when device supports wide color, pass to `WrapBackendRenderTarget`
  - `apple/MetalContext.h` — add `sk_sp<SkColorSpace> _wideColorSpace` member
  - `apple/MetalContext.mm` — detect P3 support in constructor (iOS + macOS), pass to `WrapBackendTexture` in MakeOffscreen

###  Test plan

  - On a P3-capable iPhone/Mac, render view snapshots (via `makeImageFromView`) through a Skia Canvas
  - Compare colors before/after — previously desaturated P3 colors should now match the original views
  - Verify no visual regression on sRGB-only devices (color space remains nullptr/sRGB)