### PR TITLE
fix(🐛): declare the esnext.disposable lib dependency in shipped types

### DIFF
--- a/packages/skia/src/skia/types/JsiInstance.ts
+++ b/packages/skia/src/skia/types/JsiInstance.ts
@@ -1,3 +1,5 @@
+/// <reference lib="esnext.disposable" preserve="true" />
+
 export interface SkJSIInstance<T extends string> extends Disposable {
   __typename__: T;
   dispose(): void;


### PR DESCRIPTION
## Problem

`SkJSIInstance<T>` extends the TC39 `Disposable` global, and the web hosts declare `[Symbol.dispose]()`. Neither is in `lib.es2024`, and the package declares no dependency on the lib that supplies them — so the shipped declarations don't type-check for a consumer that pins `lib` below `esnext` with `types: []`, which is normal for a React Native app that must not carry Node globals.

Against published `2.6.9`, with `probe.ts` importing any `Sk*` type:

```jsonc
// tsconfig.json
{
  "compilerOptions": {
    "strict": true,
    "moduleResolution": "bundler",
    "lib": ["dom", "es2024"],
    "types": []
    // skipLibCheck defaults to false
  }
}
```

```
lib/typescript/src/skia/types/JsiInstance.d.ts(1,58): error TS2304: Cannot find name 'Disposable'.
lib/typescript/src/skia/web/Host.d.ts(13,13): error TS2550: Property 'dispose' does not exist on type 'SymbolConstructor'.
```

Both errors are inside the package's own `.d.ts`. The only consumer-side fixes are widening `lib`, adding the reference by hand, or `skipLibCheck: true` — all of which work around a dependency the package should declare.

## Why the build doesn't catch it

`packages/skia/tsconfig.json` pins the same `lib: ["dom", "es2024"]`, so the source has the identical gap. It compiles because the config sets no `types` key, so TypeScript auto-includes every `@types/*` in `node_modules` — and `@types/node`, reached through the `@types/ws` devDependency, carries `/// <reference lib="esnext.disposable" />` at `index.d.ts:29`. That injects the lib globally into the build. `skipLibCheck: true` covers the rest.

The dependency is real; it's satisfied by accident, through a dev-only type package consumers don't have.

## Fix

One directive on the declaration that needs the global:

```ts
/// <reference lib="esnext.disposable" preserve="true" />

export interface SkJSIInstance<T extends string> extends Disposable {
```

`preserve="true"` (TS 5.5+) is the load-bearing part. Without it TypeScript strips the directive during declaration emit, so the source would compile and the shipped `.d.ts` would stay broken. Verified both ways against the actual build output. The repo installs TypeScript 5.9.3, so it's supported; on TS < 5.5 the pragma just doesn't match, which leaves current behaviour rather than a worse one.

A lib reference is program-global once any included file carries one, so this single directive also covers the `[Symbol.dispose]()` declarations in the web hosts — `JsiInstance` is in every program that touches an `Sk*` type. This is the same mechanism `@types/node` uses for its own lib dependencies.

## Verification

| Gate | Result |
| --- | --- |
| `yarn tsc` | passes, 0 errors (unchanged from baseline) |
| `yarn lint` | passes |
| `yarn build` | passes; directive present in `lib/typescript/src/`, `lib/commonjs/` and `lib/module/` |
| Consumer probe above, against the build output | 2 errors → 0 |

Nothing else changes: the directive is a comment at runtime, and the emitted type shapes are identical.
