### PR TITLE
chore(🤖): copy texture before invalidation on Android

### DIFF
--- a/packages/skia/src/external/reanimated/useVideo.ts
+++ b/packages/skia/src/external/reanimated/useVideo.ts
@@ -22,8 +22,12 @@ const copyFrameOnAndroid = (currentFrame: SharedValue<SkImage | null>) => {
   if (Platform.OS === "android") {
     const tex = currentFrame.value;
     if (tex) {
-      currentFrame.value = tex.makeNonTextureImage();
-      tex.dispose();
+      const copy = tex.makeNonTextureImage();
+      if (copy) {
+        currentFrame.value = copy;
+        tex.dispose();
+      }
+      // If copy fails, keep the original frame rather than showing black
     }
   }
 };


### PR DESCRIPTION
Ensure the original frame is retained if texture copy fails on Android.