### PR TITLE
fix(💣): guard the picture swap in RNSkPictureRenderer

### DIFF
--- a/packages/skia/cpp/rnskia/RNSkPictureView.h
+++ b/packages/skia/cpp/rnskia/RNSkPictureView.h
@@ -52,17 +52,30 @@ public:
   }
 
   void setPicture(sk_sp<SkPicture> picture) {
-    _picture = picture;
+    {
+      std::lock_guard<std::mutex> lock(_pictureMutex);
+      _picture = std::move(picture);
+    }
     _requestRedraw();
   }
 
-  sk_sp<SkPicture> getPicture() const { return _picture; }
+  sk_sp<SkPicture> getPicture() const {
+    std::lock_guard<std::mutex> lock(_pictureMutex);
+    return _picture;
+  }
 
 private:
   bool performDraw(std::shared_ptr<RNSkCanvasProvider> canvasProvider) {
-    // Capture picture pointer to ensure thread safety - _picture can be
-    // modified from the JS thread while we're drawing on the render thread
-    sk_sp<SkPicture> picture = _picture;
+    // Copy under the lock: _picture can be replaced from the JS thread while
+    // the render thread draws, and copying an sk_sp is not atomic. Without
+    // the lock, this copy can ref a picture whose count the replacement on
+    // the other thread has already taken to zero, and drawing it fails in
+    // __cxa_pure_virtual.
+    sk_sp<SkPicture> picture;
+    {
+      std::lock_guard<std::mutex> lock(_pictureMutex);
+      picture = _picture;
+    }
     auto pd = _platformContext->getPixelDensity();
     return canvasProvider->renderToCanvas([=](SkCanvas *canvas) {
       canvas->clear(SK_ColorTRANSPARENT);
@@ -77,6 +90,7 @@ private:
 
   std::shared_ptr<RNSkPlatformContext> _platformContext;
   sk_sp<SkPicture> _picture;
+  mutable std::mutex _pictureMutex;
 };
 
 class RNSkPictureView : public RNSkView {


### PR DESCRIPTION
## The crash

An app that replaces the drawn picture at a high rate (ours publishes ~30 pictures/second from an audio visualizer) intermittently dies with:

```
Abort message: 'Pure virtual function called!'
  __cxa_pure_virtual
  RNSkia::RNSkPictureRenderer::performDraw(...)::'lambda'(SkCanvas*)
  RNSkia::RNSkOpenGLCanvasProvider::renderToCanvas(...)
  RNSkia::RNSkPictureRenderer::performDraw(...)
  RNSkia::RNSkView::requestRedraw()::'lambda'()
  RNSkia::JniPlatformContext::notifyTaskReadyNative()
```

Reproduced on a Pixel 8 (RN 0.86, release build, v2.11.0): cycling between different shader-based scenes while pictures stream in kills the process within seconds.

## The race

`performDraw` copies the picture to protect against concurrent replacement:

```cpp
// Capture picture pointer to ensure thread safety - _picture can be
// modified from the JS thread while we're drawing on the render thread
sk_sp<SkPicture> picture = _picture;
```

The copy itself is the race: copying an `sk_sp` is not atomic. When `setPicture` on the JS thread replaces `_picture` at the same moment, the render thread can read the old pointer while the replacement drops the last ref, then `ref()` an already-destructed object. `drawPicture` on it fails in `__cxa_pure_virtual` (or corrupts memory silently). #3588 introduced this copy and narrowed the window without closing it.

## The fix

A `std::mutex` over the three places that touch `_picture` (`setPicture`, `getPicture`, the copy in `performDraw`). The lock is held only for a pointer copy or swap, so there is no contention worth measuring at any realistic picture rate; drawing still happens outside the lock.

With this patch, the reproduction above survived 48 consecutive scene switches plus mixed fullscreen transitions with the crash buffer empty, where the unpatched build died within the first dozen.