### PR TITLE
fix(🧵): invalidate prototype caches per install generation

### DIFF
--- a/packages/skia/cpp/jsi/NativeObject.h
+++ b/packages/skia/cpp/jsi/NativeObject.h
@@ -51,26 +51,32 @@ struct PrototypeCacheEntry {
  *
  * When used with static storage (like prototype caches), the cache persists
  * across hot reloads. But the JSI objects inside become invalid when the
- * runtime is destroyed. This wrapper tracks which runtime the cache was
- * created for and allocates a new cache when the runtime changes.
+ * runtime is destroyed. This wrapper tracks which main-runtime generation the
+ * cache was created for and allocates a new cache when the native module is
+ * reinstalled (RNSkManager construction bumps the generation).
+ *
+ * The generation is used instead of the runtime pointer on purpose: on an
+ * in-process runtime recreate (expo-updates reloadAsync, DevSettings.reload)
+ * Hermes frequently allocates the new runtime at the address of the freed
+ * one. A pointer comparison then sees "same runtime", keeps the stale cache,
+ * and create()/installConstructor() end up passing a jsi::Object owned by the
+ * dead runtime to the new one (use-after-free).
  *
  * The old cache is intentionally leaked - we cannot safely destroy JSI
  * objects after their runtime is gone.
  */
 template <typename T> struct StaticRuntimeAwareCache {
   RNJsi::RuntimeAwareCache<T> *cache = nullptr;
-  jsi::Runtime *cacheRuntime = nullptr;
+  uint64_t cacheGeneration = 0;
 
-  RNJsi::RuntimeAwareCache<T> &get(jsi::Runtime &rt) {
-    auto mainRuntime = RNJsi::BaseRuntimeAwareCache::getMainJsRuntime();
-    if (&rt == mainRuntime && cacheRuntime != mainRuntime) {
-      // Main runtime changed (hot reload) - allocate new cache, leak old one
+  RNJsi::RuntimeAwareCache<T> &get(jsi::Runtime & /*rt*/) {
+    auto generation =
+        RNJsi::BaseRuntimeAwareCache::getMainJsRuntimeGeneration();
+    if (cache == nullptr || cacheGeneration != generation) {
+      // First use, or the main runtime was reinstalled (hot reload / OTA):
+      // allocate a fresh cache and leak the old one.
       cache = new RNJsi::RuntimeAwareCache<T>();
-      cacheRuntime = mainRuntime;
-    }
-    if (cache == nullptr) {
-      cache = new RNJsi::RuntimeAwareCache<T>();
-      cacheRuntime = mainRuntime;
+      cacheGeneration = generation;
     }
     return *cache;
   }

--- a/packages/skia/cpp/jsi/NativeObject.h
+++ b/packages/skia/cpp/jsi/NativeObject.h
@@ -149,9 +149,29 @@ public:
    */
   static void installPrototype(jsi::Runtime &runtime) {
     std::lock_guard<std::mutex> lock(getPrototypeCacheMutex());
+    ensurePrototypeLocked(runtime);
+  }
+
+  /**
+   * Look up (and install on first use) the prototype entry for this runtime.
+   *
+   * Callers must hold getPrototypeCacheMutex() and must consume the returned
+   * entry while still holding it: the lookup and the use of the prototype
+   * have to share one lock scope, because a reinstall of the native module
+   * (generation bump, see StaticRuntimeAwareCache) can swap the cache from
+   * any thread. A caller that released the lock in between would re-resolve
+   * a fresh cache with an empty entry and hand out an object without a
+   * prototype.
+   *
+   * The returned reference stays valid for the runtime's lifetime: the
+   * RuntimeAwareCache is heap-allocated and never freed, and
+   * std::unordered_map keeps references to its elements stable across
+   * rehashes.
+   */
+  static PrototypeCacheEntry &ensurePrototypeLocked(jsi::Runtime &runtime) {
     auto &entry = getPrototypeCache(runtime).get(runtime);
     if (entry.prototype.has_value()) {
-      return; // Already installed
+      return entry; // Already installed
     }
 
     // Create prototype object
@@ -270,6 +290,7 @@ public:
 
     // Cache the prototype
     entry.prototype = std::move(prototype);
+    return entry;
   }
 
   /**
@@ -280,13 +301,8 @@ public:
    * created internally by the native code).
    */
   static void installConstructor(jsi::Runtime &runtime) {
-    installPrototype(runtime);
-
     std::lock_guard<std::mutex> lock(getPrototypeCacheMutex());
-    auto &entry = getPrototypeCache(runtime).get(runtime);
-    if (!entry.prototype.has_value()) {
-      return;
-    }
+    auto &entry = ensurePrototypeLocked(runtime);
 
     // Create a constructor function that throws when called directly
     auto ctor = jsi::Function::createFromHostFunction(
@@ -314,8 +330,6 @@ public:
    */
   static jsi::Value create(jsi::Runtime &runtime,
                            std::shared_ptr<Derived> instance) {
-    installPrototype(runtime);
-
     // Store creation runtime for logging etc.
     instance->setCreationRuntime(&runtime);
 
@@ -325,18 +339,16 @@ public:
     // Attach native state
     obj.setNativeState(runtime, instance);
 
-    // Set prototype
+    // Install (on first use) and apply the prototype in a single lock scope
+    // so a concurrent cache swap cannot slip in between the two steps.
     {
       std::lock_guard<std::mutex> lock(getPrototypeCacheMutex());
-      auto &entry = getPrototypeCache(runtime).get(runtime);
-      if (entry.prototype.has_value()) {
-        // Use Object.setPrototypeOf to set the prototype
-        auto objectCtor =
-            runtime.global().getPropertyAsObject(runtime, "Object");
-        auto setPrototypeOf =
-            objectCtor.getPropertyAsFunction(runtime, "setPrototypeOf");
-        setPrototypeOf.call(runtime, obj, *entry.prototype);
-      }
+      auto &entry = ensurePrototypeLocked(runtime);
+      // Use Object.setPrototypeOf to set the prototype
+      auto objectCtor = runtime.global().getPropertyAsObject(runtime, "Object");
+      auto setPrototypeOf =
+          objectCtor.getPropertyAsFunction(runtime, "setPrototypeOf");
+      setPrototypeOf.call(runtime, obj, *entry.prototype);
     }
 
     // Set memory pressure hint for GC

--- a/packages/skia/cpp/jsi/RuntimeAwareCache.cpp
+++ b/packages/skia/cpp/jsi/RuntimeAwareCache.cpp
@@ -3,5 +3,6 @@
 namespace RNJsi {
 
 std::atomic<jsi::Runtime *> BaseRuntimeAwareCache::_mainRuntime{nullptr};
+std::atomic<uint64_t> BaseRuntimeAwareCache::_mainRuntimeGeneration{0};
 
 } // namespace RNJsi

--- a/packages/skia/cpp/jsi/RuntimeAwareCache.h
+++ b/packages/skia/cpp/jsi/RuntimeAwareCache.h
@@ -34,6 +34,21 @@ public:
   static uint64_t getMainJsRuntimeGeneration() {
     return _mainRuntimeGeneration.load(std::memory_order_acquire);
   }
+  /**
+   * Called when the main runtime is about to go away (RNSkManager destruction).
+   * Bumps the generation so process-wide caches keyed on it
+   * (StaticRuntimeAwareCache) stop trusting their contents before the next
+   * install(). This closes the window where a runtime allocated at the dead
+   * runtime's address would otherwise be taken for the main runtime and be
+   * handed the stale jsi::Objects of the previous one.
+   *
+   * The pointer itself is intentionally left in place: worklet runtime
+   * threads may still call getMainJsRuntime() while teardown overlaps, and
+   * that accessor asserts on nullptr.
+   */
+  static void invalidateMainJsRuntime() {
+    _mainRuntimeGeneration.fetch_add(1, std::memory_order_acq_rel);
+  }
   static jsi::Runtime *getMainJsRuntime() {
     auto *rt = _mainRuntime.load(std::memory_order_acquire);
     assert(rt != nullptr && "Expected main Javascript runtime to be set in the "

--- a/packages/skia/cpp/jsi/RuntimeAwareCache.h
+++ b/packages/skia/cpp/jsi/RuntimeAwareCache.h
@@ -3,6 +3,7 @@
 #include <jsi/jsi.h>
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -20,6 +21,18 @@ public:
     // Atomic: hot reload rewrites this from the JS thread while worklet
     // runtime threads read it concurrently.
     _mainRuntime.store(rt, std::memory_order_release);
+    // Every (re)installation of the native module starts a new generation.
+    // Callers that hold process-wide state derived from the main runtime
+    // (see StaticRuntimeAwareCache) must key their invalidation on this
+    // counter and NOT on the runtime pointer: when the JS runtime is
+    // destroyed and recreated in-process (expo-updates OTA apply,
+    // DevSettings.reload) the new jsi::Runtime is frequently allocated at
+    // the exact address of the freed one, so a pointer comparison cannot
+    // tell a reload from the steady state.
+    _mainRuntimeGeneration.fetch_add(1, std::memory_order_acq_rel);
+  }
+  static uint64_t getMainJsRuntimeGeneration() {
+    return _mainRuntimeGeneration.load(std::memory_order_acquire);
   }
   static jsi::Runtime *getMainJsRuntime() {
     auto *rt = _mainRuntime.load(std::memory_order_acquire);
@@ -31,6 +44,7 @@ public:
 
 private:
   static std::atomic<jsi::Runtime *> _mainRuntime;
+  static std::atomic<uint64_t> _mainRuntimeGeneration;
 };
 
 /**

--- a/packages/skia/cpp/jsi/RuntimeLifecycleMonitor.cpp
+++ b/packages/skia/cpp/jsi/RuntimeLifecycleMonitor.cpp
@@ -66,12 +66,6 @@ void RuntimeLifecycleMonitor::removeListener(
     // nothing to do here
   } else {
     listenersSet->second.erase(listener);
-    if (listenersSet->second.empty()) {
-      // addListener() uses "entry exists" as "monitor already installed in
-      // this runtime". Drop empty entries so a later runtime allocated at the
-      // same address still gets its own lifecycle monitor.
-      listeners.erase(listenersSet);
-    }
   }
 }
 

--- a/packages/skia/cpp/jsi/RuntimeLifecycleMonitor.cpp
+++ b/packages/skia/cpp/jsi/RuntimeLifecycleMonitor.cpp
@@ -66,6 +66,12 @@ void RuntimeLifecycleMonitor::removeListener(
     // nothing to do here
   } else {
     listenersSet->second.erase(listener);
+    if (listenersSet->second.empty()) {
+      // addListener() uses "entry exists" as "monitor already installed in
+      // this runtime". Drop empty entries so a later runtime allocated at the
+      // same address still gets its own lifecycle monitor.
+      listeners.erase(listenersSet);
+    }
   }
 }
 

--- a/packages/skia/cpp/rnskia/RNSkManager.cpp
+++ b/packages/skia/cpp/rnskia/RNSkManager.cpp
@@ -30,6 +30,11 @@ RNSkManager::RNSkManager(
 }
 
 RNSkManager::~RNSkManager() {
+  // The main runtime is going away: key out the process-wide prototype
+  // caches now rather than at the next install(), so nothing allocated at
+  // this runtime's address in between can be mistaken for it.
+  RNJsi::BaseRuntimeAwareCache::invalidateMainJsRuntime();
+
   // Free up any references
   _viewApi = nullptr;
   _jsRuntime = nullptr;


### PR DESCRIPTION
fixes #4003

StaticRuntimeAwareCache detected a hot reload by comparing the new main jsi::Runtime pointer with the cached one. On an in-process runtime recreate (expo-updates OTA apply, DevSettings.reload) Hermes often allocates the new runtime at the address of the freed one, so the stale per-class prototype cache was kept and create()/installConstructor() passed jsi::Objects owned by the dead runtime to the new runtime (use-after-free). Same defect as react-native-webgpu issue #461.

setMainJsRuntime() now bumps an install generation and the static caches are keyed on it. RuntimeLifecycleMonitor::removeListener also drops empty entries so a reused runtime address gets its own monitor.