### PR TITLE
fix(🐛): ref the typeface borrowed from SkFont

### DIFF
--- a/packages/skia/cpp/api/JsiSkFont.h
+++ b/packages/skia/cpp/api/JsiSkFont.h
@@ -135,8 +135,9 @@ public:
   bool isEmbolden() { return getObject()->isEmbolden(); }
 
   std::shared_ptr<JsiSkTypeface> getTypeface() {
-    return std::make_shared<JsiSkTypeface>(
-        getContext(), sk_sp<SkTypeface>(getObject()->getTypeface()));
+    // refTypeface(), not getTypeface(): the wrapper owns what it is handed.
+    return std::make_shared<JsiSkTypeface>(getContext(),
+                                           getObject()->refTypeface());
   }
 
   void setEdging(double edging) {


### PR DESCRIPTION
Fixes #3983.

`SkFont` exposes two accessors, and the one used here is the borrowing one — quoting `include/core/SkFont.h` on the pinned `chrome/m152`:

```cpp
/** Does not alter SkTypeface SkRefCnt.

    @return  non-null SkTypeface
*/
SkTypeface* getTypeface() const;

/** Increases SkTypeface SkRefCnt by one.

    @return  A non-null SkTypeface.
*/
sk_sp<SkTypeface> refTypeface() const;
```

`sk_sp`'s raw-pointer constructor adopts without ref'ing ("No call to ref() or unref() will be made"), so `sk_sp<SkTypeface>(getObject()->getTypeface())` handed the `JsiSkTypeface` wrapper a reference it never owned. Every `font.getTypeface()` call from JS therefore cost the typeface one reference the moment its wrapper was garbage collected. Code that derives a paint variant from a loaded font does this per render:

```tsx
const bold = useMemo(() => {
  const f = Skia.Font(baseFont.getTypeface(), size);
  f.setEmbolden(true);
  return f;
}, [baseFont]);
```

Once the stolen unrefs cross the typeface's real refcount it is destroyed while live `SkFont`s still point at it, which is where the crashes in the issue come from — `SkTypeface::getBounds` under `GlyphsCmd::draw`, and `SkTypeface::textToGlyphs` under `JsiSkFont::getGlyphIDs`.

`refTypeface()` is the accessor that hands over an owned reference, which is what the wrapper needs. It is also the only site in `cpp/` that built an `sk_sp` from a borrowed getter — I grepped the other `sk_sp<Sk…>(…)` constructions and they all adopt a freshly `new`-ed object.

The Web binding was never affected: `JsiSkFont.getTypeface` there wraps the CanvasKit handle, which is not refcounted from JS.