### PR TITLE
fix(🐛): rename leftover rnwgpu namespace to RNJsi to fix ODR clash 

### DIFF
--- a/packages/skia/cpp/api/JsiSkConverters.h
+++ b/packages/skia/cpp/api/JsiSkConverters.h
@@ -214,7 +214,7 @@ template <typename T> struct JsiOptional : std::optional<T> {
 
 } // namespace RNSkia
 
-namespace rnwgpu {
+namespace RNJsi {
 
 /**
  * sk_sp<T> arguments (SkImage, SkShader, ...). Delegates to the wrapper
@@ -407,4 +407,4 @@ template <> struct JSIConverter<SkISize> {
   }
 };
 
-} // namespace rnwgpu
+} // namespace RNJsi

--- a/packages/skia/cpp/api/JsiSkNativeObjects.h
+++ b/packages/skia/cpp/api/JsiSkNativeObjects.h
@@ -24,7 +24,7 @@
  * be expressed as typed signatures (heterogeneous argument dispatch, typed
  * array construction, lenient options objects, promises) — everything else
  * uses installMethod/installGetter/installChainableMethod with typed C++
- * signatures converted through rnwgpu::JSIConverter.
+ * signatures converted through RNJsi::JSIConverter.
  */
 #define JSI_HOST_FUNCTION(NAME)                                                \
   jsi::Value NAME(jsi::Runtime &runtime, const jsi::Value &thisValue,          \
@@ -36,7 +36,7 @@ namespace jsi = facebook::jsi;
 
 // Minimum memory pressure reported for any native object — aliased from the
 // NativeObject infrastructure so dispose() and create() agree on the floor.
-static constexpr size_t kMinMemoryPressure = rnwgpu::kMinMemoryPressure;
+static constexpr size_t kMinMemoryPressure = RNJsi::kMinMemoryPressure;
 
 /**
  * Creates the JS object for a wrapper instance (a class based on the
@@ -102,16 +102,16 @@ std::shared_ptr<T> getJsiObject(jsi::Runtime &runtime,
  *
  * Most methods use typed C++ signatures installed with installMethod /
  * installGetter / installChainableMethod (arguments and results converted
- * through rnwgpu::JSIConverter, see JsiSkConverters.h). Methods that cannot
+ * through RNJsi::JSIConverter, see JsiSkConverters.h). Methods that cannot
  * be typed keep the classic JSI_HOST_FUNCTION signature and are installed
  * with installHostMethod, which resolves the C++ instance from `this` via
  * native state.
  */
 template <typename Derived>
-class JsiSkNativeObject : public rnwgpu::NativeObject<Derived> {
+class JsiSkNativeObject : public RNJsi::NativeObject<Derived> {
 public:
   explicit JsiSkNativeObject(std::shared_ptr<RNSkPlatformContext> context)
-      : rnwgpu::NativeObject<Derived>(Derived::CLASS_NAME),
+      : RNJsi::NativeObject<Derived>(Derived::CLASS_NAME),
         _context(std::move(context)) {}
 
   /**
@@ -120,7 +120,7 @@ public:
    */
   static std::shared_ptr<Derived> fromThis(jsi::Runtime &runtime,
                                            const jsi::Value &thisValue) {
-    return rnwgpu::NativeObject<Derived>::fromValue(runtime, thisValue);
+    return RNJsi::NativeObject<Derived>::fromValue(runtime, thisValue);
   }
 
 protected:
@@ -222,7 +222,7 @@ protected:
   /**
    * Installs a typed mutating method that returns `this` for chaining
    * (e.g. path.moveTo(...).lineTo(...)). Arguments are converted through
-   * rnwgpu::JSIConverter like installMethod; the member function's return
+   * RNJsi::JSIConverter like installMethod; the member function's return
    * value (if any) is ignored and the JS function returns thisValue.
    */
   template <typename ReturnType, typename... Args>
@@ -270,7 +270,7 @@ private:
                               ReturnType (Derived::*method)(Args...),
                               jsi::Runtime &runtime, const jsi::Value *args,
                               std::index_sequence<Is...>, size_t count) {
-    (obj->*method)(rnwgpu::JSIConverter<std::decay_t<Args>>::fromJSI(
+    (obj->*method)(RNJsi::JSIConverter<std::decay_t<Args>>::fromJSI(
         runtime, args[Is], Is >= count)...);
   }
 
@@ -280,7 +280,7 @@ private:
       jsi::Runtime &runtime, const jsi::Value *args, std::index_sequence<Is...>,
       size_t count) {
     (obj->*method)(runtime,
-                   rnwgpu::JSIConverter<std::decay_t<Args>>::fromJSI(
+                   RNJsi::JSIConverter<std::decay_t<Args>>::fromJSI(
                        runtime, args[Is], Is >= count)...);
   }
 

--- a/packages/skia/cpp/api/JsiSkRuntimeEffect.h
+++ b/packages/skia/cpp/api/JsiSkRuntimeEffect.h
@@ -39,7 +39,7 @@ struct RuntimeEffectUniform {
 
 } // namespace RNSkia
 
-namespace rnwgpu {
+namespace RNJsi {
 
 // RuntimeEffectUniform -> {columns, rows, slot, isInteger}
 template <> struct JSIConverter<RNSkia::RuntimeEffectUniform> {
@@ -54,7 +54,7 @@ template <> struct JSIConverter<RNSkia::RuntimeEffectUniform> {
   }
 };
 
-} // namespace rnwgpu
+} // namespace RNJsi
 
 namespace RNSkia {
 

--- a/packages/skia/cpp/jsi/EnumMapper.h
+++ b/packages/skia/cpp/jsi/EnumMapper.h
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace rnwgpu {
+namespace RNJsi {
 
 namespace EnumMapper {
 // Add these two methods in namespace "EnumMapper" to allow parsing a custom
@@ -60,4 +60,4 @@ static void convertEnumToJSUnion(TEnum, std::string *) {
 }
 } // namespace EnumMapper
 
-} // namespace rnwgpu
+} // namespace RNJsi

--- a/packages/skia/cpp/jsi/JSIConverter.h
+++ b/packages/skia/cpp/jsi/JSIConverter.h
@@ -25,7 +25,7 @@
 #include <cxxabi.h>
 #endif
 
-namespace rnwgpu {
+namespace RNJsi {
 
 namespace jsi = facebook::jsi;
 
@@ -495,4 +495,4 @@ template <> struct JSIConverter<std::unordered_set<std::string>> {
   }
 };
 
-} // namespace rnwgpu
+} // namespace RNJsi

--- a/packages/skia/cpp/jsi/NativeObject.h
+++ b/packages/skia/cpp/jsi/NativeObject.h
@@ -18,14 +18,14 @@
 #include "jsi/RuntimeAwareCache.h" // Use Skia's RuntimeAwareCache
 
 // Forward declare to avoid circular dependency
-namespace rnwgpu {
+namespace RNJsi {
 template <typename ArgType, typename SFINAE> struct JSIConverter;
-} // namespace rnwgpu
+} // namespace RNJsi
 
 // Include the converter - must come after forward declaration
 #include "JSIConverter.h"
 
-namespace rnwgpu {
+namespace RNJsi {
 
 namespace jsi = facebook::jsi;
 
@@ -452,7 +452,7 @@ protected:
             return jsi::Value::undefined();
           } else {
             ReturnType result = (native.get()->*getter)();
-            return rnwgpu::JSIConverter<std::decay_t<ReturnType>>::toJSI(
+            return RNJsi::JSIConverter<std::decay_t<ReturnType>>::toJSI(
                 rt, std::move(result));
           }
         });
@@ -487,7 +487,7 @@ protected:
             throw jsi::JSError(rt, "Setter requires a value argument");
           }
           auto native = NativeObject<Derived>::fromValue(rt, thisVal);
-          auto value = rnwgpu::JSIConverter<std::decay_t<ValueType>>::fromJSI(
+          auto value = RNJsi::JSIConverter<std::decay_t<ValueType>>::fromJSI(
               rt, args[0], false);
           (native.get()->*setter)(std::move(value));
           return jsi::Value::undefined();
@@ -535,7 +535,7 @@ protected:
                  const jsi::Value *args, size_t count) -> jsi::Value {
           auto native = NativeObject<Derived>::fromValue(rt, thisVal);
           ReturnType result = (native.get()->*getter)();
-          return rnwgpu::JSIConverter<std::decay_t<ReturnType>>::toJSI(
+          return RNJsi::JSIConverter<std::decay_t<ReturnType>>::toJSI(
               rt, std::move(result));
         });
 
@@ -548,7 +548,7 @@ protected:
             throw jsi::JSError(rt, "Setter requires a value argument");
           }
           auto native = NativeObject<Derived>::fromValue(rt, thisVal);
-          auto value = rnwgpu::JSIConverter<std::decay_t<ValueType>>::fromJSI(
+          auto value = RNJsi::JSIConverter<std::decay_t<ValueType>>::fromJSI(
               rt, args[0], false);
           (native.get()->*setter)(std::move(value));
           return jsi::Value::undefined();
@@ -579,9 +579,9 @@ private:
                         jsi::Runtime &runtime, const jsi::Value *args,
                         std::index_sequence<Is...>, size_t count) {
     ReturnType result = (obj->*method)(
-        runtime, rnwgpu::JSIConverter<std::decay_t<Args>>::fromJSI(
+        runtime, RNJsi::JSIConverter<std::decay_t<Args>>::fromJSI(
                      runtime, args[Is], Is >= count)...);
-    return rnwgpu::JSIConverter<std::decay_t<ReturnType>>::toJSI(
+    return RNJsi::JSIConverter<std::decay_t<ReturnType>>::toJSI(
         runtime, std::move(result));
   }
 
@@ -592,7 +592,7 @@ private:
                                jsi::Runtime &runtime, const jsi::Value *args,
                                std::index_sequence<Is...>, size_t count) {
     if constexpr (std::is_same_v<ReturnType, void>) {
-      (obj->*method)(rnwgpu::JSIConverter<std::decay_t<Args>>::fromJSI(
+      (obj->*method)(RNJsi::JSIConverter<std::decay_t<Args>>::fromJSI(
           runtime, args[Is], Is >= count)...);
       return jsi::Value::undefined();
     } else if constexpr (std::is_same_v<ReturnType, jsi::Value>) {
@@ -601,9 +601,9 @@ private:
       return (obj->*method)(runtime, jsi::Value::undefined(), args, count);
     } else {
       ReturnType result =
-          (obj->*method)(rnwgpu::JSIConverter<std::decay_t<Args>>::fromJSI(
+          (obj->*method)(RNJsi::JSIConverter<std::decay_t<Args>>::fromJSI(
               runtime, args[Is], Is >= count)...);
-      return rnwgpu::JSIConverter<std::decay_t<ReturnType>>::toJSI(
+      return RNJsi::JSIConverter<std::decay_t<ReturnType>>::toJSI(
           runtime, std::move(result));
     }
   }
@@ -616,4 +616,4 @@ template <typename T>
 struct is_native_object<std::shared_ptr<T>>
     : std::bool_constant<std::is_base_of_v<NativeObject<T>, T>> {};
 
-} // namespace rnwgpu
+} // namespace RNJsi

--- a/packages/skia/cpp/jsi/Promise.cpp
+++ b/packages/skia/cpp/jsi/Promise.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-namespace rnwgpu {
+namespace RNJsi {
 
 namespace jsi = facebook::jsi;
 
@@ -45,4 +45,4 @@ void Promise::reject(std::string message) {
   _rejecter.call(runtime, error.value());
 }
 
-} // namespace rnwgpu
+} // namespace RNJsi

--- a/packages/skia/cpp/jsi/Promise.h
+++ b/packages/skia/cpp/jsi/Promise.h
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-namespace rnwgpu {
+namespace RNJsi {
 
 namespace jsi = facebook::jsi;
 
@@ -34,4 +34,4 @@ public:
   static jsi::Value createPromise(jsi::Runtime &runtime, RunPromise run);
 };
 
-} // namespace rnwgpu
+} // namespace RNJsi


### PR DESCRIPTION
The typed-JSI-bindings migration copied the NativeObject/JSIConverter files from react-native-webgpu but left eight files in the rnwgpu namespace. When both libraries are linked into one app, the template instantiations (e.g. rnwgpu::StaticRuntimeAwareCache<rnwgpu:: PrototypeCacheEntry>::get) have identical mangled names in both packages with different bodies. The linker keeps a single weak definition, so webgpu's prototype installation can execute Skia's copy, which reads RNJsi::BaseRuntimeAwareCache::_mainRuntime before RNSkManager has set it and aborts:

  Assertion failed: (rt != nullptr && "Expected main Javascript
  runtime to be set in the BaseRuntimeAwareCache class."),
  RuntimeAwareCache.h line 27

Moving the copied files into RNJsi gives every colliding symbol a distinct mangled name. Verified against react-native-webgpu@0.8.1: the assert reproduced before the rename and the app boots cleanly after, with both packages' cache instantiations present in the binary.

fixes wcandillon/react-native-webgpu#367