### PR TITLE
feat(api): add optional sync flag to Surface.flush() for zero-copy GPU interop

### DIFF
--- a/packages/skia/cpp/api/JsiSkSurface.h
+++ b/packages/skia/cpp/api/JsiSkSurface.h
@@ -84,16 +84,22 @@ public:
 
   JSI_HOST_FUNCTION(flush) {
     auto surface = getObject();
+    // When `sync` is true, block until the GPU has finished executing the
+    // submitted work. Required before a native consumer on a different command
+    // queue reads this surface's texture via getNativeTextureUnstable(). #3916
+    bool sync = count > 0 && arguments[0].isBool() && arguments[0].getBool();
 #if defined(SK_GRAPHITE)
     // A raster surface (e.g. Skia.Surface.Make) has no Graphite recorder;
     // only Graphite-backed surfaces need to snap and submit a recording.
     if (auto *recorder = surface->recorder()) {
       auto recording = recorder->snap();
-      DawnContext::getInstance().submitRecording(recording.get());
+      DawnContext::getInstance().submitRecording(
+          recording.get(), sync ? skgpu::graphite::SyncToCpu::kYes
+                                : skgpu::graphite::SyncToCpu::kNo);
     }
 #else
     if (auto dContext = GrAsDirectContext(surface->recordingContext())) {
-      dContext->flushAndSubmit();
+      dContext->flushAndSubmit(sync ? GrSyncCpu::kYes : GrSyncCpu::kNo);
     }
 #endif
     return jsi::Value::undefined();

--- a/packages/skia/src/renderer/__tests__/e2e/Surfaces.spec.tsx
+++ b/packages/skia/src/renderer/__tests__/e2e/Surfaces.spec.tsx
@@ -14,4 +14,18 @@ describe("Surfaces", () => {
     });
     expect(result).toEqual([1920, 1080, 1920, 1080]);
   });
+
+  it("flush(true) submits and CPU-syncs without breaking rendering", async () => {
+    const result = await surface.eval((Skia) => {
+      using sf = Skia.Surface.MakeOffscreen(64, 64)!;
+      const canvas = sf.getCanvas();
+      const paint = Skia.Paint();
+      paint.setColor(Skia.Color("red"));
+      canvas.drawRect(Skia.XYWHRect(0, 0, 64, 64), paint);
+      sf.flush(true); // submit + wait for the GPU
+      using img = sf.makeImageSnapshot();
+      return [img.width(), img.height()];
+    });
+    expect(result).toEqual([64, 64]);
+  });
 });

--- a/packages/skia/src/skia/types/Surface/Surface.ts
+++ b/packages/skia/src/skia/types/Surface/Surface.ts
@@ -39,8 +39,12 @@ export interface SkSurface extends SkJSIInstance<"Surface"> {
 
   /**
    * Make sure any queued draws are sent to the screen or the GPU.
+   * @param sync - When true, block until the GPU has finished executing the
+   * submitted work. Use this before reading the surface's texture from a native
+   * consumer on a different command queue (see {@link getNativeTextureUnstable}).
+   * Defaults to false.
    */
-  flush(): void;
+  flush(sync?: boolean): void;
 
   /**
    * Returns the possibly scaled width of the surface.

--- a/packages/skia/src/skia/web/JsiSkSurface.ts
+++ b/packages/skia/src/skia/web/JsiSkSurface.ts
@@ -19,7 +19,8 @@ export class JsiSkSurface
     this.ref.dispose();
   }
 
-  flush() {
+  flush(_sync?: boolean) {
+    // CanvasKit has no separate CPU sync; flush() is sufficient on the web backend.
     this.ref.flush();
   }
 


### PR DESCRIPTION
## What

Adds an optional `sync` argument to `Surface.flush()`:

```ts
surface.flush();      // unchanged: submit, return immediately (GrSyncCpu::kNo)
surface.flush(true);  // submit AND block until the GPU has finished
```

- Ganesh: `flushAndSubmit(sync ? GrSyncCpu::kYes : GrSyncCpu::kNo)`
- Graphite/Dawn: `submitRecording(recording, sync ? SyncToCpu::kYes : SyncToCpu::kNo)`

Fully backward-compatible — `flush()` with no argument behaves exactly as before.

## Why

`getNativeTextureUnstable()` (added for zero-copy / video-export interop, #3379) returns a surface's GPU texture so a native consumer (e.g. a video encoder) can blit it directly — avoiding the per-frame `makeImageSnapshot → makeNonTextureImage → NativeBuffer.MakeFromImage` readback, which allocates a full-frame buffer per frame and is jetsammed on real iOS devices (~8.7 MB/frame → OOM; see #3916 for measurements).

But that native consumer typically runs on a **different command queue**, and the GPU backends don't order work across queues automatically. Today there's no way from JS to guarantee the surface's render is GPU-complete before the texture is read:

- `flush()` → `flushAndSubmit(GrSyncCpu::kNo)` — submits, doesn't wait.
- `getNativeTextureUnstable()` → `GetBackendTexture(..., kFlushRead)` — flushes, doesn't submit-and-wait.

So zero-copy reads race → intermittent torn/black frames. `flush(true)` closes that gap and makes the existing `getNativeTextureUnstable()` safe to consume:

```ts
// render into the surface ...
surface.flush(true);
const { mtlTexture } = surface.getNativeTextureUnstable() as { mtlTexture: bigint };
// hand mtlTexture to a native encoder that GPU-blits it — no readback
```

In a downstream video-export pipeline this took a 765-frame export from OOM-crashing at ~frame 180 (≈2 GB) to completing at ~470 MB peak, ~33× lower per-frame growth, and ~3.3× faster render (no CPU readback). Full numbers in #3916.

## Changes

- `cpp/api/JsiSkSurface.h` — `flush()` reads an optional bool; Ganesh + Graphite paths sync accordingly.
- `src/skia/types/Surface/Surface.ts` — `flush(sync?: boolean)` with docs.
- `src/skia/web/JsiSkSurface.ts` — web shim (CanvasKit needs no separate CPU sync).
- `src/renderer/__tests__/e2e/Surfaces.spec.tsx` — e2e test for `flush(true)`.

## Testing

- Added an e2e test (`flush(true)` submits + syncs without breaking rendering).
- Validated downstream on a physical iOS device in a real zero-copy export pipeline (`getNativeTextureUnstable()` + native Metal blit): correct frames, bounded memory.
- Note: I could not run the full native/e2e suite locally (requires a Skia build); CI will exercise it.

## Open questions for maintainers

- API shape: `flush(sync?)` (this PR) vs. a separate `flushAndSync()` — happy to change.
- Graphite path uses `SyncToCpu::kYes` (existing precedent in `RNDawnContext`); please confirm that's the intended sync primitive there.

Closes #3916
