### PR TITLE
fix(🐛): don't drop the ImageSVG offset when x or y is zero

### DIFF
--- a/packages/skia/src/sksg/Recorder/commands/Drawing.ts
+++ b/packages/skia/src/sksg/Recorder/commands/Drawing.ts
@@ -297,7 +297,8 @@ export const drawImageSVG = (ctx: DrawingContext, props: ImageSVGProps) => {
     return;
   }
   canvas.save();
-  if (x && y) {
+  // An offset of 0 is a valid position, so it must not be read as "unset".
+  if (x !== undefined && y !== undefined) {
     canvas.translate(x, y);
   }
   canvas.drawSvg(svg, width, height);

--- a/packages/skia/src/sksg/__tests__/ImageSVG.spec.tsx
+++ b/packages/skia/src/sksg/__tests__/ImageSVG.spec.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import type { ReactElement } from "react";
+
+import { importSkia } from "../../renderer/__tests__/setup";
+import type { SkSVG } from "../../skia/types";
+import { SkiaSGRoot } from "../Reconciler";
+
+// drawSvg() rasterizes through a DOM image on Web, so it is stubbed out here:
+// these tests only check where the SVG is placed on the canvas.
+const recordTranslations = async (element: ReactElement) => {
+  const { Skia } = importSkia();
+  const root = new SkiaSGRoot(Skia);
+  await root.render(element);
+  const surface = Skia.Surface.Make(128, 128)!;
+  const canvas = surface.getCanvas();
+  const translate = jest.spyOn(canvas, "translate");
+  jest.spyOn(canvas, "drawSvg").mockImplementation(() => {});
+  root.drawOnCanvas(canvas);
+  root.unmount();
+  return translate;
+};
+
+describe("ImageSVG", () => {
+  const svg = {} as SkSVG;
+
+  it("offsets an SVG whose x is zero", async () => {
+    const translate = await recordTranslations(
+      <skImageSVG svg={svg} x={0} y={100} width={64} height={64} />
+    );
+    expect(translate).toHaveBeenCalledWith(0, 100);
+  });
+
+  it("offsets an SVG whose y is zero", async () => {
+    const translate = await recordTranslations(
+      <skImageSVG svg={svg} x={100} y={0} width={64} height={64} />
+    );
+    expect(translate).toHaveBeenCalledWith(100, 0);
+  });
+
+  it("offsets an SVG placed with a rect whose x is zero", async () => {
+    const { Skia } = importSkia();
+    const translate = await recordTranslations(
+      <skImageSVG svg={svg} rect={Skia.XYWHRect(0, 100, 64, 64)} />
+    );
+    expect(translate).toHaveBeenCalledWith(0, 100);
+  });
+});


### PR DESCRIPTION
## Bug

`drawImageSVG()` in the JS player gates the canvas translation on `x && y`, which is falsy when either coordinate is `0`. An `<ImageSVG>` positioned with a zero component is drawn at the canvas origin instead of at the requested offset.

## Reproduction

```tsx
<Canvas style={{ flex: 1 }}>
  <ImageSVG svg={svg} x={0} y={100} width={64} height={64} />
</Canvas>
```

The SVG renders at `(0, 0)` rather than `(0, 100)`. The same happens for `x={100} y={0}` and for a `rect` whose `x` or `y` is `0`.

This path runs on Web, and on every platform for `drawAsPicture` / `drawAsImage` / `Offscreen`, which go through `StaticContainer` and the JS player.

## Root cause

The guard tests truthiness rather than presence, so a valid offset of `0` is read as "not provided". `ImageSVGCmd::draw` in `cpp/api/recorder/Drawings.h` translates in that case, so the JS player also diverged from the native recorder.

## Fix

Check `x !== undefined && y !== undefined` instead.

## Test

`packages/skia/src/sksg/__tests__/ImageSVG.spec.tsx` renders `skImageSVG` through `SkiaSGRoot` and asserts the exact `canvas.translate` arguments for `x={0} y={100}`, `x={100} y={0}`, and a `rect` at `(0, 100)`. `drawSvg` is stubbed because it rasterizes through a DOM image on Web. Without the fix all three fail with `Number of calls: 0`.
