### PR TITLE
fix(📝): unify matchFont and Paragraph font style types

### DIFF
--- a/apps/docs/docs/text/text.md
+++ b/apps/docs/docs/text/text.md
@@ -132,8 +132,26 @@ The `fontStyle` object can have the following list of optional attributes:
 
 - `fontFamily`: The name of the font family.
 - `fontSize`: The size of the font.
-- `fontStyle`: The slant of the font. Can be `normal`, `italic`, or `oblique`.
-- `fontWeight`: The weight of the font. Can be `normal`, `bold`, or any of `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900`.
+- `fontStyle`: The slant of the font. Can be `normal`, `italic`, or `oblique`, or a `FontSlant` enum value.
+- `fontWeight`: The weight of the font. Can be `normal`, `bold`, or any of `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900`, or a `FontWeight` enum value.
+
+The font style type is exported as `RNFontStyle` (with its `fontStyle` and `fontWeight` attributes typed as `RNFontSlant` and `RNFontWeight`), so you can type your own helpers.
+`fontWeight` and `fontStyle` also accept the `FontWeight` and `FontSlant` enums used by the [Paragraph API](/docs/text/paragraph/), meaning the same style values can be shared between `matchFont` and a Paragraph `TextStyle` without any conversion:
+
+```tsx twoslash
+import {matchFont, FontWeight, FontSlant} from "@shopify/react-native-skia";
+import type {RNFontStyle} from "@shopify/react-native-skia";
+
+const labelStyle: Partial<RNFontStyle> = {
+  fontFamily: "Roboto",
+  fontSize: 16,
+  // FontWeight.Medium (500) and FontSlant.Italic are the same values
+  // you would use in a Paragraph TextStyle
+  fontWeight: FontWeight.Medium,
+  fontStyle: FontSlant.Italic,
+};
+const font = matchFont(labelStyle);
+```
 
 By default, `matchFont` uses the system font manager to match the font style. However, if you want to use your custom font manager, you can pass it as the second parameter to the `matchFont` function:
 

