### PR TITLE
fix(🌐): forward isCCW when adding a circle to a PathBuilder

### DIFF
--- a/packages/skia/src/skia/__tests__/Path.spec.ts
+++ b/packages/skia/src/skia/__tests__/Path.spec.ts
@@ -1,6 +1,6 @@
 import { interpolatePaths } from "../../animation/functions/interpolatePaths";
-import type { Skia, SkPath } from "../types";
-import { FillType, PathOp, PathVerb } from "../types";
+import type { Skia, SkImage, SkPath } from "../types";
+import { AlphaType, ColorType, FillType, PathOp, PathVerb } from "../types";
 import { processResult } from "../../__tests__/setup";
 import { PaintStyle } from "../types/Paint/Paint";
 
@@ -8,6 +8,16 @@ import { setupSkia } from "./setup";
 
 const roundtrip = (Skia: Skia, path: SkPath) =>
   Skia.Path.MakeFromCmds(path.toCmds())!;
+
+const readPixel = (image: SkImage, x: number, y: number) =>
+  Array.from(
+    image.readPixels(x, y, {
+      width: 1,
+      height: 1,
+      colorType: ColorType.RGBA_8888,
+      alphaType: AlphaType.Unpremul,
+    })!
+  );
 
 // Helper to create a path with moveTo and lineTo
 const makePath = (
@@ -354,5 +364,31 @@ describe("Path", () => {
       b.moveTo(20, 20).lineTo(20, 40).lineTo(40, 20)
     );
     expect(path).toBeTruthy();
+  });
+  // The non-zero winding rule reads the contour direction, so isCCW is what
+  // turns an inner contour into a hole rather than more of the same fill.
+  it("should add a circle in the direction given by isCCW", () => {
+    const { surface, canvas, Skia } = setupSkia(64, 64);
+    const donut = (isCCW: boolean) =>
+      Skia.PathBuilder.Make()
+        .setFillType(FillType.Winding)
+        .addRect(Skia.XYWHRect(0, 0, 64, 64), false)
+        .addCircle(32, 32, 20, isCCW)
+        .build();
+    const paint = Skia.Paint();
+    paint.setColor(Skia.Color("red"));
+
+    canvas.drawPath(donut(true), paint);
+    surface.flush();
+    expect(readPixel(surface.makeImageSnapshot(), 32, 32)).toEqual([
+      0, 0, 0, 0,
+    ]);
+
+    canvas.clear(Float32Array.of(0, 0, 0, 0));
+    canvas.drawPath(donut(false), paint);
+    surface.flush();
+    expect(readPixel(surface.makeImageSnapshot(), 32, 32)).toEqual([
+      255, 0, 0, 255,
+    ]);
   });
 });

--- a/packages/skia/src/skia/web/JsiSkPathBuilder.ts
+++ b/packages/skia/src/skia/web/JsiSkPathBuilder.ts
@@ -188,8 +188,8 @@ export class JsiSkPathBuilder
     return this;
   }
 
-  addCircle(x: number, y: number, r: number, _isCCW?: boolean) {
-    this.ref.addCircle(x, y, r);
+  addCircle(x: number, y: number, r: number, isCCW?: boolean) {
+    this.ref.addCircle(x, y, r, isCCW);
     return this;
   }
 


### PR DESCRIPTION
## What breaks

On web/CanvasKit, `SkPathBuilder.addCircle(x, y, r, isCCW)` ignores `isCCW`. Every circle is added clockwise, whatever the caller asks for.

`packages/skia/src/skia/web/JsiSkPathBuilder.ts:191`

```ts
addCircle(x: number, y: number, r: number, _isCCW?: boolean) {
  this.ref.addCircle(x, y, r);
  return this;
}
```

The argument is real everywhere else:

* the public type declares it, with a doc comment, at `packages/skia/src/skia/types/Path/PathBuilder.ts:219` (`@param isCCW - if true, draws counter-clockwise`)
* CanvasKit honours it: `PathBuilder.addCircle(x, y, r, isCCW?: boolean)` in `canvaskit-wasm/types/index.d.ts:2576`
* the three sibling shape methods in the very same file forward theirs: `addRect` (:159), `addOval` (:164), `addRRect` (:186)

## Why it matters

Contour direction is what the non-zero winding rule uses to decide whether an inner contour is a hole. The usual way to punch a hole is an outer contour one way and an inner contour the other. On web both end up clockwise, the winding numbers add instead of cancelling, and the hole fills in solid. The same code renders correctly on iOS and Android. It is silent: it type-checks, throws nothing, and warns about nothing.

Direction also drives `Path.Trim`, dash phase and `ContourMeasure.getPosTan`, so circle-based trim animations run the other way round on web relative to native.

## Second implementation

Yes, there is one, and it is already correct, so it needs no change: `packages/skia/cpp/api/JsiSkPathBuilder.h:126` passes the flag through `toDirection()` to `SkPathBuilder::addCircle`. This is a web-binding-only divergence.

Note that `SkPath.addCircle` and `PathFactory.Circle` take no direction argument on either platform by design, so `JsiSkPathBuilder.ts:191` is the only divergence point.

## How I proved it

Added a regression test to `packages/skia/src/skia/__tests__/Path.spec.ts`: a full-canvas rect (clockwise) plus a circle with `isCCW: true` under `FillType.Winding`, then read the centre pixel. It should be transparent (the hole) and it should be opaque when the same circle is added clockwise.

With the fix, the whole file is green. Reverting only `JsiSkPathBuilder.ts` and leaving the test in place:

```
  ● Path › should add a circle in the direction given by isCCW

    expect(received).toEqual(expected) // deep equality

    - Expected  - 2
    + Received  + 2

      Array [
    -   0,
    -   0,
    +   255,
        0,
        0,
    +   255,
      ]

      381 |     canvas.drawPath(donut(true), paint);
      382 |     surface.flush();
    > 383 |     expect(readPixel(surface.makeImageSnapshot(), 32, 32)).toEqual([
```

i.e. the counter-clockwise circle comes back solid red instead of being a hole. Restoring the fix turns it green again.

`yarn lint`, `yarn tsc` and `yarn test` were run in `packages/skia`. Lint and typecheck are clean. The full suite shows only the two pre-existing flakes that also fail on an unmodified checkout of `main` here: the hardcoded 250ms budget in `PathBenchmark.spec.ts` (254.8ms) and a random `jest-worker` SIGSEGV; both suites pass when run on their own.
