### PR TITLE
docs: add image byte-budget tutorial

### DIFF
--- a/apps/docs/docs/tutorials.md
+++ b/apps/docs/docs/tutorials.md
@@ -40,6 +40,9 @@ Please [make a PR](https://github.com/Shopify/react-native-skia/edit/main/docs/d
 ## ✨ Image Filters
 * 🔘 [Neumorphism in React Native ](https://www.youtube.com/watch?v=GFssmWUhwww)
 
+## 🖼️ Image Processing
+* 📦 [Compressing a React Native image to a strict byte budget with Skia](https://github.com/MarshallBear1/juno-open-health-tools/blob/main/tutorials/react-native-skia-image-byte-budget.md)
+
 ## 🌈 Gradients
 * 🌈 [Introducing Gen-Z Mode ](https://www.youtube.com/watch?v=0FC8O9mRUmg)
 * 📱 [iPhone wallpapers, but in React Native Skia](https://www.youtube.com/watch?v=Apqd749v34I)


### PR DESCRIPTION
## Summary

Adds a written tutorial showing how to use React Native Skia's imperative API to decode a local image, resize it on an offscreen surface, and search across JPEG quality and dimensions until the decoded output fits a strict byte budget.

The tutorial includes:

- a complete reusable TypeScript implementation;
- exact Base64 decoded-byte accounting;
- explicit disposal of Skia data, image, paint, snapshot, and surface objects; and
- production notes on alpha, EXIF orientation, memory, request overhead, and server-side validation.

The example was extracted from production use, rewritten without application-specific dependencies or data, and checked against `@shopify/react-native-skia` 2.6.2. It is published under the MIT license.

## Validation

- branch is based on the current upstream `main` commit
- tutorial and source resolve from the public default branch
- tutorial implementation passes a strict TypeScript no-emit check against React Native Skia 2.6.2
- known-value checks pass for Base64 byte accounting
- this PR changes only `apps/docs/docs/tutorials.md`
- `git diff --check` passes
