### PR TITLE
fix(🌎): implement Font.measureText on Web

### DIFF
--- a/packages/skia/src/skia/__tests__/Font.spec.ts
+++ b/packages/skia/src/skia/__tests__/Font.spec.ts
@@ -1,0 +1,63 @@
+import { loadFont } from "../../renderer/__tests__/setup";
+
+import { setupSkia } from "./setup";
+
+describe("Font API", () => {
+  it("measureText doesn't throw on web", () => {
+    setupSkia();
+    const font = loadFont("skia/__tests__/assets/Roboto-Medium.ttf", 32);
+    expect(() => font.measureText("Hello World")).not.toThrow();
+    const rect = font.measureText("Hello World");
+    expect(rect.width).toBeGreaterThan(0);
+    expect(rect.height).toBeGreaterThan(0);
+    // The ink bounds start above the baseline.
+    expect(rect.y).toBeLessThan(0);
+  });
+
+  it("measureText width grows with the text length", () => {
+    setupSkia();
+    const font = loadFont("skia/__tests__/assets/Roboto-Medium.ttf", 32);
+    const one = font.measureText("A").width;
+    const two = font.measureText("AA").width;
+    const three = font.measureText("AAA").width;
+    expect(two).toBeGreaterThan(one);
+    expect(three).toBeGreaterThan(two);
+    // "AAA" spans two full advances plus the ink width of the last "A",
+    // so it is roughly three times the width of a single "A".
+    expect(three).toBeGreaterThan(2 * one);
+    expect(three).toBeLessThan(4 * one);
+  });
+
+  it("measureText is consistent with the sum of the glyph advances", () => {
+    setupSkia();
+    const fontSize = 32;
+    const font = loadFont("skia/__tests__/assets/Roboto-Medium.ttf", fontSize);
+    const text = "Hello World";
+    const advances = font
+      .getGlyphWidths(font.getGlyphIDs(text))
+      .reduce((a, b) => a + b, 0);
+    const rect = font.measureText(text);
+    // The ink bounds are contained within the advance width (modulo bearings)
+    // and shouldn't differ from it by more than a glyph's worth of bearing.
+    expect(rect.x + rect.width).toBeLessThanOrEqual(advances);
+    expect(rect.width).toBeGreaterThan(advances - fontSize);
+  });
+
+  it("measureText returns an empty rect for an empty string", () => {
+    setupSkia();
+    const font = loadFont("skia/__tests__/assets/Roboto-Medium.ttf", 32);
+    const rect = font.measureText("");
+    expect(rect.x).toBe(0);
+    expect(rect.y).toBe(0);
+    expect(rect.width).toBe(0);
+    expect(rect.height).toBe(0);
+  });
+
+  it("measureText returns an empty rect for whitespace only", () => {
+    setupSkia();
+    const font = loadFont("skia/__tests__/assets/Roboto-Medium.ttf", 32);
+    const rect = font.measureText("   ");
+    expect(rect.width).toBe(0);
+    expect(rect.height).toBe(0);
+  });
+});

--- a/packages/skia/src/skia/web/JsiSkFont.ts
+++ b/packages/skia/src/skia/web/JsiSkFont.ts
@@ -1,4 +1,4 @@
-import type { CanvasKit, Font } from "canvaskit-wasm";
+import type { CanvasKit, Font, Paint } from "canvaskit-wasm";
 
 import type {
   FontEdging,
@@ -10,7 +10,7 @@ import type {
   SkTypeface,
 } from "../types";
 
-import { HostObject, getEnum, throwNotImplementedOnRNWeb } from "./Host";
+import { HostObject, getEnum } from "./Host";
 import { JsiSkPaint } from "./JsiSkPaint";
 import { JsiSkPoint } from "./JsiSkPoint";
 import { JsiSkRect } from "./JsiSkRect";
@@ -21,8 +21,52 @@ export class JsiSkFont extends HostObject<Font, "Font"> implements SkFont {
     super(CanvasKit, ref, "Font");
   }
 
-  measureText(_text: string, _paint?: SkPaint | undefined) {
-    return throwNotImplementedOnRNWeb<SkRect>();
+  measureText(text: string, paint?: SkPaint | undefined): SkRect {
+    // CanvasKit doesn't expose SkFont::measureText directly, so we polyfill
+    // it: for each glyph we take its ink bounds (relative to its own origin),
+    // offset it by the accumulated advance, and union the results. This
+    // matches the bounds computed natively by SkFont::measureText.
+    const glyphs = this.ref.getGlyphIDs(text);
+    if (glyphs.length === 0) {
+      return new JsiSkRect(this.CanvasKit, this.CanvasKit.XYWHRect(0, 0, 0, 0));
+    }
+    const skPaint = paint ? JsiSkPaint.fromValue<Paint>(paint) : null;
+    // Flattened rectangles: 4 floats (left, top, right, bottom) per glyph.
+    const bounds = this.ref.getGlyphBounds(glyphs, skPaint);
+    const advances = this.ref.getGlyphWidths(glyphs, skPaint);
+    let left = 0;
+    let top = 0;
+    let right = 0;
+    let bottom = 0;
+    let isEmpty = true;
+    let xPos = 0;
+    for (let i = 0; i < glyphs.length; i++) {
+      const l = bounds[i * 4] + xPos;
+      const t = bounds[i * 4 + 1];
+      const r = bounds[i * 4 + 2] + xPos;
+      const b = bounds[i * 4 + 3];
+      xPos += advances[i];
+      // Skip empty glyph bounds (e.g. whitespace), like SkRect::join does.
+      if (l >= r || t >= b) {
+        continue;
+      }
+      if (isEmpty) {
+        left = l;
+        top = t;
+        right = r;
+        bottom = b;
+        isEmpty = false;
+      } else {
+        left = Math.min(left, l);
+        top = Math.min(top, t);
+        right = Math.max(right, r);
+        bottom = Math.max(bottom, b);
+      }
+    }
+    return new JsiSkRect(
+      this.CanvasKit,
+      this.CanvasKit.LTRBRect(left, top, right, bottom)
+    );
   }
 
   getTextWidth(text: string, paint?: SkPaint | undefined) {


### PR DESCRIPTION
CanvasKit doesn't expose SkFont::measureText, so measureText threw NotImplemented on React Native Web. Polyfill it with the same semantics as the native implementation: get the glyph IDs, offset each glyph's ink bounds (getGlyphBounds) by the accumulated advances (getGlyphWidths), and union the results into a single bounding rect.

Fixes #2639