### PR TITLE
fix(🐛): pop shader children from the top of the declaration stack

### DIFF
--- a/packages/skia/src/sksg/Recorder/commands/Shaders.ts
+++ b/packages/skia/src/sksg/Recorder/commands/Shaders.ts
@@ -46,7 +46,7 @@ const declareShader = (
   const shader = ctx.track(
     source.makeShaderWithChildren(
       processUniforms(source, uniforms),
-      ctx.shaders.splice(0, children),
+      ctx.shaders.splice(Math.max(0, ctx.shaders.length - children), children),
       m3
     )
   );

--- a/packages/skia/src/sksg/__tests__/ShaderChildren.spec.tsx
+++ b/packages/skia/src/sksg/__tests__/ShaderChildren.spec.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+import { importSkia } from "../../renderer/__tests__/setup";
+import type { SkImage } from "../../skia/types";
+import { SkiaSGRoot } from "../Reconciler";
+
+const SIZE = 16;
+
+// mix() with a runtime uniform keeps both children alive through the SkSL
+// optimizer, so the effect always reports two children and returns the first.
+const FIRST_CHILD = `
+uniform shader c0;
+uniform shader c1;
+uniform float w;
+
+half4 main(float2 xy) {
+  return mix(c0.eval(xy), c1.eval(xy), w);
+}`;
+
+const colorAt = (image: SkImage, x: number, y: number) => {
+  const pixels = image.readPixels() as Uint8Array;
+  const offset = (y * image.width() + x) * 4;
+  return [pixels[offset], pixels[offset + 1], pixels[offset + 2]];
+};
+
+describe("Shader children", () => {
+  it("resolves the children of a nested multi-child shader", async () => {
+    const { Skia } = importSkia();
+    const source = Skia.RuntimeEffect.Make(FIRST_CHILD)!;
+    expect(source).toBeTruthy();
+    const root = new SkiaSGRoot(Skia);
+    await root.render(
+      <skFill>
+        <skShader source={source} uniforms={{ w: 0 }}>
+          <skColorShader color="red" />
+          <skShader source={source} uniforms={{ w: 0 }}>
+            <skColorShader color="green" />
+            <skColorShader color="blue" />
+          </skShader>
+        </skShader>
+      </skFill>
+    );
+    const surface = Skia.Surface.Make(SIZE, SIZE)!;
+    root.drawOnCanvas(surface.getCanvas());
+    surface.flush();
+    const image = surface.makeImageSnapshot();
+    root.unmount();
+    // The inner shader must consume the two shaders declared under it, leaving
+    // red as the first child of the outer one.
+    expect(colorAt(image, SIZE / 2, SIZE / 2)).toEqual([255, 0, 0]);
+  });
+});


### PR DESCRIPTION
## Context

`declareShader` in `packages/skia/src/sksg/Recorder/commands/Shaders.ts` consumed its
child shaders with `ctx.shaders.splice(0, children)`, taking them from the **bottom** of
the declaration stack. Every other producer pushes onto the end (`ctx.shaders.push(...)`),
and the native recorder pops from the end too:

```cpp
// packages/skia/cpp/api/recorder/DrawingCtx.h
std::vector<sk_sp<SkShader>> popShaders(int count) {
  ...
  // Get the last 'actualCount' shaders
  auto start = shaders.end() - actualCount;
  ...
}
```

The two agree while the stack holds exactly `children` entries, so simple trees are fine.
They diverge as soon as a multi-child `<Shader>` is not the first declaration under its
parent, because entries belonging to earlier siblings are still sitting below it.

## Reproduction

```tsx
<Fill>
  <Shader source={pickFirstChild}>
    <ColorShader color="red" />
    <Shader source={pickFirstChild}>
      <ColorShader color="green" />
      <ColorShader color="blue" />
    </Shader>
  </Shader>
</Fill>
```

Declarations are emitted depth first, so the stack reads `[red, green, blue]` when the
inner shader is declared. It takes `[red, green]` instead of `[green, blue]`, leaving
`[blue, inner]` for the outer shader, whose first child is then `blue`. The fill paints
blue where it should paint red. The native recorder paints red.

## Fix

Pop the last `children` entries, mirroring `popShaders` including its clamp to the stack
size.

## Test

`packages/skia/src/sksg/__tests__/ShaderChildren.spec.tsx` renders the tree above and
reads the resulting pixel. Reverting the one-line fix turns it red:

```
● Shader children › resolves the children of a nested multi-child shader

  expect(received).toEqual(expected) // deep equality

  - Expected  - 1
  + Received  + 1

    Array [
  -   255,
      0,
      0,
  +   255,
    ]
```

The runtime effect uses `mix(c0.eval(xy), c1.eval(xy), w)` with `w` supplied as a uniform
so the SkSL optimizer cannot drop the second child, which would change the child count the
test depends on.

The rest of `yarn test` in `packages/skia` still passes, along with `yarn tsc` and `yarn lint`.
