### PR TITLE
fix(🐛): compare isEdge against the far edges of the rect

### DIFF
--- a/packages/skia/src/dom/nodes/datatypes/Rect.ts
+++ b/packages/skia/src/dom/nodes/datatypes/Rect.ts
@@ -6,11 +6,13 @@ import { processRadius } from "./Radius";
 
 export const isEdge = (pos: Vector, b: SkRect) => {
   "worklet";
+  const right = b.x + b.width;
+  const bottom = b.y + b.height;
+  const withinX = pos.x >= b.x && pos.x <= right;
+  const withinY = pos.y >= b.y && pos.y <= bottom;
   return (
-    pos.x === b.x ||
-    pos.y === b.y ||
-    pos.x === b.x + b.width ||
-    pos.y === b.y + b.height
+    (withinY && (pos.x === b.x || pos.x === right)) ||
+    (withinX && (pos.y === b.y || pos.y === bottom))
   );
 };
 

--- a/packages/skia/src/dom/nodes/datatypes/Rect.ts
+++ b/packages/skia/src/dom/nodes/datatypes/Rect.ts
@@ -7,7 +7,10 @@ import { processRadius } from "./Radius";
 export const isEdge = (pos: Vector, b: SkRect) => {
   "worklet";
   return (
-    pos.x === b.x || pos.y === b.y || pos.x === b.width || pos.y === b.height
+    pos.x === b.x ||
+    pos.y === b.y ||
+    pos.x === b.x + b.width ||
+    pos.y === b.y + b.height
   );
 };
 

--- a/packages/skia/src/skia/__tests__/Geometry.spec.ts
+++ b/packages/skia/src/skia/__tests__/Geometry.spec.ts
@@ -50,4 +50,16 @@ describe("Geometry", () => {
     expect(isEdge({ x: 60, y: 50 }, r)).toBe(false);
     expect(isEdge({ x: 60, y: 45 }, r)).toBe(false);
   });
+
+  it("should only detect points on the border of a rectangle", () => {
+    const { rect } = importSkia();
+
+    const r = rect(10, 20, 100, 50);
+    expect(isEdge({ x: 10, y: 20 }, r)).toBe(true);
+    expect(isEdge({ x: 110, y: 70 }, r)).toBe(true);
+    expect(isEdge({ x: 10, y: 5000 }, r)).toBe(false);
+    expect(isEdge({ x: 110, y: 0 }, r)).toBe(false);
+    expect(isEdge({ x: -5000, y: 20 }, r)).toBe(false);
+    expect(isEdge({ x: 500, y: 70 }, r)).toBe(false);
+  });
 });

--- a/packages/skia/src/skia/__tests__/Geometry.spec.ts
+++ b/packages/skia/src/skia/__tests__/Geometry.spec.ts
@@ -1,3 +1,4 @@
+import { isEdge } from "../../dom/nodes";
 import { importSkia } from "../../renderer/__tests__/setup";
 
 describe("Geometry", () => {
@@ -35,5 +36,18 @@ describe("Geometry", () => {
     expect(color[1]).toBeCloseTo(0.5);
     expect(color[2]).toBeCloseTo(0);
     expect(color[3]).toBeCloseTo(0.5);
+  });
+
+  it("should detect the edges of a rectangle away from the origin", () => {
+    const { rect } = importSkia();
+
+    const r = rect(10, 20, 100, 50);
+    expect(isEdge({ x: 10, y: 45 }, r)).toBe(true);
+    expect(isEdge({ x: 60, y: 20 }, r)).toBe(true);
+    expect(isEdge({ x: 110, y: 45 }, r)).toBe(true);
+    expect(isEdge({ x: 60, y: 70 }, r)).toBe(true);
+    expect(isEdge({ x: 100, y: 45 }, r)).toBe(false);
+    expect(isEdge({ x: 60, y: 50 }, r)).toBe(false);
+    expect(isEdge({ x: 60, y: 45 }, r)).toBe(false);
   });
 });


### PR DESCRIPTION
`isEdge` is exported from the package root (`dom/nodes` → `datatypes` → `Rect`) and compares the far edges against the rect's `width`/`height` rather than `x + width` / `y + height`:

```ts
pos.x === b.x || pos.y === b.y || pos.x === b.width || pos.y === b.height
```

It is inconsistent with itself — the near edges are offset by `b.x`/`b.y`, the far ones are not. The history explains why: #500 extracted it from an inline check in the Aurora example,

```ts
pt.pos.x === 0 || pt.pos.y === 0 ||
pt.pos.x === Math.fround(width) || pt.pos.y === Math.fround(height)
```

whose rect was always `Skia.XYWHRect(0, 0, width, height)`. At the origin the offset makes no difference, so only half the generalisation was needed and only half got written.

For a rect away from the origin it reports two edges that fall *inside* the rect and misses the two real ones. For `rect(10, 20, 100, 50)` the right edge is at `x = 110`, but the current code answers `true` for `x = 100` and `false` for `x = 110`.

**No behaviour change for any existing caller.** The three call sites in the repo — `Examples/Vertices/Vertices.tsx`, `Examples/Aurora/components/CoonsPatchMeshGradient.tsx` and its `useHandles.ts` — all pass a `win` built as `Skia.XYWHRect(0, 0, width, height)`. With `x = y = 0`, `b.x + b.width === b.width` and `b.y + b.height === b.height`, so both branches evaluate identically; the demos are unaffected.

Test added to `Geometry.spec.ts`; it fails on `main` at the first far-edge assertion.
