### PR TITLE
fix: implicit global bindings in worklets

### DIFF
--- a/packages/skia/src/sksg/Container.native.ts
+++ b/packages/skia/src/sksg/Container.native.ts
@@ -10,6 +10,9 @@ import { visit } from "./Recorder/Visitor";
 import "../skia/NativeSetup";
 import "../views/api";
 
+// create local reference for `strictGlobal` option in Worklets
+const SkiaViewApi = globalThis.SkiaViewApi;
+
 const nativeDrawOnscreen = (
   nativeId: number,
   recorder: JsiRecorder,

--- a/packages/skia/src/sksg/Container.web.ts
+++ b/packages/skia/src/sksg/Container.web.ts
@@ -12,6 +12,9 @@ import { Container, StaticContainer } from "./StaticContainer";
 import "../skia/NativeSetup";
 import "../views/api";
 
+// create local reference for `strictGlobal` option in Worklets
+const SkiaViewApi = globalThis.SkiaViewApi;
+
 const drawOnscreen = (Skia: Skia, nativeId: number, recording: Recording) => {
   "worklet";
   const rec = Skia.PictureRecorder();


### PR DESCRIPTION
Worklets Babel plugin now features and option [strictGlobal](https://docs.swmansion.com/react-native-worklets/docs/worklets-babel-plugin/plugin-options/#strictglobal-) which means that global identifiers are no longer copied into the worklets closure.

This PR fixes errors that are thrown when this option is enabled by creating a local reference to the global `SkiaViewApi` object.