### PR TITLE
Awaiting root unmount promises

### DIFF
--- a/packages/skia/src/headless/index.ts
+++ b/packages/skia/src/headless/index.ts
@@ -35,7 +35,7 @@ export const drawOffscreen = async (surface: SkSurface, element: ReactNode) => {
   await root.render(element);
   const canvas = surface.getCanvas();
   root.drawOnCanvas(canvas);
-  root.unmount();
+  await root.unmount();
   surface.flush();
   return surface.makeImageSnapshot();
 };

--- a/packages/skia/src/renderer/Offscreen.tsx
+++ b/packages/skia/src/renderer/Offscreen.tsx
@@ -21,7 +21,7 @@ export const drawAsPicture = async (element: ReactElement, bounds?: SkRect) => {
   root.drawOnCanvas(canvas);
   const picture = recorder.finishRecordingAsPicture();
   recorder.dispose();
-  root.unmount();
+  await root.unmount();
   return picture;
 };
 

--- a/packages/skia/src/renderer/__tests__/setup.tsx
+++ b/packages/skia/src/renderer/__tests__/setup.tsx
@@ -193,7 +193,7 @@ export const center = { x: width / 2, y: height / 2 };
 export const drawOnNode = async (element: ReactNode) => {
   const { surface: ckSurface, draw, root } = await mountCanvas(element);
   await draw();
-  root.unmount();
+  await root.unmount();
   return ckSurface;
 };
 


### PR DESCRIPTION
# Description

Awaits the promises returned by `root.unmount` to avoid potential race conditions leading to memory leak bugs. This fix may have detrimental impacts depending on how long `skiaReconciler.updateContainer` takes, but I believe that memory safety and reliability are more important.

## Context

This pull request attempts to fix memory leaks reported in #3769. We've been testing this fix (amongst others) in production for the past 12 hours. So far, we haven't seen any memory issues since deploying.

## Additional Notes

There's one `useEffect` in `Canvas.tsx` in which the `root.unmount` wasn't changed and is left unawaited. This is pretty standard for useEffects, but may be worth investigating to make sure there's no risk for memory leak race conditions there.