### PR TITLE
fix(apple): guard RCTCxxBridge with RCT_REMOVE_LEGACY_ARCH

### DIFF
--- a/packages/skia/apple/RNSkiaModule.mm
+++ b/packages/skia/apple/RNSkiaModule.mm
@@ -35,7 +35,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
     // Already initialized, ignore call.
     return @true;
   }
-#ifndef RCT_DISABLE_LEGACY_ARCH
+#ifndef RCT_REMOVE_LEGACY_ARCH
   if (!jsInvoker) {
     RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
     jsInvoker = cxxBridge.jsCallInvoker;

--- a/packages/skia/apple/SkiaManager.mm
+++ b/packages/skia/apple/SkiaManager.mm
@@ -9,7 +9,7 @@
 
 // Forward-declared runtime accessor that is satisfied by RCTCxxBridge
 // (legacy/transitional) and RCTBridgeProxy (bridgeless). Avoids referencing
-// RCTCxxBridge directly, which is compiled out when RCT_DISABLE_LEGACY_ARCH
+// RCTCxxBridge directly, which is compiled out when RCT_REMOVE_LEGACY_ARCH
 // is set (React Native 0.82+).
 @interface RCTBridge (RNSkiaRuntime)
 - (void *)runtime;


### PR DESCRIPTION
## Summary

The legacy `RCTCxxBridge` branch in `RNSkiaModule.mm` is guarded by `RCT_DISABLE_LEGACY_ARCH` — a macro that **does not exist** in React Native. React Native compiles out `RCTCxxBridge` (from `RCTBridge+Private.h`) behind **`RCT_REMOVE_LEGACY_ARCH`** instead (facebook/react-native#56837).

Because the macro name never matches, the `#ifndef` guard is always true and the `RCTCxxBridge` branch is compiled in unconditionally. On React Native `main` — where `RCT_REMOVE_LEGACY_ARCH` is defined and `RCTCxxBridge` is fully removed — the iOS build fails:

```
RNSkiaModule.mm:40:5: error: unknown type name 'RCTCxxBridge'; did you mean 'RCTBridge'?
    RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
```

This is what the [React Native community nightly tests](https://react-native-community.github.io/nightly-tests/) are currently flagging for `@shopify/react-native-skia` on iOS.

## Fix

- `RNSkiaModule.mm`: change the guard from `RCT_DISABLE_LEGACY_ARCH` → `RCT_REMOVE_LEGACY_ARCH`. When the legacy arch is removed, the branch is dropped and the new-arch `getTurboModule` path already supplies `jsInvoker`.
- `SkiaManager.mm`: fix the stale macro name in the explanatory comment (no code change there — it already avoids `RCTCxxBridge` via a forward-declared `runtime` accessor).

## Test plan

- Builds against current React Native `main`/nightly (where `RCT_REMOVE_LEGACY_ARCH` is set and `RCTCxxBridge` is absent).
- Still builds on legacy/new-arch RN where `RCTCxxBridge` is available (macro undefined → branch retained, same as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)