### PR TITLE
fix(🤖): ship consumer proguard rules

### DIFF
--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -62,14 +62,6 @@ If the NDK is not installed, you can install it via Android Studio by going to t
 
 And then the _SDK Location_ section. It will show you the NDK path, or the option to download it if you don't have it installed.
 
-### Proguard
-
-If you're using Proguard, make sure to add the following rule at `proguard-rules.pro`:
-
-```
--keep class com.shopify.reactnative.skia.** { *; }
-```
-
 ### TroubleShooting
 
 For error **_CMake 'X.X.X' was not found in SDK, PATH, or by cmake.dir property._**

--- a/packages/skia/android/build.gradle
+++ b/packages/skia/android/build.gradle
@@ -215,6 +215,8 @@ android {
         versionName "1.0"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
+        consumerProguardFiles 'proguard-rules.pro'
+
         externalNativeBuild {
             cmake {
                 cppFlags "-fexceptions", "-frtti", "-std=c++1y", "-DONANDROID"

--- a/packages/skia/android/proguard-rules.pro
+++ b/packages/skia/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.shopify.reactnative.skia.** { *; }

--- a/packages/skia/package.json
+++ b/packages/skia/package.json
@@ -22,6 +22,7 @@
     "README.md",
     "LICENSE.md",
     "android/build.gradle",
+    "android/proguard-rules.pro",
     "android/CMakeLists.txt",
     "android/cpp/**",
     "android/src/**",


### PR DESCRIPTION
Shipping consumer proguard rules applies them automatically, not requiring addition of those rules in the app consuming the library