--- a/packages/skia/src/skia/__tests__/MatchFont.spec.ts
+++ b/packages/skia/src/skia/__tests__/MatchFont.spec.ts
@@ -1,0 +1,154 @@
+import fs from "fs";
+import path from "path";
+
+// Type-level check: the font style types used by matchFont are exported
+// from the package root (https://github.com/Shopify/react-native-skia/issues/3491)
+import type { RNFontStyle, RNFontSlant, RNFontWeight } from "../../index";
+// Type-only import: core/Font captures the global Skia object at module
+// evaluation time, so the module itself is imported lazily in beforeAll.
+import type { matchFont as matchFontType } from "../core/Font";
+import { LoadSkiaWeb } from "../../web/LoadSkiaWeb";
+import { FontSlant, FontWeight } from "../types";
+import type { FontStyle, SkFontMgr, SkTypeface } from "../types";
+import { JsiSkApi } from "../web";
+
+jest.mock("react-native", () => ({
+  PixelRatio: {
+    get(): number {
+      return 1;
+    },
+  },
+  Platform: { OS: "web" },
+  Image: {
+    resolveAssetSource: jest.fn,
+  },
+}));
+
+let Skia: ReturnType<typeof JsiSkApi>;
+let matchFont: typeof matchFontType;
+let typeface: SkTypeface;
+
+const capturedStyles: FontStyle[] = [];
+const capturedFamilies: string[] = [];
+
+// matchFamilyStyle is not implemented by CanvasKit on web, so we use a
+// stub font manager that records the style resolved by matchFont and
+// returns a real typeface.
+const makeFontMgr = (): SkFontMgr =>
+  ({
+    countFamilies: () => 1,
+    getFamilyName: () => "Roboto",
+    matchFamilyStyle: (name: string, style: FontStyle) => {
+      capturedFamilies.push(name);
+      capturedStyles.push(style);
+      return typeface;
+    },
+  }) as unknown as SkFontMgr;
+
+const lastStyle = () => capturedStyles[capturedStyles.length - 1];
+
+beforeAll(async () => {
+  await LoadSkiaWeb();
+  Skia = JsiSkApi(global.CanvasKit);
+  global.SkiaApi = Skia;
+  // core/Font captures the global Skia object at module evaluation time,
+  // so it needs to be imported once the global has been set.
+  ({ matchFont } = await import("../core/Font"));
+  const data = Skia.Data.fromBytes(
+    fs.readFileSync(path.resolve(__dirname, "./assets/Roboto-Medium.ttf"))
+  );
+  typeface = Skia.Typeface.MakeFreeTypeFaceFromData(data)!;
+  expect(typeface).toBeTruthy();
+});
+
+describe("matchFont", () => {
+  it("applies the documented default font style", () => {
+    const fontMgr = makeFontMgr();
+    const font = matchFont(undefined, fontMgr);
+    expect(font.getSize()).toBe(14);
+    expect(capturedFamilies[capturedFamilies.length - 1]).toBe("System");
+    expect(lastStyle()).toEqual({
+      weight: FontWeight.Normal,
+      width: 5,
+      slant: FontSlant.Upright,
+    });
+  });
+
+  it("accepts React Native string weights", () => {
+    const fontMgr = makeFontMgr();
+    const font = matchFont(
+      { fontFamily: "Roboto", fontSize: 16, fontWeight: "bold" },
+      fontMgr
+    );
+    expect(font.getSize()).toBe(16);
+    expect(capturedFamilies[capturedFamilies.length - 1]).toBe("Roboto");
+    expect(lastStyle().weight).toBe(FontWeight.Bold);
+  });
+
+  it("accepts FontWeight enum values used by the Paragraph API", () => {
+    const fontMgr = makeFontMgr();
+    matchFont({ fontWeight: FontWeight.Medium }, fontMgr);
+    expect(lastStyle().weight).toBe(500);
+    matchFont({ fontWeight: 300 }, fontMgr);
+    expect(lastStyle().weight).toBe(FontWeight.Light);
+  });
+
+  it("resolves string weights and FontWeight enum values identically", () => {
+    const fontMgr = makeFontMgr();
+    const pairs: [RNFontWeight, FontWeight][] = [
+      ["normal", FontWeight.Normal],
+      ["bold", FontWeight.Bold],
+      ["100", FontWeight.Thin],
+      ["200", FontWeight.ExtraLight],
+      ["300", FontWeight.Light],
+      ["400", FontWeight.Normal],
+      ["500", FontWeight.Medium],
+      ["600", FontWeight.SemiBold],
+      ["700", FontWeight.Bold],
+      ["800", FontWeight.ExtraBold],
+      ["900", FontWeight.Black],
+    ];
+    pairs.forEach(([str, enumValue]) => {
+      matchFont({ fontWeight: str }, fontMgr);
+      const fromString = lastStyle().weight;
+      matchFont({ fontWeight: enumValue }, fontMgr);
+      const fromEnum = lastStyle().weight;
+      expect(fromString).toBe(enumValue);
+      expect(fromEnum).toBe(enumValue);
+    });
+  });
+
+  it("accepts both string and FontSlant enum values for fontStyle", () => {
+    const fontMgr = makeFontMgr();
+    const pairs: [RNFontSlant, FontSlant][] = [
+      ["normal", FontSlant.Upright],
+      ["italic", FontSlant.Italic],
+      ["oblique", FontSlant.Oblique],
+      [FontSlant.Italic, FontSlant.Italic],
+      [FontSlant.Oblique, FontSlant.Oblique],
+      [FontSlant.Upright, FontSlant.Upright],
+    ];
+    pairs.forEach(([input, expected]) => {
+      matchFont({ fontStyle: input }, fontMgr);
+      expect(lastStyle().slant).toBe(expected);
+    });
+  });
+
+  it("accepts a style object shared with the Paragraph API", () => {
+    const fontMgr = makeFontMgr();
+    // The same values can be used both with matchFont and in a Paragraph
+    // TextStyle without any conversion.
+    const labelFont: Partial<RNFontStyle> = {
+      fontSize: 16,
+      fontWeight: FontWeight.Medium,
+      fontStyle: FontSlant.Italic,
+    };
+    const font = matchFont(labelFont, fontMgr);
+    expect(font.getSize()).toBe(16);
+    expect(lastStyle()).toEqual({
+      weight: FontWeight.Medium,
+      width: 5,
+      slant: FontSlant.Italic,
+    });
+  });
+});

