### PR TITLE
fix(🗿): export dispose() on native MaskFilter host object

### DIFF
--- a/packages/skia/cpp/api/JsiSkMaskFilter.h
+++ b/packages/skia/cpp/api/JsiSkMaskFilter.h
@@ -30,6 +30,7 @@ public:
   std::string getObjectType() const override { return "JsiSkMaskFilter"; }
 
   EXPORT_JSI_API_TYPENAME(JsiSkMaskFilter, MaskFilter)
+  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkMaskFilter, dispose))
 };
 
 } // namespace RNSkia


### PR DESCRIPTION
## Summary

On the native backend (iOS/Android), calling `dispose()` on a `SkMaskFilter` throws `dispose is not a function` at runtime:

```ts
const maskFilter = Skia.MaskFilter.MakeBlur(BlurStyle.Normal, 8, true);
paint.setMaskFilter(maskFilter);
maskFilter.dispose(); // 💥 TypeError: maskFilter.dispose is not a function (native only)
```

This is surprising because:
- `SkMaskFilter` extends `Disposable` and declares `dispose(): void` in the TS types (`SkJSIInstance`).
- The web backend works fine — `BaseHostObject` implements `dispose()` in JS.
- Every other wrapped Skia object (`ColorFilter`, `ImageFilter`, `Shader`, `PathEffect`, `Image`, `Paint`, …) can be disposed.

## Root cause

`dispose` is a `JSI_HOST_FUNCTION` defined on the base `JsiSkWrappingHostObject`, but each host object must register it with JS by overriding `getExportedFunctionMap()` via the `JSI_EXPORT_FUNCTIONS(...)` macro. The base implementation returns an **empty** map.

`JsiSkMaskFilter` only declares `EXPORT_JSI_API_TYPENAME(...)` (which exports the `__typename__` getter) and never calls `JSI_EXPORT_FUNCTIONS`, so the native `MaskFilter` instance exposes no functions at all — `dispose` is `undefined`.

Compare with its siblings, e.g. `JsiSkColorFilter.h`:

```cpp
EXPORT_JSI_API_TYPENAME(JsiSkColorFilter, ColorFilter)
JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkColorFilter, dispose)) // <- present
```

`JsiSkMaskFilter.h` was missing that second line.

## Fix

Export `dispose` exactly like every other wrapped host object:

```cpp
EXPORT_JSI_API_TYPENAME(JsiSkMaskFilter, MaskFilter)
JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkMaskFilter, dispose))
```

One line, no behavior change for any other API. The web backend already supports `dispose()`, so this just brings the native backend in line with the types and the web implementation.

## Test plan

- `Skia.MaskFilter.MakeBlur(...).dispose()` no longer throws on iOS/Android.
- `typeof maskFilter.dispose === "function"` on the native backend.
