### PR TITLE
fix(🤖): fail gracefully if the OpenGL context can't be created

### DIFF
--- a/packages/skia/android/cpp/rnskia-android/OpenGLContext.h
+++ b/packages/skia/android/cpp/rnskia-android/OpenGLContext.h
@@ -42,6 +42,11 @@ private:
     _glConfig = _glDisplay->chooseConfig();
     _glContext = _glDisplay->makeContext(_glConfig, nullptr);
     _glSurface = _glDisplay->makePixelBufferSurface(_glConfig, 1, 1);
+    if (_glContext == nullptr || _glSurface == nullptr) {
+      RNSkLogger::logToConsole(
+          "Couldn't create the shared OpenGL context or surface");
+      return;
+    }
     _glContext->makeCurrent(_glSurface.get());
   }
 };
@@ -60,6 +65,10 @@ public:
 
   sk_sp<SkSurface> MakeOffscreen(int width, int height,
                                  bool useP3ColorSpace = false) {
+    if (_directContext == nullptr) {
+      return nullptr;
+    }
+
     auto colorType = kRGBA_8888_SkColorType;
 
     SkSurfaceProps props(0, kUnknown_SkPixelGeometry);
@@ -110,6 +119,9 @@ public:
   sk_sp<SkImage> MakeImageFromBuffer(void *buffer,
                                      bool requireKnownFormat = false) {
 #if __ANDROID_API__ >= 26
+    if (_directContext == nullptr) {
+      return nullptr;
+    }
     const AHardwareBuffer *hardwareBuffer =
         static_cast<AHardwareBuffer *>(buffer);
     DeleteImageProc deleteImageProc = nullptr;
@@ -181,6 +193,11 @@ public:
   // TODO: remove width, height
   std::unique_ptr<WindowContext> MakeWindow(ANativeWindow *window,
                                             bool highBitDepth = false) {
+    if (_directContext == nullptr) {
+      RNSkLogger::logToConsole(
+          "The OpenGL context is invalid, the surface will not be rendered");
+      return nullptr;
+    }
     auto display = OpenGLSharedContext::getInstance().getDisplay();
     if (highBitDepth) {
       // A 10-bit window surface would require the shared EGL context to be
@@ -196,7 +213,11 @@ public:
   }
 
   GrDirectContext *getDirectContext() { return _directContext.get(); }
-  void makeCurrent() { _glContext->makeCurrent(_glSurface.get()); }
+  void makeCurrent() {
+    if (_glContext != nullptr) {
+      _glContext->makeCurrent(_glSurface.get());
+    }
+  }
 
 private:
   std::unique_ptr<gl::Context> _glContext;
@@ -209,12 +230,17 @@ private:
     auto glConfig = OpenGLSharedContext::getInstance().getConfig();
     _glContext = display->makeContext(glConfig, sharedContext);
     _glSurface = display->makePixelBufferSurface(glConfig, 1, 1);
-    _glContext->makeCurrent(_glSurface.get());
+    if (_glContext == nullptr || _glSurface == nullptr ||
+        !_glContext->makeCurrent(_glSurface.get())) {
+      RNSkLogger::logToConsole(
+          "Couldn't create the OpenGL context, Skia rendering is disabled");
+      return;
+    }
     auto backendInterface = GrGLMakeNativeInterface();
     _directContext = GrDirectContexts::MakeGL(backendInterface);
 
     if (_directContext == nullptr) {
-      throw std::runtime_error("GrDirectContexts::MakeGL failed");
+      RNSkLogger::logToConsole("GrDirectContexts::MakeGL failed");
     }
   }
 };

--- a/packages/skia/android/cpp/rnskia-android/OpenGLWindowContext.cpp
+++ b/packages/skia/android/cpp/rnskia-android/OpenGLWindowContext.cpp
@@ -16,7 +16,12 @@ namespace RNSkia {
 
 sk_sp<SkSurface> OpenGLWindowContext::getSurface() {
   if (_skSurface == nullptr) {
-    _glContext->makeCurrent(_glSurface.get());
+    if (_glSurface == nullptr || !_glContext->makeCurrent(_glSurface.get())) {
+      RNSkLogger::logToConsole(
+          "Couldn't create the EGL window surface, the surface will not be "
+          "rendered");
+      return nullptr;
+    }
     GLint stencil;
     glGetIntegerv(GL_STENCIL_BITS, &stencil);
 
@@ -52,7 +57,9 @@ sk_sp<SkSurface> OpenGLWindowContext::getSurface() {
 }
 
 void OpenGLWindowContext::present() {
-  _glContext->makeCurrent(_glSurface.get());
+  if (_glSurface == nullptr || !_glContext->makeCurrent(_glSurface.get())) {
+    return;
+  }
   _directContext->flushAndSubmit();
   _glSurface->present();
 }

--- a/packages/skia/android/cpp/rnskia-android/gl/Context.h
+++ b/packages/skia/android/cpp/rnskia-android/gl/Context.h
@@ -26,6 +26,9 @@ public:
     if (_context == EGL_NO_CONTEXT) {
       return false;
     }
+    if (surface == nullptr || !surface->isValid()) {
+      return false;
+    }
     const auto result =
         eglMakeCurrentIfNecessary(_display, surface->getHandle(),
                                   surface->getHandle(), _context) == EGL_TRUE;

--- a/packages/skia/android/cpp/rnskia-android/gl/Surface.h
+++ b/packages/skia/android/cpp/rnskia-android/gl/Surface.h
@@ -17,7 +17,7 @@ public:
     }
   }
 
-  bool isValid() { return _surface != EGL_NO_SURFACE; }
+  bool isValid() const { return _surface != EGL_NO_SURFACE; }
 
   const EGLSurface &getHandle() const { return _surface; }
 

--- a/packages/skia/cpp/api/JsiSkiaContext.h
+++ b/packages/skia/cpp/api/JsiSkiaContext.h
@@ -79,6 +79,10 @@ public:
       }
       auto result =
           context->makeContextFromNativeSurface(surface, width, height);
+      if (result == nullptr) {
+        throw std::runtime_error(
+            "Couldn't create a Skia context from the native surface");
+      }
       // Return the newly constructed object
       auto hostObjectInstance =
           std::make_shared<JsiSkiaContext>(context, std::move(result));

--- a/packages/skia/cpp/rnskia/RNSkView.h
+++ b/packages/skia/cpp/rnskia/RNSkView.h
@@ -84,6 +84,9 @@ public:
    Returns a snapshot of the current surface/canvas
    */
   sk_sp<SkImage> makeSnapshot(SkRect *bounds) {
+    if (_surface == nullptr) {
+      return nullptr;
+    }
     sk_sp<SkImage> image;
     if (bounds != nullptr) {
       SkIRect b =
@@ -120,6 +123,9 @@ public:
    Render to a canvas
    */
   bool renderToCanvas(const std::function<void(SkCanvas *)> &cb) override {
+    if (_surface == nullptr) {
+      return false;
+    }
     cb(_surface->getCanvas());
     return true;
   };


### PR DESCRIPTION
Fixes #3793
Relates to #3156