### PR TITLE
fix(🐛): accept undefined paragraph style values, document line height via heightMultiplier

### DIFF
--- a/apps/docs/docs/text/paragraph.md
+++ b/apps/docs/docs/text/paragraph.md
@@ -380,8 +380,8 @@ These properties are used to style specific segments of text within a paragraph.
 | `fontStyle`           | Font style (weight, width, slant).                                                  |
 | `fontVariations`      | Font variations.                                                                    |
 | `foregroundColor`     | Foreground color (for effects like gradients).                                      |
-| `heightMultiplier`    | Multiplier for line height.                                                         |
-| `halfLeading`         | Controls half-leading value.                                                        |
+| `heightMultiplier`    | Line height as a multiple of the font size (see [Line Height](#line-height)).       |
+| `halfLeading`         | Distributes the extra line height evenly above and below the text.                  |
 | `letterSpacing`       | Space between characters.                                                           |
 | `locale`              | Locale for the text (affects things like sorting).                                  |
 | `shadows`             | List of text shadows.                                                               |
@@ -437,3 +437,66 @@ const MyParagraph = () => {
 #### Result
 
 <img src={require("/static/img/paragraph/font-style-node.png").default} width="256" height="256" />
+
+## Line Height
+
+Skia has no absolute `lineHeight` property like CSS or React Native.
+Instead, the text style has a `heightMultiplier` property: the line height is exactly `heightMultiplier * fontSize` pixels.
+This means you can emulate `lineHeight` with the following formula:
+
+```tsx
+heightMultiplier = lineHeight / fontSize
+```
+
+For instance, `fontSize: 24` with `heightMultiplier: 40 / 24` produces lines that are exactly 40 pixels tall.
+When `heightMultiplier` is not set, the line height comes from the font metrics (ascent + descent), which is usually larger than the font size and differs from font to font.
+
+Since `heightMultiplier` is a text style property, it can also be used to normalize line heights when mixing fonts or font sizes: give each style a `heightMultiplier` of `lineHeight / fontSize` and every line will have the same height, regardless of the natural metrics of each font.
+
+```tsx twoslash
+import { useMemo } from "react";
+import { Paragraph, Skia, useFonts, Canvas } from "@shopify/react-native-skia";
+
+const MyParagraph = () => {
+  const customFontMgr = useFonts({
+    Roboto: [require("path/to/Roboto-Regular.ttf")],
+    "Noto Sans SC": [require("path/to/NotoSansSC-Regular.otf")],
+  });
+
+  const paragraph = useMemo(() => {
+    if (!customFontMgr) {
+      return null;
+    }
+    // Every line will be exactly 40px tall, like lineHeight: 40 in CSS
+    const lineHeight = 40;
+    const paragraphBuilder = Skia.ParagraphBuilder.Make({}, customFontMgr);
+    paragraphBuilder
+      .pushStyle({
+        color: Skia.Color("black"),
+        fontFamilies: ["Roboto"],
+        fontSize: 24,
+        heightMultiplier: lineHeight / 24,
+      })
+      .addText("Hello\n")
+      .pop()
+      .pushStyle({
+        color: Skia.Color("black"),
+        fontFamilies: ["Noto Sans SC"],
+        fontSize: 16,
+        heightMultiplier: lineHeight / 16,
+      })
+      .addText("你好")
+      .pop();
+    return paragraphBuilder.build();
+  }, [customFontMgr]);
+
+  return (
+    <Canvas style={{ width: 256, height: 256 }}>
+      <Paragraph paragraph={paragraph} x={0} y={0} width={256} />
+    </Canvas>
+  );
+};
+```
+
+By default, the extra space added by `heightMultiplier` is distributed proportionally to the font's ascent and descent.
+Setting `halfLeading: true` splits the extra space evenly above and below the text instead (like CSS half-leading); the line height stays the same but the text sits higher within the line.

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -3208,88 +3208,88 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 11b010917f5f15150b2c015abddef1573d2bb05d
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: a41bbdd9af30bf2e5715796b313e44ec43eefff1
   RCTRequired: 7be34aabb0b77c3cefe644528df0fa0afad4e4d0
   RCTSwiftUI: a6c7271c39098bf00dbdad8f8ed997a59bbfbe44
-  RCTSwiftUIWrapper: ff9098ccf7727e58218f2f8ea110349863f43438
+  RCTSwiftUIWrapper: 5ec163e8fde163d3fba714a992b50a266e1ece37
   RCTTypeSafety: 27927d0ca04e419ed9467578b3e6297e37210b5c
   React: 4bc1f928568ad4bcfd147260f907b4ea5873a03b
   React-callinvoker: 87f8728235a0dc62e9dc19b3851c829d9347d015
-  React-Core: 76bed73b02821e5630e7f2cb2e82432ee964695d
-  React-CoreModules: 752dbfdaeb096658aa0adc4a03ba6214815a08df
-  React-cxxreact: b6798528aa601c6db66e6adc7e2da2b059c8be74
+  React-Core: 19e0183e28d7a6613ecacebd7525fe6650efa3b6
+  React-CoreModules: 73cc86f2a0ff84b93d6325073ad2e4874d21ad40
+  React-cxxreact: 4bf734645c77c9b86e2f3e933e0411cf2f14d1ba
   React-debug: 8978deb306f6f38c28b5091e52b0ac9f942b157e
-  React-defaultsnativemodule: 682b77ef4acfb298017be15f4f93c1d998deb174
-  React-domnativemodule: 4c4b44f7eb68dbc3a2218db088bef318a7302017
-  React-Fabric: b6f82a4d8498ce4475586f71ca8397a771fe292d
-  React-FabricComponents: c8695f4b11918a127c4560d66f7d3fdb01a17986
-  React-FabricImage: d64f48830f63830e8ffaaf69fa487116856fbbf1
-  React-featureflags: 2a46b229903e906d33dbaf9207ce57c59306c369
-  React-featureflagsnativemodule: cba6c0814051a0934f8bcee4a436ee2a6bcc9754
-  React-graphics: 3d0435051e1ab8904d065f8ffbe981a9fc202841
-  React-hermes: 32fc9c231c1aa5c2fcfe851b0d19ee9269f88f4c
-  React-idlecallbacksnativemodule: f8ee42581795c4844d97147596bcc2d824c0f188
-  React-ImageManager: e8f7377ef0585fd2df05559a17e01a03e187d5cf
-  React-intersectionobservernativemodule: b1bea12ca29accdd2eda60c87605a6030b894eb9
-  React-jserrorhandler: 1a86df895b4eaf4e771abe8cf34cbb26d821f771
-  React-jsi: adf8527fec197ad9d0480cc5b8945eb56de627f0
-  React-jsiexecutor: 315fa2f879b43e3a9ca08f5f4b733472f7e4e8a4
-  React-jsinspector: b4fd1933666bcb2549b566b40656c1e45e9d7632
-  React-jsinspectorcdp: 80141710f2668e5b8f00417298d9b76b4abf90fa
-  React-jsinspectornetwork: 1d3ea717dbbec316cd8c21a0af53928a7bf74901
-  React-jsinspectortracing: 4ce745374d4b2bfbd164cce9f8de8383d3d818a0
-  React-jsitooling: fc4ac4c3b1f3f9f7fedf0c777c6ff3f244f568bd
-  React-jsitracing: bff08a6faeef4a9bd286487da191f5e5329e21a9
-  React-logger: b8483fa08e0d62e430c76d864309d90576ca2f68
-  React-Mapbuffer: 7b72a669e94662359dad4f42b5af005eb24b4e83
-  React-microtasksnativemodule: cdc02da075f2857803ed63f24f5f72fc40e094c0
-  react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
-  react-native-skia: 82260e6ce556ff33eb29360905eb775383d01a8c
-  React-NativeModulesApple: a2c3d2cbec893956a5b3e4060322db2984fff75b
-  React-networking: 3f98bd96893a294376e7e03730947a08d474c380
+  React-defaultsnativemodule: 724eb9ec388d494f1e2057d83355ee8fe6f1d780
+  React-domnativemodule: 9068f41092f725acd09950233d2847364c731947
+  React-Fabric: 945cc8abf08d9d0966acef605bffce7b501c49d9
+  React-FabricComponents: 4c4ad6f0d16c964a68f945e029505e2eeec6654b
+  React-FabricImage: a8b628fd98db21b9f8588e06f14a9194dda11b40
+  React-featureflags: 0937601c1af1cc125851ec5bbf4654285d47a3e7
+  React-featureflagsnativemodule: ac1a3e0353e1a6e15411b17ed6c7122adb0468a4
+  React-graphics: cca521e06463608be46207a4aa160f8a7f725f8b
+  React-hermes: ec50b9fcea2c3bfdd42f8cec845eac3f35888572
+  React-idlecallbacksnativemodule: effcae5b7b4473211adb154aaa321d5d9e2fbcc9
+  React-ImageManager: b38459e538f1840fa5c3e7612a4bcb0029a3c366
+  React-intersectionobservernativemodule: 8d33366661971200cf2e151727f6fe007b62ae7b
+  React-jserrorhandler: f94c688a0dbe2e045b91b992722b92e97d56f77f
+  React-jsi: 3216c876cd4c571a57909e22d77c8fd9530aa067
+  React-jsiexecutor: 475563c0042841a85930a455d3199f6b1483a5fe
+  React-jsinspector: bc484fb32bf1b9fed80afe8793e614eba4f7b39e
+  React-jsinspectorcdp: 5a574d1d35016968a67e78e6b8a7917473ffbb77
+  React-jsinspectornetwork: dce3a5a1351b527ee8c28ad4a8bdd211507e1a45
+  React-jsinspectortracing: 65f6b166bd67e5adc31eba027e1570bacf7a3cc7
+  React-jsitooling: d5463f5489a31640b0fa0ec4e31566ca8aa86c13
+  React-jsitracing: 3c7fc18821aba64855acb8658aa857ca6a7fddf6
+  React-logger: 6ac901f5c7f7321d2be1a40b203bccc2e23411e3
+  React-Mapbuffer: 2e0e7cc5b7064eaed9c8b8afc3a87621cb7ef5cd
+  React-microtasksnativemodule: dd4d33b251b57e5027c572c6d0b45cbfbcfaa386
+  react-native-safe-area-context: 54d812805f3c4e08a4580ad086cbde1d8780c2e4
+  react-native-skia: b28747dc1cf8c344ad041f14a618eda7f429bfeb
+  React-NativeModulesApple: 7f2f2fed3f6c858889eb61d09941be965d52df58
+  React-networking: 43e5e6773ac2ca2a93261a1388fed269c9fce092
   React-oscompat: 80166b66da22e7af7fad94474e9997bd52d4c8c6
-  React-perflogger: d6797918d2b1031e91a9d8f5e7fdd2c8728fb390
-  React-performancecdpmetrics: 5570be61e2f97c4741c5d432c91570e8e5a39892
-  React-performancetimeline: 5763499ae1991fc18dcf416e340ce7bc829bb298
+  React-perflogger: 63c90e0d8c24df87ffa14dad01aeafc352847dd0
+  React-performancecdpmetrics: 5a9b81c08f75045635127d626440d9ada01e774b
+  React-performancetimeline: 31cebfff69ec9174b3fb54b0606fcb12ef91cbad
   React-RCTActionSheet: 3bd5f5db9f983cf38d51bb9a7a198e2ebea94821
-  React-RCTAnimation: 46a9978f27dc434dbeed16afa7b82619b690a9af
-  React-RCTAppDelegate: 62ecd60a2b2a8cae26ce6a066bfa59cfde97af01
-  React-RCTBlob: 8285c859513023ee3cc8c806d9b59d4da078c4ba
-  React-RCTFabric: 05ed09347e938de985052f791a6a0698816d5761
-  React-RCTFBReactNativeSpec: 83ba579fca9a51e774ac32578ef5dd3262edd7e2
-  React-RCTImage: a5364d0f098692cfbf5bef1e8a63e7712ecb14b7
-  React-RCTLinking: 34b63b0aa0e92d30f5d7aa2c255a8f95fa75ee8f
-  React-RCTNetwork: 1ef88b7a5310b8f915d3556b5b247def113191ed
-  React-RCTRuntime: ed29cf68a46782fec891e5afe1d8d758ca6ccd9b
-  React-RCTSettings: 2c45623d6c0f30851a123f621eb9d32298bcbb0c
-  React-RCTText: 0ee70f5dc18004b4d81b2c214267c6cbec058587
-  React-RCTVibration: 88557e21e7cc3fe76b5b174cba28ff45c6def997
+  React-RCTAnimation: 346865a809fa5132f6c594c8b376c6cf46b44e88
+  React-RCTAppDelegate: b2d1e0d3663c987f49f45094883b9e36fcbf0181
+  React-RCTBlob: 74759ebb7ff9077d19f60c301782c1f8c3eb2813
+  React-RCTFabric: 7b4b14dad21ca99333ebcbc0bf5c205647a315a8
+  React-RCTFBReactNativeSpec: 39151968adb68b8c59f29a8bd4223d4d7780a793
+  React-RCTImage: 60763f56e8a5e45d861d7c4777e428bb820ec52a
+  React-RCTLinking: 52aee78b0b3163167c7fcf58f80a42943c03a056
+  React-RCTNetwork: f5e1e8ae5eff6982efff6289b06ec0a76d0a6ac2
+  React-RCTRuntime: 0e99199322afd372e74b95ae5c58f4e074cc2855
+  React-RCTSettings: 298bb40d3412bf32e0b4f0797e48416b0b7278a1
+  React-RCTText: dfb74800e27d792d1188fa975a3b9807c3362e3e
+  React-RCTVibration: ffe5fd4f50a835e353a3b6869eb005dab11eea44
   React-rendererconsistency: d280314a3e7f0097152f89e815b4de821c2be8b9
-  React-renderercss: f8cbf83d95c2c2bbf893d37fe50c73f046584411
-  React-rendererdebug: 37216ddfcd38e49d1e92bf9052ea4bc9d7b932e5
-  React-RuntimeApple: 1c0e7cb8e1c2c5775585afcaaa666ec151629a8d
-  React-RuntimeCore: 925fe2ca24cf8e6ed87586dbb92827306b93b83f
-  React-runtimeexecutor: 962dae024f6df760d029512a7d99e3f73d570935
-  React-RuntimeHermes: 19a7c59ec1bc9908516f0bbc29b49425f6ec64ba
-  React-runtimescheduler: 62f21127cd97f4d8f164eee5150d3ce53dd36f66
-  React-timing: 8757bf6fb96227c264f2d1609f4ba5c68217b8ce
-  React-utils: 8ab26781c2f5c2f7fafb2022c8ab39d39f231b80
-  React-webperformancenativemodule: 7953b7fe519f76fa595111fe18ff3d5de131bfe9
-  ReactAppDependencyProvider: 0eb286cc274abb059ee601b862ebddac2e681d01
-  ReactCodegen: b8e56b780fffe6edd6405be0af4a1e3049a937f7
-  ReactCommon: ac934cb340aee91282ecd6f273a26d24d4c55cae
-  ReactNativeHost: eef98ec49b55d88ad4cabf5a4378a12b42b551ee
-  ReactTestApp-DevSupport: ea18f446cff64b6c9a3e28788600c82ecf51bde6
+  React-renderercss: 8a1a346f3665fd5ea7a7be7b3b9f95d4743e1180
+  React-rendererdebug: af74afdfb3d6c5382ebab35562efd8eb9e690473
+  React-RuntimeApple: 06e33d291e72fd0c73ac47046c3536d77d5aeedd
+  React-RuntimeCore: 99273d2af072062eb07f0b2d2d4a0f2de697ea14
+  React-runtimeexecutor: 2063c03c18810ee57939d138142e6493333360ef
+  React-RuntimeHermes: 2253a7f4c8d56b449230b330b0b15383ed4b3df4
+  React-runtimescheduler: ff37ac6720a943da91645c06274282ac46b71f23
+  React-timing: 831d7e081ba4c332ca5cccf389b88e363f13f2b4
+  React-utils: 25db6c17598c4fed22b5956d7551bb8bddf1f95b
+  React-webperformancenativemodule: 57e41e6193cfb815bde0b5534bef68673f1270eb
+  ReactAppDependencyProvider: bfb12ead469222b022a2024f32aba47ce50de512
+  ReactCodegen: 9ca1bd49eee1eccf6e427e406d2163f49e9c48c0
+  ReactCommon: 05ad684db7d88e194272ae26baddf6300e30b8b7
+  ReactNativeHost: e7e0a518b0120f0070b3e1f13c7006d3e0e8ee13
+  ReactTestApp-DevSupport: 6994b53b5b81139a8ce63e0776c726c95de079a1
   ReactTestApp-Resources: 1bd9ff10e4c24f2ad87101a32023721ae923bccf
-  RNGestureHandler: cd4be101cfa17ea6bbd438710caa02e286a84381
-  RNReanimated: c26dfcd831add485c2ed93de9d7bfb90b035eeaa
-  RNScreens: 714e10b6b554f7dc7ad9f78dcf36dc8e3fc73415
-  RNSVG: 11354d28dd6cb71a59570b68c91ba6772a2d781d
-  RNWorklets: b89b501d37972e6419d6f87effe41d6d76157648
+  RNGestureHandler: 77eecab5fd636666ca73a55bb61e2f1a685b7e84
+  RNReanimated: d1a7a4c20eefc371e062990ce1debeaff4f1b9be
+  RNScreens: b2a5c76af24a02a2fd71bfce42780fdd9c79cc6d
+  RNSVG: ea9cbf6dcdbebdfff5822b0ad9311bbc4510a0b7
+  RNWorklets: 5f6e5664c1819eac103ca75cc2f36191f55aa110
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 5456bb010373068fc92221140921b09d126b116e
+  Yoga: 5bd0956bf9cb16f75101e78b5e852c7577bc5a45
 
 PODFILE CHECKSUM: dca89d921c9f2a2d3d405a5fca0bfb60b30b5022
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/packages/skia/cpp/api/JsiSkParagraphStyle.h
+++ b/packages/skia/cpp/api/JsiSkParagraphStyle.h
@@ -42,6 +42,16 @@ public:
    textHeightBehavior?: SkTextHeightBehavior;
    textStyle?: SkTextStyle;
    */
+  // A property set to undefined or null is treated as absent, like on web.
+  static bool hasValue(jsi::Runtime &runtime, const jsi::Object &object,
+                       const char *name) {
+    if (!object.hasProperty(runtime, name)) {
+      return false;
+    }
+    auto propValue = object.getProperty(runtime, name);
+    return !propValue.isUndefined() && !propValue.isNull();
+  }
+
   static para::ParagraphStyle fromValue(jsi::Runtime &runtime,
                                         const jsi::Value &value) {
     para::ParagraphStyle retVal;
@@ -59,52 +69,52 @@ public:
 
     auto object = value.asObject(runtime);
 
-    if (object.hasProperty(runtime, "disableHinting")) {
+    if (hasValue(runtime, object, "disableHinting")) {
       auto propValue = object.getProperty(runtime, "disableHinting");
       if (asBool(runtime, propValue)) {
         retVal.turnHintingOff();
       }
     }
-    if (object.hasProperty(runtime, "ellipsis")) {
+    if (hasValue(runtime, object, "ellipsis")) {
       auto propValue = object.getProperty(runtime, "ellipsis");
       auto inStr = propValue.asString(runtime).utf8(runtime);
       std::u16string uStr;
       fromUTF8(inStr, uStr);
       retVal.setEllipsis(uStr);
     }
-    if (object.hasProperty(runtime, "heightMultiplier")) {
+    if (hasValue(runtime, object, "heightMultiplier")) {
       auto propValue = object.getProperty(runtime, "heightMultiplier");
       retVal.setHeight(propValue.asNumber());
     }
-    if (object.hasProperty(runtime, "maxLines")) {
+    if (hasValue(runtime, object, "maxLines")) {
       auto propValue = object.getProperty(runtime, "maxLines");
       if (propValue.asNumber() != 0) {
         retVal.setMaxLines(propValue.asNumber());
       }
     }
-    if (object.hasProperty(runtime, "replaceTabCharacters")) {
+    if (hasValue(runtime, object, "replaceTabCharacters")) {
       auto propValue = object.getProperty(runtime, "replaceTabCharacters");
       retVal.setReplaceTabCharacters(asBool(runtime, propValue));
     }
-    if (object.hasProperty(runtime, "textAlign")) {
+    if (hasValue(runtime, object, "textAlign")) {
       auto propValue = object.getProperty(runtime, "textAlign");
       retVal.setTextAlign(static_cast<para::TextAlign>(propValue.asNumber()));
     }
-    if (object.hasProperty(runtime, "textDirection")) {
+    if (hasValue(runtime, object, "textDirection")) {
       auto propValue = object.getProperty(runtime, "textDirection");
       retVal.setTextDirection(
           static_cast<para::TextDirection>(propValue.asNumber()));
     }
-    if (object.hasProperty(runtime, "textHeightBehavior")) {
+    if (hasValue(runtime, object, "textHeightBehavior")) {
       auto propValue = object.getProperty(runtime, "textHeightBehavior");
       retVal.setTextHeightBehavior(
           static_cast<para::TextHeightBehavior>(propValue.asNumber()));
     }
-    if (object.hasProperty(runtime, "strutStyle")) {
+    if (hasValue(runtime, object, "strutStyle")) {
       auto propValue = object.getProperty(runtime, "strutStyle");
       retVal.setStrutStyle(JsiSkStrutStyle::fromValue(runtime, propValue));
     }
-    if (object.hasProperty(runtime, "textStyle")) {
+    if (hasValue(runtime, object, "textStyle")) {
       auto propValue = object.getProperty(runtime, "textStyle");
       retVal.setTextStyle(JsiSkTextStyle::fromValue(runtime, propValue));
     }

--- a/packages/skia/cpp/api/JsiSkStrutStyle.h
+++ b/packages/skia/cpp/api/JsiSkStrutStyle.h
@@ -32,6 +32,16 @@ bool asBool(jsi::Runtime &runtime, const jsi::Value &value) {
  */
 class JsiSkStrutStyle {
 public:
+  // A property set to undefined or null is treated as absent, like on web.
+  static bool hasValue(jsi::Runtime &runtime, const jsi::Object &object,
+                       const char *name) {
+    if (!object.hasProperty(runtime, name)) {
+      return false;
+    }
+    auto propValue = object.getProperty(runtime, name);
+    return !propValue.isUndefined() && !propValue.isNull();
+  }
+
   static para::StrutStyle fromValue(jsi::Runtime &runtime,
                                     const jsi::Value &value) {
     // Read values from the argument - expected to be a TextStyle shaped object
@@ -52,11 +62,11 @@ public:
 
     para::StrutStyle retVal;
 
-    if (object.hasProperty(runtime, "strutEnabled")) {
+    if (hasValue(runtime, object, "strutEnabled")) {
       auto propValue = object.getProperty(runtime, "strutEnabled");
       retVal.setStrutEnabled(asBool(runtime, propValue));
     }
-    if (object.hasProperty(runtime, "fontFamilies")) {
+    if (hasValue(runtime, object, "fontFamilies")) {
       auto propValue = object.getProperty(runtime, "fontFamilies")
                            .asObject(runtime)
                            .asArray(runtime);
@@ -70,28 +80,28 @@ public:
       }
     }
 
-    if (object.hasProperty(runtime, "fontStyle")) {
+    if (hasValue(runtime, object, "fontStyle")) {
       auto propValue = object.getProperty(runtime, "fontStyle");
       retVal.setFontStyle(*JsiSkFontStyle::fromValue(runtime, propValue).get());
     }
-    if (object.hasProperty(runtime, "fontSize")) {
+    if (hasValue(runtime, object, "fontSize")) {
       auto propValue = object.getProperty(runtime, "fontSize");
       retVal.setFontSize(propValue.asNumber());
     }
-    if (object.hasProperty(runtime, "heightMultiplier")) {
+    if (hasValue(runtime, object, "heightMultiplier")) {
       auto propValue = object.getProperty(runtime, "heightMultiplier");
       retVal.setHeight(propValue.asNumber());
       retVal.setHeightOverride(true);
     }
-    if (object.hasProperty(runtime, "halfLeading")) {
+    if (hasValue(runtime, object, "halfLeading")) {
       auto propValue = object.getProperty(runtime, "halfLeading");
       retVal.setHalfLeading(asBool(runtime, propValue));
     }
-    if (object.hasProperty(runtime, "leading")) {
+    if (hasValue(runtime, object, "leading")) {
       auto propValue = object.getProperty(runtime, "leading");
       retVal.setLeading(propValue.asNumber());
     }
-    if (object.hasProperty(runtime, "forceStrutHeight")) {
+    if (hasValue(runtime, object, "forceStrutHeight")) {
       auto propValue = object.getProperty(runtime, "forceStrutHeight");
       retVal.setForceStrutHeight(asBool(runtime, propValue));
     }

--- a/packages/skia/cpp/api/JsiSkTextStyle.h
+++ b/packages/skia/cpp/api/JsiSkTextStyle.h
@@ -26,6 +26,16 @@ namespace para = skia::textlayout;
  */
 class JsiSkTextStyle {
 public:
+  // A property set to undefined or null is treated as absent, like on web.
+  static bool hasValue(jsi::Runtime &runtime, const jsi::Object &object,
+                       const char *name) {
+    if (!object.hasProperty(runtime, name)) {
+      return false;
+    }
+    auto propValue = object.getProperty(runtime, name);
+    return !propValue.isUndefined() && !propValue.isNull();
+  }
+
   static para::TextStyle fromValue(jsi::Runtime &runtime,
                                    const jsi::Value &value) {
 
@@ -43,35 +53,35 @@ public:
 
     auto object = value.asObject(runtime);
 
-    if (object.hasProperty(runtime, "backgroundColor")) {
+    if (hasValue(runtime, object, "backgroundColor")) {
       auto propValue = object.getProperty(runtime, "backgroundColor");
       SkPaint p;
       p.setColor(JsiSkColor::fromValue(runtime, propValue));
       retVal.setBackgroundPaint(p);
     }
-    if (object.hasProperty(runtime, "color")) {
+    if (hasValue(runtime, object, "color")) {
       auto propValue = object.getProperty(runtime, "color");
       retVal.setColor(JsiSkColor::fromValue(runtime, propValue));
     }
-    if (object.hasProperty(runtime, "decoration")) {
+    if (hasValue(runtime, object, "decoration")) {
       auto propValue = object.getProperty(runtime, "decoration");
       retVal.setDecoration(
           static_cast<para::TextDecoration>(propValue.asNumber()));
     }
-    if (object.hasProperty(runtime, "decorationColor")) {
+    if (hasValue(runtime, object, "decorationColor")) {
       auto propValue = object.getProperty(runtime, "decorationColor");
       retVal.setDecorationColor(JsiSkColor::fromValue(runtime, propValue));
     }
-    if (object.hasProperty(runtime, "decorationThickness")) {
+    if (hasValue(runtime, object, "decorationThickness")) {
       auto propValue = object.getProperty(runtime, "decorationThickness");
       retVal.setDecorationThicknessMultiplier(propValue.asNumber());
     }
-    if (object.hasProperty(runtime, "decorationStyle")) {
+    if (hasValue(runtime, object, "decorationStyle")) {
       auto propValue = object.getProperty(runtime, "decorationStyle");
       retVal.setDecorationStyle(
           static_cast<para::TextDecorationStyle>(propValue.asNumber()));
     }
-    if (object.hasProperty(runtime, "fontFamilies")) {
+    if (hasValue(runtime, object, "fontFamilies")) {
       auto propValue = object.getProperty(runtime, "fontFamilies")
                            .asObject(runtime)
                            .asArray(runtime);
@@ -85,7 +95,7 @@ public:
       }
       retVal.setFontFamilies(families);
     }
-    if (object.hasProperty(runtime, "fontFeatures")) {
+    if (hasValue(runtime, object, "fontFeatures")) {
       auto propValue = object.getProperty(runtime, "fontFeatures")
                            .asObject(runtime)
                            .asArray(runtime);
@@ -100,58 +110,58 @@ public:
         retVal.addFontFeature(SkString(name), value);
       }
     }
-    if (object.hasProperty(runtime, "fontSize")) {
+    if (hasValue(runtime, object, "fontSize")) {
       auto propValue = object.getProperty(runtime, "fontSize");
       retVal.setFontSize(propValue.asNumber());
     }
-    if (object.hasProperty(runtime, "fontStyle")) {
+    if (hasValue(runtime, object, "fontStyle")) {
       auto propValue =
           object.getProperty(runtime, "fontStyle").asObject(runtime);
       auto weight = static_cast<SkFontStyle::Weight>(
-          propValue.hasProperty(runtime, "weight")
+          hasValue(runtime, propValue, "weight")
               ? propValue.getProperty(runtime, "weight").asNumber()
               : static_cast<double>(SkFontStyle::Weight::kNormal_Weight));
 
       auto width = static_cast<SkFontStyle::Width>(
-          propValue.hasProperty(runtime, "width")
+          hasValue(runtime, propValue, "width")
               ? propValue.getProperty(runtime, "width").asNumber()
               : static_cast<double>(SkFontStyle::Width::kNormal_Width));
 
       auto slant = static_cast<SkFontStyle::Slant>(
-          propValue.hasProperty(runtime, "slant")
+          hasValue(runtime, propValue, "slant")
               ? propValue.getProperty(runtime, "slant").asNumber()
               : static_cast<double>(SkFontStyle::Slant::kUpright_Slant));
 
       retVal.setFontStyle(SkFontStyle(weight, width, slant));
     }
-    if (object.hasProperty(runtime, "foregroundColor")) {
+    if (hasValue(runtime, object, "foregroundColor")) {
       auto propValue = object.getProperty(runtime, "foregroundColor");
       SkPaint p;
       p.setColor(JsiSkColor::fromValue(runtime, propValue));
       retVal.setForegroundColor(p);
     }
-    if (object.hasProperty(runtime, "heightMultiplier")) {
+    if (hasValue(runtime, object, "heightMultiplier")) {
       auto propValue = object.getProperty(runtime, "heightMultiplier");
       retVal.setHeight(propValue.asNumber());
       retVal.setHeightOverride(true);
     }
-    if (object.hasProperty(runtime, "halfLeading")) {
+    if (hasValue(runtime, object, "halfLeading")) {
       auto propValue = object.getProperty(runtime, "halfLeading");
       retVal.setHalfLeading(propValue.getBool());
     }
-    if (object.hasProperty(runtime, "letterSpacing")) {
+    if (hasValue(runtime, object, "letterSpacing")) {
       auto propValue = object.getProperty(runtime, "letterSpacing");
       retVal.setLetterSpacing(propValue.asNumber());
     }
-    if (object.hasProperty(runtime, "wordSpacing")) {
+    if (hasValue(runtime, object, "wordSpacing")) {
       auto propValue = object.getProperty(runtime, "wordSpacing");
       retVal.setWordSpacing(propValue.asNumber());
     }
-    if (object.hasProperty(runtime, "locale")) {
+    if (hasValue(runtime, object, "locale")) {
       auto propValue = object.getProperty(runtime, "locale");
       retVal.setLocale(SkString(propValue.asString(runtime).utf8(runtime)));
     }
-    if (object.hasProperty(runtime, "shadows")) {
+    if (hasValue(runtime, object, "shadows")) {
       auto propValue = object.getProperty(runtime, "shadows")
                            .asObject(runtime)
                            .asArray(runtime);
@@ -159,24 +169,24 @@ public:
       retVal.resetShadows();
       for (size_t i = 0; i < size; ++i) {
         auto element = propValue.getValueAtIndex(runtime, i).asObject(runtime);
-        auto color = element.hasProperty(runtime, "color")
+        auto color = hasValue(runtime, element, "color")
                          ? JsiSkColor::fromValue(
                                runtime, element.getProperty(runtime, "color"))
                          : SK_ColorBLACK;
         SkPoint offset =
-            element.hasProperty(runtime, "offset")
+            hasValue(runtime, element, "offset")
                 ? *JsiSkPoint::fromValue(runtime,
                                          element.getProperty(runtime, "offset"))
                        .get()
                 : SkPoint::Make(0, 0);
         auto blurSigma =
-            element.hasProperty(runtime, "blurRadius")
+            hasValue(runtime, element, "blurRadius")
                 ? element.getProperty(runtime, "blurRadius").asNumber()
                 : 0;
         retVal.addShadow(para::TextShadow(color, offset, blurSigma));
       }
     }
-    if (object.hasProperty(runtime, "textBaseline")) {
+    if (hasValue(runtime, object, "textBaseline")) {
       auto propValue = object.getProperty(runtime, "textBaseline");
       retVal.setTextBaseline(
           static_cast<para::TextBaseline>(propValue.asNumber()));

--- a/packages/skia/src/renderer/__tests__/e2e/ParagraphLineHeight.spec.tsx
+++ b/packages/skia/src/renderer/__tests__/e2e/ParagraphLineHeight.spec.tsx
@@ -1,3 +1,4 @@
+import type { SkTextStyle } from "../../../skia/types";
 import { resolveFile, surface } from "../setup";
 
 const RobotoRegular = Array.from(
@@ -179,6 +180,49 @@ describe("Paragraph line height via heightMultiplier (#2561)", () => {
     // every line to the same 40 pixels.
     expect(result.normalized.lines).toEqual([40, 40]);
     expect(result.normalized.height).toBe(80);
+  });
+
+  it("treats undefined style values the same as absent keys (web parity)", async () => {
+    const result = await surface.eval(
+      (Skia, ctx) => {
+        const typeface = Skia.Typeface.MakeFreeTypeFaceFromData(
+          Skia.Data.fromBytes(new Uint8Array(ctx.RobotoRegular))
+        )!;
+        const provider = Skia.TypefaceFontProvider.Make();
+        provider.registerFont(typeface, "Roboto");
+        const measure = (style: SkTextStyle) => {
+          const builder = Skia.ParagraphBuilder.Make(
+            { heightMultiplier: undefined, strutStyle: undefined },
+            provider
+          );
+          builder.pushStyle(style);
+          builder.addText("Hello");
+          const paragraph = builder.build();
+          paragraph.layout(512);
+          return paragraph.getHeight();
+        };
+        return {
+          absent: measure({
+            color: Skia.Color("black"),
+            fontFamilies: ["Roboto"],
+            fontSize: 24,
+          }),
+          explicitUndefined: measure({
+            color: Skia.Color("black"),
+            fontFamilies: ["Roboto"],
+            fontSize: 24,
+            heightMultiplier: undefined,
+            halfLeading: undefined,
+            letterSpacing: undefined,
+          }),
+        };
+      },
+      { RobotoRegular }
+    );
+    // On web, CanvasKit treats a key set to undefined like a missing key; the
+    // JSI implementation must not throw and must produce the same layout.
+    expect(result.absent).toBe(28);
+    expect(result.explicitUndefined).toBe(28);
   });
 
   it("halfLeading changes where the extra space goes, not the line height", async () => {

--- a/packages/skia/src/renderer/__tests__/e2e/ParagraphLineHeight.spec.tsx
+++ b/packages/skia/src/renderer/__tests__/e2e/ParagraphLineHeight.spec.tsx
@@ -1,0 +1,236 @@
+import { resolveFile, surface } from "../setup";
+
+const RobotoRegular = Array.from(
+  resolveFile("skia/__tests__/assets/Roboto-Regular.ttf")
+);
+
+const NotoSansSC = Array.from(
+  resolveFile("skia/__tests__/assets/NotoSansSC-Regular.otf")
+);
+
+// Use case from https://github.com/Shopify/react-native-skia/issues/2561:
+// Skia has no absolute lineHeight property (like CSS or React Native), but
+// TextStyle has heightMultiplier: the line height becomes exactly
+// heightMultiplier × fontSize. Therefore lineHeight: X can be emulated with
+// heightMultiplier: X / fontSize. These tests establish that relationship
+// empirically.
+describe("Paragraph line height via heightMultiplier (#2561)", () => {
+  it("sets the line height to exactly heightMultiplier × fontSize", async () => {
+    const result = await surface.eval(
+      (Skia, ctx) => {
+        const typeface = Skia.Typeface.MakeFreeTypeFaceFromData(
+          Skia.Data.fromBytes(new Uint8Array(ctx.RobotoRegular))
+        )!;
+        const provider = Skia.TypefaceFontProvider.Make();
+        provider.registerFont(typeface, "Roboto");
+        const measure = (heightMultiplier?: number) => {
+          const builder = Skia.ParagraphBuilder.Make({}, provider);
+          builder.pushStyle({
+            color: Skia.Color("black"),
+            fontFamilies: ["Roboto"],
+            fontSize: 24,
+            heightMultiplier,
+          });
+          builder.addText("Hello");
+          const paragraph = builder.build();
+          paragraph.layout(512);
+          const metrics = paragraph.getLineMetrics()[0];
+          return {
+            height: paragraph.getHeight(),
+            lineHeight: metrics.height,
+            ascent: metrics.ascent,
+            descent: metrics.descent,
+          };
+        };
+        return {
+          unset: measure(),
+          multiplier1: measure(1),
+          multiplier2: measure(2),
+        };
+      },
+      { RobotoRegular }
+    );
+    // Without heightMultiplier, the line height comes from the font metrics:
+    // for Roboto at fontSize 24, ascent (22.266) + descent (5.859) = 28.125,
+    // i.e. ~1.17 × fontSize (rounded to 28) — not fontSize itself.
+    expect(result.unset.height).toBe(28);
+    expect(result.unset.ascent + result.unset.descent).toBeCloseTo(28.125, 3);
+    // heightMultiplier: 1 forces the line height to exactly 1 × fontSize,
+    // scaling ascent/descent proportionally (19 + 5 = 24).
+    expect(result.multiplier1.height).toBe(24);
+    expect(result.multiplier1.lineHeight).toBe(24);
+    // heightMultiplier: 2 gives exactly 2 × fontSize.
+    expect(result.multiplier2.height).toBe(48);
+    expect(result.multiplier2.lineHeight).toBe(48);
+    // The extra space is distributed proportionally to the font's
+    // ascent/descent ratio (38 + 10 = 48 keeps the 22.266/5.859 ratio).
+    expect(result.multiplier2.ascent).toBeCloseTo(38, 3);
+    expect(result.multiplier2.descent).toBeCloseTo(10, 3);
+  });
+
+  it("emulates CSS lineHeight with heightMultiplier = lineHeight / fontSize", async () => {
+    const result = await surface.eval(
+      (Skia, ctx) => {
+        const roboto = Skia.Typeface.MakeFreeTypeFaceFromData(
+          Skia.Data.fromBytes(new Uint8Array(ctx.RobotoRegular))
+        )!;
+        const noto = Skia.Typeface.MakeFreeTypeFaceFromData(
+          Skia.Data.fromBytes(new Uint8Array(ctx.NotoSansSC))
+        )!;
+        const provider = Skia.TypefaceFontProvider.Make();
+        provider.registerFont(roboto, "Roboto");
+        provider.registerFont(noto, "Noto Sans SC");
+        const lineHeight = 40;
+        const measure = (
+          text: string,
+          fontFamily: string,
+          fontSize: number,
+          normalize: boolean
+        ) => {
+          const builder = Skia.ParagraphBuilder.Make({}, provider);
+          builder.pushStyle({
+            color: Skia.Color("black"),
+            fontFamilies: [fontFamily],
+            fontSize,
+            heightMultiplier: normalize ? lineHeight / fontSize : undefined,
+          });
+          builder.addText(text);
+          const paragraph = builder.build();
+          paragraph.layout(512);
+          return {
+            height: paragraph.getHeight(),
+            lines: paragraph.getLineMetrics().map((m) => m.height),
+          };
+        };
+        return {
+          roboto: measure("Hello", "Roboto", 24, true),
+          notoNatural: measure("你好", "Noto Sans SC", 24, false),
+          noto: measure("你好", "Noto Sans SC", 24, true),
+          multiline: measure(
+            "Hello World\nHello World\nHello World",
+            "Roboto",
+            24,
+            true
+          ),
+        };
+      },
+      { RobotoRegular, NotoSansSC }
+    );
+    // lineHeight: 40 at fontSize 24 → heightMultiplier: 40 / 24 gives a line
+    // of exactly 40 pixels, regardless of the font's natural metrics.
+    expect(result.roboto.height).toBe(40);
+    // Noto Sans SC has much taller natural metrics (35 at fontSize 24)...
+    expect(result.notoNatural.height).toBe(35);
+    // ...but the same formula still lands exactly on 40.
+    expect(result.noto.height).toBe(40);
+    // Each line of a multiline paragraph is exactly lineHeight tall and the
+    // paragraph height is the sum of the lines.
+    expect(result.multiline.lines).toEqual([40, 40, 40]);
+    expect(result.multiline.height).toBe(120);
+  });
+
+  it("normalizes line heights across mixed fonts and font sizes", async () => {
+    const result = await surface.eval(
+      (Skia, ctx) => {
+        const roboto = Skia.Typeface.MakeFreeTypeFaceFromData(
+          Skia.Data.fromBytes(new Uint8Array(ctx.RobotoRegular))
+        )!;
+        const noto = Skia.Typeface.MakeFreeTypeFaceFromData(
+          Skia.Data.fromBytes(new Uint8Array(ctx.NotoSansSC))
+        )!;
+        const provider = Skia.TypefaceFontProvider.Make();
+        provider.registerFont(roboto, "Roboto");
+        provider.registerFont(noto, "Noto Sans SC");
+        const measure = (lineHeight?: number) => {
+          const builder = Skia.ParagraphBuilder.Make({}, provider);
+          builder.pushStyle({
+            color: Skia.Color("black"),
+            fontFamilies: ["Roboto"],
+            fontSize: 24,
+            heightMultiplier: lineHeight ? lineHeight / 24 : undefined,
+          });
+          builder.addText("Hello\n");
+          builder.pushStyle({
+            color: Skia.Color("black"),
+            fontFamilies: ["Noto Sans SC"],
+            fontSize: 16,
+            heightMultiplier: lineHeight ? lineHeight / 16 : undefined,
+          });
+          builder.addText("你好");
+          const paragraph = builder.build();
+          paragraph.layout(512);
+          return {
+            height: paragraph.getHeight(),
+            lines: paragraph.getLineMetrics().map((m) => m.height),
+          };
+        };
+        return {
+          natural: measure(),
+          normalized: measure(40),
+        };
+      },
+      { RobotoRegular, NotoSansSC }
+    );
+    // This is the exact problem reported in the issue thread: with mixed
+    // fonts/sizes each line gets a different height from its font metrics
+    // (Roboto at 24 → 28, Noto Sans SC at 16 → 23).
+    expect(result.natural.lines).toEqual([28, 23]);
+    // Setting heightMultiplier per style to lineHeight / fontSize normalizes
+    // every line to the same 40 pixels.
+    expect(result.normalized.lines).toEqual([40, 40]);
+    expect(result.normalized.height).toBe(80);
+  });
+
+  it("halfLeading changes where the extra space goes, not the line height", async () => {
+    const result = await surface.eval(
+      (Skia, ctx) => {
+        const typeface = Skia.Typeface.MakeFreeTypeFaceFromData(
+          Skia.Data.fromBytes(new Uint8Array(ctx.RobotoRegular))
+        )!;
+        const provider = Skia.TypefaceFontProvider.Make();
+        provider.registerFont(typeface, "Roboto");
+        const measure = (halfLeading: boolean) => {
+          const builder = Skia.ParagraphBuilder.Make({}, provider);
+          builder.pushStyle({
+            color: Skia.Color("black"),
+            fontFamilies: ["Roboto"],
+            fontSize: 24,
+            heightMultiplier: 2,
+            halfLeading,
+          });
+          builder.addText("Hello");
+          const paragraph = builder.build();
+          paragraph.layout(512);
+          const metrics = paragraph.getLineMetrics()[0];
+          return {
+            height: paragraph.getHeight(),
+            ascent: metrics.ascent,
+            descent: metrics.descent,
+            baseline: metrics.baseline,
+          };
+        };
+        return {
+          proportional: measure(false),
+          halfLeading: measure(true),
+        };
+      },
+      { RobotoRegular }
+    );
+    // The line height is 2 × 24 = 48 in both cases.
+    expect(result.proportional.height).toBe(48);
+    expect(result.halfLeading.height).toBe(48);
+    // Without halfLeading, ascent and descent are scaled proportionally to
+    // the font metrics: 38 + 10 = 48, pushing the baseline down to 38.
+    expect(result.proportional.ascent).toBeCloseTo(38, 3);
+    expect(result.proportional.descent).toBeCloseTo(10, 3);
+    // With halfLeading, the extra space (48 - 28.125 = 19.875) is split
+    // evenly above and below the natural metrics (like CSS half-leading):
+    // ascent = 22.266 + 9.9375 = 32.203, descent = 5.859 + 9.9375 = 15.797.
+    // The text sits higher within the same line box.
+    expect(result.halfLeading.ascent).toBeCloseTo(32.203125, 3);
+    expect(result.halfLeading.descent).toBeCloseTo(15.796875, 3);
+    expect(result.halfLeading.baseline).toBeLessThan(
+      result.proportional.baseline
+    );
+  });
+});


### PR DESCRIPTION
Skia has no absolute lineHeight property, but TextStyle.heightMultiplier sets the line height to exactly heightMultiplier × fontSize. Document the lineHeight / fontSize mapping (including normalizing line heights across mixed fonts and font sizes) and add e2e tests that establish the exact relationship, the CSS emulation formula, and the halfLeading behavior.

Fixes #2561