--- a/packages/skia/src/skia/core/Font.ts
+++ b/packages/skia/src/skia/core/Font.ts
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { Skia } from "../Skia";
-import { FontSlant } from "../types";
+import { FontSlant, FontWeight } from "../types";
 import type { DataModule, DataSourceParam, SkFontMgr } from "../types";
 import { Platform } from "../../Platform";
 import type { SkTypefaceFontProvider } from "../types/Paragraph/TypefaceFontProvider";
@@ -29,8 +29,18 @@ export const useFont = (
   }, [size, typeface]);
 };
 
-type Slant = "normal" | "italic" | "oblique";
-type Weight =
+/**
+ * React Native style font slant, as found in the `fontStyle` property of
+ * `TextStyle`. The Skia {@link FontSlant} enum is accepted as well.
+ */
+export type RNFontSlant = "normal" | "italic" | "oblique" | FontSlant;
+
+/**
+ * React Native style font weight, as found in the `fontWeight` property of
+ * `TextStyle`. Numeric weights such as the {@link FontWeight} enum values
+ * used by the Paragraph API are accepted as well.
+ */
+export type RNFontWeight =
   | "normal"
   | "bold"
   | "100"
@@ -41,13 +51,20 @@ type Weight =
   | "600"
   | "700"
   | "800"
-  | "900";
+  | "900"
+  | FontWeight;
 
-interface RNFontStyle {
+/**
+ * Font style accepted by {@link matchFont}.
+ * `fontStyle` and `fontWeight` accept both the React Native string values
+ * and the Skia enums ({@link FontSlant} and {@link FontWeight}), so the same
+ * values can be shared with the Paragraph API.
+ */
+export interface RNFontStyle {
   fontFamily: string;
   fontSize: number;
-  fontStyle: Slant;
-  fontWeight: Weight;
+  fontStyle: RNFontSlant;
+  fontWeight: RNFontWeight;
 }
 
 const defaultFontStyle: RNFontStyle = {
@@ -57,8 +74,10 @@ const defaultFontStyle: RNFontStyle = {
   fontWeight: "normal",
 };
 
-const slant = (s: Slant) => {
-  if (s === "italic") {
+const slant = (s: RNFontSlant): FontSlant => {
+  if (typeof s === "number") {
+    return s;
+  } else if (s === "italic") {
     return FontSlant.Italic;
   } else if (s === "oblique") {
     return FontSlant.Oblique;
@@ -67,14 +86,16 @@ const slant = (s: Slant) => {
   }
 };
 
-const weight = (fontWeight: Weight) => {
+const weight = (fontWeight: RNFontWeight): FontWeight => {
   switch (fontWeight) {
     case "normal":
-      return 400;
+      return FontWeight.Normal;
     case "bold":
-      return 700;
+      return FontWeight.Bold;
     default:
-      return parseInt(fontWeight, 10);
+      return typeof fontWeight === "number"
+        ? fontWeight
+        : (parseInt(fontWeight, 10) as FontWeight);
   }
 };
 


### PR DESCRIPTION
matchFont now also accepts the FontWeight and FontSlant enums used by the Paragraph API for its fontWeight and fontStyle attributes, so the same style values can be shared between both APIs without manual conversion. The previously internal font style types are now exported as RNFontStyle, RNFontWeight, and RNFontSlant so users can type their own helpers.

Fixes #3491