### PR TITLE
fix(🤖): copy the video frame on Android again

### DIFF
--- a/packages/skia/src/external/reanimated/__tests__/useVideo.spec.ts
+++ b/packages/skia/src/external/reanimated/__tests__/useVideo.spec.ts
@@ -1,0 +1,127 @@
+import type { FrameInfo, SharedValue } from "react-native-reanimated";
+
+import type { Platform as PlatformType } from "../../../Platform";
+import type { SkImage, Video } from "../../../skia/types";
+import type { useVideo as UseVideo } from "../useVideo";
+
+let frameCallback: ((frameInfo: FrameInfo) => void) | undefined;
+const useVideoLoadingMock = jest.fn();
+
+jest.doMock("react", () => ({
+  useEffect: jest.fn(),
+  useMemo: <T>(factory: () => T) => factory(),
+}));
+
+jest.doMock("../ReanimatedProxy", () => ({
+  __esModule: true,
+  default: {
+    isSharedValue: () => false,
+    runOnUI: jest.fn((fn) => fn),
+    useAnimatedReaction: jest.fn(),
+    useFrameCallback: (callback: (frameInfo: FrameInfo) => void) => {
+      frameCallback = callback;
+    },
+    useSharedValue: <T>(value: T) => ({ value }) as SharedValue<T>,
+  },
+}));
+
+jest.doMock("../useVideoLoading", () => ({
+  useVideoLoading: useVideoLoadingMock,
+}));
+
+jest.doMock("../../../Platform", () => ({
+  Platform: { OS: "android" },
+}));
+
+const { useVideo } = require("../useVideo") as { useVideo: typeof UseVideo };
+const { Platform } = require("../../../Platform") as {
+  Platform: typeof PlatformType;
+};
+
+// A decoder-backed frame: makeNonTextureImage() is the readback, and the
+// texture itself becomes invalid as soon as the decoder recycles the slot.
+const texture = (copy: SkImage | null) =>
+  ({
+    dispose: jest.fn(),
+    makeNonTextureImage: jest.fn(() => copy),
+  }) as unknown as SkImage;
+
+const videoOf = (...frames: Array<SkImage | null>) => {
+  const nextImage = jest.fn();
+  frames.forEach((frame) => nextImage.mockReturnValueOnce(frame));
+  return {
+    currentTime: jest.fn(() => 0),
+    duration: jest.fn(() => 1000),
+    framerate: jest.fn(() => 30),
+    nextImage,
+    rotation: jest.fn(() => 0),
+    size: jest.fn(() => ({ width: 1920, height: 1080 })),
+  } as unknown as Video;
+};
+
+const advance = () => {
+  expect(frameCallback).toBeDefined();
+  frameCallback!({} as FrameInfo);
+};
+
+describe("useVideo", () => {
+  beforeEach(() => {
+    Platform.OS = "android";
+    frameCallback = undefined;
+    useVideoLoadingMock.mockReset();
+  });
+
+  it("publishes a copy of the Android frame and releases the texture", () => {
+    const copy = texture(null);
+    const tex = texture(copy);
+    useVideoLoadingMock.mockReturnValue(videoOf(tex));
+
+    const { currentFrame } = useVideo("video.mp4");
+    advance();
+
+    expect(tex.makeNonTextureImage).toHaveBeenCalledTimes(1);
+    expect(tex.dispose).toHaveBeenCalledTimes(1);
+    expect(currentFrame.value).toBe(copy);
+  });
+
+  it("keeps the last good frame when the Android readback fails", () => {
+    const good = texture(null);
+    const first = texture(good);
+    // makeNonTextureImage() returns null when the readback fails.
+    const second = texture(null);
+    useVideoLoadingMock.mockReturnValue(videoOf(first, second));
+
+    const { currentFrame } = useVideo("video.mp4");
+    advance();
+    expect(currentFrame.value).toBe(good);
+
+    advance();
+    // The canvas must not go blank, and the texture is still released.
+    expect(currentFrame.value).toBe(good);
+    expect(second.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("never publishes a disposed texture on Android", () => {
+    const copy = texture(null);
+    const tex = texture(copy);
+    useVideoLoadingMock.mockReturnValue(videoOf(tex));
+
+    const { currentFrame } = useVideo("video.mp4");
+    advance();
+
+    expect(currentFrame.value).not.toBe(tex);
+  });
+
+  it("uses the frame as-is on iOS", () => {
+    Platform.OS = "ios";
+    const image = texture(null);
+    useVideoLoadingMock.mockReturnValue(videoOf(image));
+
+    const { currentFrame } = useVideo("video.mp4");
+    advance();
+
+    expect(image.makeNonTextureImage).not.toHaveBeenCalled();
+    expect(image.dispose).not.toHaveBeenCalled();
+    expect(currentFrame.value).toBe(image);
+  });
+});

--- a/packages/skia/src/external/reanimated/useVideo.ts
+++ b/packages/skia/src/external/reanimated/useVideo.ts
@@ -16,24 +16,27 @@ interface PlaybackOptions {
   volume: MaybeAnimated<number>;
 }
 
-const copyFrameOnAndroid = (currentFrame: SharedValue<SkImage | null>) => {
+// on android we need to copy the texture before it's invalidated
+const copyFrameOnAndroid = (tex: SkImage) => {
   "worklet";
-  // on android we need to copy the texture before it's invalidated
-  if (Platform.OS === "android") {
-    const tex = currentFrame.value;
-    if (tex) {
-      currentFrame.value = tex; //.makeNonTextureImage();
-      tex.dispose();
-    }
+  if (Platform.OS !== "android") {
+    return tex;
   }
+  const copy = tex.makeNonTextureImage();
+  tex.dispose();
+  return copy;
 };
 
 const setFrame = (video: Video, currentFrame: SharedValue<SkImage | null>) => {
   "worklet";
   const img = video.nextImage();
   if (img) {
-    currentFrame.value = img;
-    copyFrameOnAndroid(currentFrame);
+    const frame = copyFrameOnAndroid(img);
+    // A failed readback returns null: keep the last good frame rather than
+    // blanking the canvas.
+    if (frame) {
+      currentFrame.value = frame;
+    }
   }
 };
 


### PR DESCRIPTION
Fixes #4000.

Restores the copy in `copyFrameOnAndroid`, which is currently commented out:

```ts
currentFrame.value = tex; //.makeNonTextureImage();
tex.dispose();
```

As written it assigns the image back to itself and then disposes it, so the renderer is handed a disposed image on every frame.

**Why the copy is required.** The Android frame is a borrowed view of a recycled buffer, end to end:

- `RNSkVideo.java#nextImage()` does `imageReader.acquireLatestImage()` → `image.getHardwareBuffer()` → **`image.close()`**, which returns the slot to the `ImageReader`'s pool for the next `acquireLatestImage()`.
- `RNSkAndroidVideo::nextImage` passes that `AHardwareBuffer` to `OpenGLContext::MakeImageFromBuffer`.
- That builds a `GR_GL_TEXTURE_EXTERNAL` backend texture over the buffer and wraps it with **`SkImages::BorrowTextureFrom`** — the `SkImage` owns no pixels of its own.

So the image is only valid until the decoder reuses that slot, which is what the surviving comment ("on android we need to copy the texture before it's invalidated") is about, and what `makeNonTextureImage()` does — it reads the frame back off the recycled GPU buffer. That also explains the reported logcat, `HardwareBuffer.close` followed by `EGLConsumer is not attached to an OpenGL ES context`.

**The copy is fallible, so it is done before publishing.** `JsiSkImage::makeNonTextureImage` returns null when the readback fails (`if (!rasterImage) { return nullptr; }`), and the TS signature says so: `makeNonTextureImage(): SkImage | null`. Simply restoring the call in place would then assign `null` into `currentFrame` — a blank canvas, which is the symptom being fixed here — with the texture already disposed and no way back.

The helper now takes the frame and returns the image to publish, so `setFrame` can decide:

```ts
const frame = copyFrameOnAndroid(img);
// A failed readback returns null: keep the last good frame rather than
// blanking the canvas.
if (frame) {
  currentFrame.value = frame;
}
```

A failed readback drops that one frame instead of blanking the view, and the texture is released either way.

**Where the regression came from.** `git log -L 19,29:packages/skia/src/external/reanimated/useVideo.ts` puts the change in #3686, a WebGPU-canvas PR that touches nothing else about video — a leftover local edit rather than an intended behaviour change.

**Field measurements** from the reporter, physical Pixel 9 (Android 16) and Galaxy S23 (Android 13), arm64 release builds:

| Variant | Result |
|---|---|
| current `main` | black, mean frame-to-frame diff `0.000` |
| drop only `tex.dispose()` | still doesn't paint |
| restore `makeNonTextureImage()` | paints and animates, frame diffs 17–40/255, stable over 75 s |

**Tests.** `src/external/reanimated/__tests__/useVideo.spec.ts` drives the frame callback with a mocked decoder frame and covers: the copy is published and the texture released; a failed readback keeps the last good frame and still releases the texture; a disposed texture is never published; and iOS still uses the frame as-is. Three of the four fail on `main`. The e2e suite has no video coverage on either backend (`Video.ts` is `it.skip`), so none of this is exercised by CI today.

**Relation to #4019**, which fixes the same issue: that PR restores the call in place, so a failed readback publishes `null` — running the readback test above against it gives `Received: null`. It also adds `currentFrame.value?.dispose()` in `setFrame` to release the previous frame. I have deliberately left that out: it is a separate memory concern rather than part of this bug, and on iOS it disposes the image the renderer is currently displaying, which I have no way to validate on-device here. Happy to fold either PR into the other, whichever shape you prefer.
