### PR TITLE
fix(🤖): release the Java Surface wrapper on the non-opaque path

### DIFF
--- a/packages/skia/android/cpp/rnskia-android/RNSkOpenGLCanvasProvider.cpp
+++ b/packages/skia/android/cpp/rnskia-android/RNSkOpenGLCanvasProvider.cpp
@@ -100,6 +100,20 @@ void RNSkOpenGLCanvasProvider::surfaceAvailable(jobject jSurfaceTexture,
     _updateTexImageMethod =
         env->GetMethodID(surfaceTextureClass, "updateTexImage", "()V");
 
+    // ANativeWindow_fromSurface acquires its own reference on the underlying
+    // buffer producer, so the Java Surface wrapper can be released here.
+    // Without this, every Canvas leaks one android.view.Surface until
+    // finalization and CloseGuard reports "A resource failed to call
+    // Surface.release."
+    jmethodID surfaceRelease =
+        env->GetMethodID(surfaceClass, "release", "()V");
+    if (surfaceRelease != nullptr) {
+      env->CallVoidMethod(jSurface, surfaceRelease);
+      if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+      }
+    }
+
     // Acquire the native window from the Surface
     // Clean up local references
     env->DeleteLocalRef(jSurface);


### PR DESCRIPTION
Fixes #4045

### Problem

On Android, every non-opaque `<Canvas>` leaks one `android.view.Surface`.

`surfaceAvailable` builds a `Surface` to wrap the `SurfaceTexture`, hands it to `ANativeWindow_fromSurface`, then drops it with `DeleteLocalRef`. That only releases the JNI *local reference* — `Surface.release()` is never called, so the underlying buffer producer is left to the finalizer and CloseGuard logs:

```
W System: A resource failed to call Surface.release.
```

once per Canvas.

`surfaceDestroyed()` releases `_jSurfaceTexture` and `OpenGLWindowContext` releases the `ANativeWindow`, but nothing owns the intermediate `Surface`.

### Fix

Release the Java wrapper once `ANativeWindow_fromSurface` has taken its own reference on the producer. The lookup is null-guarded and the call is exception-guarded, so it degrades to the current behaviour rather than throwing if anything is unexpected.

This mirrors the ownership rule the WebGPU path already documents in `JniWebGPUView.cpp`:

```cpp
// ANativeWindow_fromSurface acquires a reference; SurfaceInfo releases it
// (via the releaser below) once it is done with the window.
```

Only the `!opaque` branch is touched; the opaque branch never creates the wrapper.

### Verification

Measured on an app with 6 `<Canvas>` components (a tab bar of Skia icons), counting `Surface.release` warnings per launch:

| environment | before | after |
| --- | --- | --- |
| Emulator API 37, debug | 6 | **0** |
| Samsung SM-M366B (Mali), API 36, debug | 6 | **0** |
| Samsung SM-M366B, minified release (R8) | 6 | **0** |

The unpatched release build was measured first as an instrument check — CloseGuard is normally gated on the debuggable flag, so a patched `0` would be meaningless if the unpatched release were also silent. It reported 6, so the `0` is a real measurement.

No regressions across 20 navigations plus 3 background/foreground cycles on the release build:

- `SIGSEGV` / `SIGABRT` / `Fatal signal` / tombstone / ANR — 0
- `BufferQueue has been abandoned` — 0
- `EGL_BAD_SURFACE`, `EGL_BAD_NATIVE_WINDOW` — 0
- rendering unchanged; canvases still transparent, no visual diff

R8 does not affect the change: `GetMethodID(surfaceClass, "release", "()V")` resolves `android.view.Surface.release` from the platform framework at runtime, and minification never rewrites `android.*`.

### Not addressed here

`surfaceSizeChanged` re-enters `surfaceAvailable`, which assigns `_jSurfaceTexture = env->NewGlobalRef(...)` without `DeleteGlobalRef` on the previous value — a separate JNI global-ref leak on the resize/rotation path. Left alone deliberately: it is a distinct defect, and I could not exercise that path to verify a fix (the app I reproduced on is portrait-locked). Noted in #4045.

### Testing done

Verified by rebuilding the Android native library from source and measuring on device via logcat, in both debug and minified release builds, on a physical Mali device and an emulator. I did not run the repo's own example app or test suite locally — happy to do so, or to adjust the approach, if you'd prefer.