### PR TITLE
fix(🐛): guard the picture renderer's SkPicture behind a mutex

### DIFF
--- a/packages/skia/cpp/rnskia/RNSkPictureView.h
+++ b/packages/skia/cpp/rnskia/RNSkPictureView.h
@@ -52,17 +52,24 @@ public:
   }
 
   void setPicture(sk_sp<SkPicture> picture) {
-    _picture = picture;
+    {
+      std::lock_guard<std::mutex> lock(_pictureMutex);
+      _picture = std::move(picture);
+    }
     _requestRedraw();
   }
 
-  sk_sp<SkPicture> getPicture() const { return _picture; }
+  sk_sp<SkPicture> getPicture() const {
+    std::lock_guard<std::mutex> lock(_pictureMutex);
+    return _picture;
+  }
 
 private:
   bool performDraw(std::shared_ptr<RNSkCanvasProvider> canvasProvider) {
-    // Capture picture pointer to ensure thread safety - _picture can be
-    // modified from the JS thread while we're drawing on the render thread
-    sk_sp<SkPicture> picture = _picture;
+    // The ref has to be taken under the lock: setPicture() writes _picture from
+    // the JS thread while this reads it on the render thread. The local sk_sp
+    // then keeps the picture alive for the whole draw.
+    sk_sp<SkPicture> picture = getPicture();
     auto pd = _platformContext->getPixelDensity();
     return canvasProvider->renderToCanvas([=](SkCanvas *canvas) {
       canvas->clear(SK_ColorTRANSPARENT);
@@ -76,6 +83,7 @@ private:
   }
 
   std::shared_ptr<RNSkPlatformContext> _platformContext;
+  mutable std::mutex _pictureMutex;
   sk_sp<SkPicture> _picture;
 };
 


### PR DESCRIPTION
Fixes #3925.

## The problem

`RNSkPictureRenderer` keeps the current picture in a plain `sk_sp<SkPicture>` that is written from one thread and read from two others, with nothing synchronizing them:

- **JS thread** — `RNSkPictureView::setJsiProperties` → `setPicture()` writes `_picture`.
- **Render thread** — `RNSkView::requestRedraw()` → `renderImmediate()` → `performDraw()` reads it.
- **Android** — `JniSkiaPictureView::getBitmap()` reads it through `getPicture()`.

`performDraw()` carries a comment saying the local copy is what makes this safe:

```cpp
// Capture picture pointer to ensure thread safety - _picture can be
// modified from the JS thread while we're drawing on the render thread
sk_sp<SkPicture> picture = _picture;
```

Copying an `sk_sp` refs the pointee, so that line is a non-atomic read of `_picture` plus a `SkSafeRef` on whatever it happened to observe — it is the race, not a guard against it. `_redrawRequested` on `RNSkView` is already `std::atomic<bool>`, so the threading was accounted for elsewhere in the same path; `_picture` was simply missed.

That produces exactly the two crash signatures in the issue:

1. The copy refs a picture whose refcount already reached zero → Skia's `SkRefCntBase::ref()` assert fires `sk_abort_no_print` (`EXC_BREAKPOINT` / `SIGTRAP`).
2. The copy wins the race but the picture dies before the deferred lambda runs → `SkCanvas::drawPicture` dereferences freed memory (`EXC_BAD_ACCESS` / `SIGSEGV`).

Both stacks in the report enter through `requestRedraw` → `renderImmediate` → `performDraw`, which is this path.

## The fix

Put `_picture` behind a `std::mutex` and take the `sk_sp` copy while holding it. Once copied, the local `sk_sp` owns a reference for the whole draw, so the lock is released before rendering. `setPicture()` also drops the lock before calling `_requestRedraw()`, so the redraw path itself stays lock-free and there is no way to re-enter the lock from a synchronous dispatch.

`<mutex>` was already included in the file. The mutex is `mutable` so `getPicture()` stays `const` and the Android JNI caller is unchanged.

## Verification

Because the race needs two threads hammering the same member, I reproduced it in a standalone harness that mirrors the storage exactly — same `setPicture` / `getPicture` / `performDraw` shape, a minimal `sk_sp` whose `ref()` aborts on a zero refcount the way Skia's does — and ran both variants under ThreadSanitizer for 3 seconds each:

| build | exit | TSan data races | `ref()` on dead object |
|---|---|---|---|
| current `main` (unsynchronized) | 134 (`SIGABRT`) | 3 | **1** |
| this PR (mutex) | 0 | 0 | 0 |

The unsynchronized build aborts inside `ref()` on a destroyed picture, which is crash signature 1 from the issue. The patched build runs clean.

I could not exercise the real render path end to end (the crash is sporadic in the field and the reporter sees it roughly once per several days), so the on-device confirmation is still the reporter's to give — but the race itself is unambiguous in the source and the harness shows the lock closes it.

`clang-format` reports no changes on the file.
