### PR TITLE
ci(si-2496): Migrate to shop/setup-python-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      - run: pip install cpplint
+      - uses: shop/setup-python-action@main
+      # TODO: add cpplint as dev dependencies via uv
+      - run: uv venv && uv pip install cpplint
       - run: cpplint --linelength=230 --filter=-legal/copyright,-whitespace/indent,-whitespace/comments,-whitespace/ending_newline,-build/include_order,-runtime/references,-readability/todo,-whitespace/blank_line,-whitespace/todo,-runtime/int,-build/c++11,-whitespace/parens --exclude=package/cpp/skia --exclude=package/apple --exclude=package/android/build --exclude=package/node_modules --recursive package
 
       - name: Install clang-format


### PR DESCRIPTION
ci(si-2496): Migrate to shop/setup-python-action

Hey there, we are mitigating #si-2496-remediation 

We expect JavaScript and Python to migrate immediately based on [this recent annoucement](https://my.slack.com/archives/C0Q0DSZR8/p1775767510960779) in [#dev-up][dev-up]

This PR is a best-effort attempt to migrate for you!

* :green_heart: If this passes CI and we think it's a trivial change, we may merge this for you.
* :broken_heart: If this doesn't pass CI or we think it's a non-trivial change, feel free to take over ownership, add commits to it, and do what it takes to merge it.
* :hammer_and_pick: If you have already mitigated it, or are working on it separately, feel free to close this PR with a comment referencing the other PR.

If you need help, reach out in [#dev-up][dev-up]

[dev-up]: https://slack.com/archives/C0Q0DSZR8