### PR TITLE
fix(🐛): swap the skew shear axes in the native recorder too

### DIFF
--- a/packages/skia/cpp/api/recorder/Convertor.h
+++ b/packages/skia/cpp/api/recorder/Convertor.h
@@ -361,13 +361,16 @@ SkM44 getPropertyValue(jsi::Runtime &runtime, const jsi::Value &value) {
         m4.preScale(1, s);
       } else if (key == "skewX") {
         auto angle = value.getProperty(runtime, key.c_str()).asNumber();
-        SkM44 skewX(1, 0, 0, 0, std::tan(angle), 1, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+        // The SkM44 constructor takes its arguments in row-major reading
+        // order, so the shear factor of a horizontal skew belongs in row 0,
+        // where it scales y into x.
+        SkM44 skewX(1, std::tan(angle), 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0,
                     1);
         m4.preConcat(skewX);
 
       } else if (key == "skewY") {
         auto angle = value.getProperty(runtime, key.c_str()).asNumber();
-        SkM44 skewY(1, std::tan(angle), 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+        SkM44 skewY(1, 0, 0, 0, std::tan(angle), 1, 0, 0, 0, 0, 1, 0, 0, 0, 0,
                     1);
         m4.preConcat(skewY);
       } else if (key == "rotate" || key == "rotateZ") {


### PR DESCRIPTION
Follow-up to #4015 — that PR is why `main` is currently red.

### What went wrong

#4015 fixed `skewX`/`skewY` in `processTransform3d`, but the native recorder keeps its own copy of that conversion in `cpp/api/recorder/Convertor.h`, and that copy has the same two axes swapped. Only the TypeScript side was corrected, so the two backends now disagree.

The snapshots were regenerated for the corrected behaviour, so native is the one that fails. On `main` today:

| job | result |
|---|---|
| `build-test-ios-graphite` ([run](https://github.com/Shopify/react-native-skia/actions/runs/32564885541)) | `Transforms.spec.tsx` — both skew tests fail, 167673 px diff |
| `test-android` (on open PRs, which merge with `main`) | same two tests, 167047 / 167045 px diff |

### The fix

`SkM44`’s constructor reads its arguments in row-major order — the same layout as the `Matrix4` tuple in TypeScript. So the two argument lists are now literally identical to the arrays in `Matrix4.ts`:

```cpp
// skewX — shear factor in row 0, scaling y into x
SkM44 skewX(1, std::tan(angle), 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
// skewY — shear factor in row 0 of column 0, scaling x into y
SkM44 skewY(1, 0, 0, 0, std::tan(angle), 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
```

The `perspective` case a few lines below is a useful control: its C++ argument list already matches the TypeScript array element for element, and its snapshot passes on native — which is what confirms the constructor convention.

### Testing

No new test: `Transforms.spec.tsx` already covers both axes and already fails on `main`, so `test-android` and `build-test-ios-graphite` going green here is the verification. I have no local Skia build, so I could not run the native path myself — CI is the check.

Sorry for the breakage.