### PR TITLE
fix(ios): redraw when the view re-enters a window

### DIFF
--- a/packages/skia/apple/MetalWindowContext.mm
+++ b/packages/skia/apple/MetalWindowContext.mm
@@ -91,5 +91,8 @@ void MetalWindowContext::present() {
   id<MTLCommandBuffer> commandBuffer([_commandQueue commandBuffer]);
   [commandBuffer presentDrawable:_currentDrawable];
   [commandBuffer commit];
+  if (_layer.presentsWithTransaction) {
+    [commandBuffer waitUntilScheduled];
+  }
   _skSurface = nullptr;
 }

--- a/packages/skia/apple/MetalWindowContext.mm
+++ b/packages/skia/apple/MetalWindowContext.mm
@@ -89,10 +89,16 @@ void MetalWindowContext::present() {
   }
 
   id<MTLCommandBuffer> commandBuffer([_commandQueue commandBuffer]);
-  [commandBuffer presentDrawable:_currentDrawable];
-  [commandBuffer commit];
   if (_layer.presentsWithTransaction) {
+    // Present inside the current Core Animation transaction: commit, wait
+    // until the command buffer is scheduled, then present the drawable
+    // directly (CAMetalLayer.presentsWithTransaction documentation).
+    [commandBuffer commit];
     [commandBuffer waitUntilScheduled];
+    [_currentDrawable present];
+  } else {
+    [commandBuffer presentDrawable:_currentDrawable];
+    [commandBuffer commit];
   }
   _skSurface = nullptr;
 }

--- a/packages/skia/apple/SkiaUIView.mm
+++ b/packages/skia/apple/SkiaUIView.mm
@@ -138,6 +138,24 @@
   }
 }
 
+#if !TARGET_OS_OSX
+- (void)didMoveToWindow {
+  [super didMoveToWindow];
+  // A frame drawn while the view was detached from the window (an inactive
+  // tab, a covered screen) is never presented, so redraw the current picture
+  // as soon as the view is back in a window instead of showing the last
+  // frame that was presented before it left. Present it inside the current
+  // Core Animation transaction so it is on screen in the same frame the view
+  // appears rather than one later.
+  if (self.window != nil && _impl != nullptr) {
+    CAMetalLayer *layer = (CAMetalLayer *)_impl->getLayer();
+    layer.presentsWithTransaction = YES;
+    _impl->getDrawView()->redraw();
+    layer.presentsWithTransaction = NO;
+  }
+}
+#endif // !TARGET_OS_OSX
+
 #pragma mark Layout
 
 - (void)layoutSubviews {


### PR DESCRIPTION
## Problem

A `SkiaUIView` that draws while its screen is detached from the window keeps presenting the last frame it showed before it left. Typical case: a static canvas inside an inactive tab of a react-native-screens container. The app changes theme, the canvas re-renders and draws while the tab is offscreen, that frame is never presented, and when the tab comes back the view still shows the old theme. Nothing invalidates it again, so it stays stale until the screen remounts. `layoutSubviews` doesn't help because the frame is unchanged.

## Fix

Override `didMoveToWindow` and redraw the current picture when the view is back in a window. Present that frame with `presentsWithTransaction` and wait until the command buffer is scheduled, so it lands in the same Core Animation transaction as the view's return. Without that, the frame presents one vsync later and the stale contents flash for one frame.

## Verification

iPhone 17 Pro simulator, iOS 26.5, React Native 0.86.3, react-native-screens 4.26.2, with a canvas whose colors change while its tab is inactive.

- Before: stale frame on return.
- With the redraw alone: a one-frame flash of the stale contents.
- With `presentsWithTransaction`: correct on the first frame.

iOS only. macOS is excluded since `didMoveToWindow` is UIKit.