### PR TITLE
fix(🐛): don't crash the web view when no WebGL surface can be created

### DIFF
--- a/packages/skia/src/views/SkiaPictureView.web.tsx
+++ b/packages/skia/src/views/SkiaPictureView.web.tsx
@@ -45,19 +45,40 @@ class WebGLRenderer implements Renderer {
   constructor(private canvas: HTMLCanvasElement) {
     this.contextHandle = CanvasKit.GetWebGLContext(canvas);
     if (!this.contextHandle) {
-      throw new Error("Could not create a WebGL context");
+      // WebGL is unavailable (disabled, blocklisted GPU, or the per-page
+      // context limit is exhausted). Throwing here would escape the layout
+      // effect that constructs the renderer, so degrade to an inert renderer
+      // instead: draw() and makeImageSnapshot() already no-op on a null
+      // surface, and the event lets embedders show a fallback UI.
+      this.announceSurfaceUnavailable();
+      return;
     }
     this.grContext = CanvasKit.MakeWebGLContext(this.contextHandle);
     if (!this.grContext) {
       CanvasKit.deleteContext(this.contextHandle);
       this.contextHandle = 0;
-      throw new Error("Could not create a graphics context");
+      this.announceSurfaceUnavailable();
+      return;
     }
     const ctx = canvas.getContext("webgl2");
     if (ctx) {
       ctx.drawingBufferColorSpace = "display-p3";
     }
     this.onResize();
+  }
+
+  // Announces that no drawing surface could be created, on the next frame so
+  // listeners attached in an effect of the same commit that mounted the view
+  // are registered first. Bubbles so embedders can react (e.g. swap in a
+  // fallback UI); without a listener it is a no-op. Mirrors how
+  // StaticWebGLRenderer already treats a failed surface as recoverable
+  // rather than fatal.
+  private announceSurfaceUnavailable() {
+    requestAnimationFrame(() => {
+      this.canvas.dispatchEvent(
+        new CustomEvent("skia-surface-unavailable", { bubbles: true })
+      );
+    });
   }
 
   makeImageSnapshot(picture: SkPicture, rect?: SkRect): SkImage | null {
@@ -95,7 +116,12 @@ class WebGLRenderer implements Renderer {
       CanvasKit.ColorSpace.SRGB
     );
     if (!surface) {
-      throw new Error("Could not create surface");
+      // onResize runs from a ResizeObserver callback, so a throw here escapes
+      // as an unhandled error that no try/catch or React error boundary can
+      // reach. Leave the surface null instead — draw() and makeImageSnapshot()
+      // already no-op on it — and let embedders know.
+      this.announceSurfaceUnavailable();
+      return;
     }
     this.surface = new JsiSkSurface(CanvasKit, surface);
   }


### PR DESCRIPTION
## Description

On web, `WebGLRenderer` in `SkiaPictureView.web.tsx` throws when the browser cannot provide a WebGL surface — hardware acceleration disabled, a blocklisted GPU, a GPU process restart, or the per-page live-context limit being exhausted. Both throw sites escape as **uncatchable errors**:

- the constructor throws inside the `useLayoutEffect` that builds the renderer, and
- `onResize` throws inside the `ResizeObserver` callback,

so no `try/catch` or React error boundary in the embedding app can reach them, and an environmental limitation becomes an app crash. We (Expensify) see this at scale in production Sentry as `failed to create webgl context: err 0` / `Could not create surface` from chart views on `/home` and `/search` (Sentry issue APP-7MV: hundreds of users, thousands of events), currently worked around with a `patch-package` patch.

## Change

Degrade instead of throwing, mirroring how `StaticWebGLRenderer` already treats a failed surface as recoverable rather than fatal:

- When no WebGL/graphics context or on-screen surface can be created, leave the renderer inert — `draw()`, `makeImageSnapshot()` and `onResize` already no-op on a null `surface`/`grContext`, and `dispose()` already handles the null fields.
- Dispatch a bubbling `skia-surface-unavailable` `CustomEvent` on the canvas so embedders can detect the condition and show a fallback UI (deferred one frame so listeners attached in an effect of the same commit are registered first). Without a listener the event is a no-op, so existing consumers see no behavioral change other than not crashing.

## Notes

- No API change; capable clients are unaffected.
- The event lets an app render its own "chart unavailable" state — a capability check before mounting cannot cover this, because the surface is created after the CanvasKit WASM module loads and WebGL availability can change in between.

## Test plan

- Simulated an incapable client in Chrome by making `HTMLCanvasElement.prototype.getContext` return `null` for `"webgl2"`: previously the uncaught throw surfaced and the canvas stayed blank; with this change the view mounts inert, the event fires on the canvas, and a listener can swap in fallback UI. Restoring WebGL and remounting renders normally.
- Verified `prettier --check` (2.8.7) passes on the touched file.