### PR TITLE
fix(🍏): include cpp/api, cpp/skia, cpp/jsi, cpp/rnskia, cpp/utils in HEADER_SEARCH_PATHS

### DIFF
--- a/packages/skia/react-native-skia.podspec
+++ b/packages/skia/react-native-skia.podspec
@@ -65,7 +65,7 @@ Pod::Spec.new do |s|
     'GCC_PREPROCESSOR_DEFINITIONS' => preprocessor_defs,
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
     'DEFINES_MODULE' => 'YES',
-    "HEADER_SEARCH_PATHS" => '"$(PODS_TARGET_SRCROOT)/cpp/"/** "$(PODS_TARGET_SRCROOT)/cpp" "$(PODS_TARGET_SRCROOT)/cpp/jsi2" "$(PODS_TARGET_SRCROOT)/cpp/rnwgpu" "$(PODS_TARGET_SRCROOT)/cpp/rnwgpu/api" "$(PODS_TARGET_SRCROOT)/cpp/rnwgpu/api/descriptors" "$(PODS_TARGET_SRCROOT)/cpp/rnwgpu/async" "$(PODS_TARGET_SRCROOT)/cpp/dawn/include"'
+    "HEADER_SEARCH_PATHS" => '"$(PODS_TARGET_SRCROOT)/cpp/"/** "$(PODS_TARGET_SRCROOT)/cpp" "$(PODS_TARGET_SRCROOT)/cpp/api" "$(PODS_TARGET_SRCROOT)/cpp/skia" "$(PODS_TARGET_SRCROOT)/cpp/jsi" "$(PODS_TARGET_SRCROOT)/cpp/jsi2" "$(PODS_TARGET_SRCROOT)/cpp/rnskia" "$(PODS_TARGET_SRCROOT)/cpp/utils" "$(PODS_TARGET_SRCROOT)/cpp/rnwgpu" "$(PODS_TARGET_SRCROOT)/cpp/rnwgpu/api" "$(PODS_TARGET_SRCROOT)/cpp/rnwgpu/api/descriptors" "$(PODS_TARGET_SRCROOT)/cpp/rnwgpu/async" "$(PODS_TARGET_SRCROOT)/cpp/dawn/include"'
   }
 
   s.frameworks = ['MetalKit', 'AVFoundation', 'AVKit', 'CoreMedia']


### PR DESCRIPTION
## Summary

Under `use_frameworks! :linkage => :static` (or Expo's `useFrameworks: 'static'`), the recursive `"$(PODS_TARGET_SRCROOT)/cpp/"/**` glob in the podspec does not propagate to sibling directories under `cpp/`, so compilation fails with errors like:

```
node_modules/@shopify/react-native-skia/cpp/api/third_party/base64.cpp:7:10
> 7 | #include "third_party/base64.h"
     |          ^ 'third_party/base64.h' file not found
```

The header exists at `cpp/api/third_party/base64.h`, but `cpp/api` is not on the explicit `HEADER_SEARCH_PATHS` list — and likewise for sibling sources that reference headers under `cpp/skia`, `cpp/jsi`, `cpp/rnskia`, and `cpp/utils`.

## Fix

Add the five missing directories explicitly alongside the existing `rnwgpu` / `dawn` entries:

```diff
-"HEADER_SEARCH_PATHS" => '"$(PODS_TARGET_SRCROOT)/cpp/"/** "$(PODS_TARGET_SRCROOT)/cpp" "$(PODS_TARGET_SRCROOT)/cpp/jsi2" ...'
+"HEADER_SEARCH_PATHS" => '"$(PODS_TARGET_SRCROOT)/cpp/"/** "$(PODS_TARGET_SRCROOT)/cpp" "$(PODS_TARGET_SRCROOT)/cpp/api" "$(PODS_TARGET_SRCROOT)/cpp/skia" "$(PODS_TARGET_SRCROOT)/cpp/jsi" "$(PODS_TARGET_SRCROOT)/cpp/jsi2" "$(PODS_TARGET_SRCROOT)/cpp/rnskia" "$(PODS_TARGET_SRCROOT)/cpp/utils" ...'
```

The relative ordering of the rnwgpu/dawn entries is preserved; only the five sibling roots are inserted.

## Verification

- Reproduced on Expo SDK 55 (RN 0.83.1, New Architecture) + `useFrameworks: 'static'` + Skia 2.6.2 via both local `pod install && xcodebuild` and EAS Build. Without the patch, source-built Skia fails as above. With the patch (applied via `patch-package` in the consuming app), the iOS app compiles and links cleanly.
- No change to source files outside the podspec; no behavioral or runtime change on dynamic-framework builds (the existing search-path entries remain in place, this PR only extends the list).
- Same root cause and proposed fix as described in #3839, which has reproductions from several users on the same stack.

## Affected versions

The same incomplete line exists on `main` and back through at least 2.4.18, so this PR targets `main` and benefits every consumer using static frameworks.

## Related

- Fixes #3839
- Same class of static-frameworks header-resolution issue as the earlier `SkData.h` report (#652)